### PR TITLE
Datasets reorganization

### DIFF
--- a/examples/cifar10.exs
+++ b/examples/cifar10.exs
@@ -1,92 +1,3 @@
-defmodule CIFAR do
-  defp unzip_cache_or_download(zip) do
-    base_url = 'https://www.cs.toronto.edu/~kriz/'
-    path = Path.join("tmp", zip)
-
-    data =
-      if File.exists?(path) do
-        IO.puts("Using #{zip} from tmp/\n")
-        File.read!(path)
-      else
-        IO.puts("Fetching #{zip} from https://www.cs.toronto.edu/~kriz/cifar-10-binary.tar.gz\n")
-        :inets.start()
-        :ssl.start()
-
-        {:ok, {_status, _response, data}} = :httpc.request(:get, {base_url ++ zip, []}, [], [])
-        File.mkdir_p!("tmp")
-        File.write!(path, data)
-
-        data
-      end
-
-    data
-  end
-
-  def parse_images(content) do
-    {imgs, labels} =
-      for <<example::size(3073)-binary <- content>>, reduce: {[], []} do
-        {imgs, labels} ->
-          <<label::size(8)-bitstring, image::size(3072)-binary>> = example
-          # In order to "stack" we need a leading batch dim,
-          # we can introduce an Nx.stack for this similar to
-          # torch.stack
-          img =
-            image
-            |> Nx.from_binary({:u, 8})
-            |> Nx.reshape({1, 3, 32, 32})
-
-          label =
-            label
-            |> Nx.from_binary({:u, 8})
-
-          {[img | imgs], [label | labels]}
-      end
-
-    {Nx.concatenate(imgs, axis: 0), Nx.concatenate(labels, axis: 0)}
-  end
-
-  def download(zip) do
-    gz = unzip_cache_or_download(zip)
-
-    # Extract image and labels from tarfile, ideally we can also do this lazily
-    # such that we overlap training with IO - essentially have workers reading
-    # batches from the files and caching them in memory while the accelerator
-    # is busy doing actual training
-    with {:ok, files} <- :erl_tar.extract({:binary, gz}, [:memory, :compressed]) do
-      {imgs, labels} =
-        files
-        |> Enum.filter(fn {fname, _} -> String.match?(List.to_string(fname), ~r/data_batch/) end)
-        |> Enum.map(fn {_, content} -> Task.async(fn -> parse_images(content) end) end)
-        |> Enum.map(&Task.await(&1, :infinity))
-        |> Enum.unzip()
-
-      # Batch and one hot encode
-      #
-      # Ideally, we have something we can use as a batched stream
-      # such that we can lazily query for batches and avoid loading the
-      # entire dataset into memory, with this we could also apply lazy
-      # transformations enabling things like data echoing, see TFDS
-      imgs =
-        imgs
-        |> Nx.concatenate(axis: 0)
-        # We shouldn't have to do this, the batch should wrap or truncate
-        |> Nx.slice([0, 0, 0, 0], [49984, 3, 32, 32])
-        |> Nx.divide(255)
-        |> Nx.to_batched_list(32)
-
-      labels =
-        labels
-        |> Nx.concatenate(axis: 0)
-        |> Nx.slice([0], [49984])
-        |> Nx.new_axis(-1)
-        |> Nx.equal(Nx.tensor(Enum.to_list(0..9)))
-        |> Nx.to_batched_list(32)
-
-      {imgs, labels}
-    end
-  end
-end
-
 model =
   Axon.input({nil, 3, 32, 32})
   |> Axon.conv(32, kernel_size: {3, 3}, activation: :relu)
@@ -105,7 +16,7 @@ model =
 
 IO.inspect model
 
-{train_images, train_labels} = CIFAR.download('cifar-10-binary.tar.gz')
+{train_images, train_labels} = Axon.Data.CIFAR.download()
 
 {final_params, _optimizer_state} =
   model

--- a/examples/mnist.exs
+++ b/examples/mnist.exs
@@ -1,55 +1,3 @@
-defmodule MNIST do
-  defp unzip_cache_or_download(zip) do
-    base_url = 'https://storage.googleapis.com/cvdf-datasets/mnist/'
-    path = Path.join("tmp", zip)
-
-    data =
-      if File.exists?(path) do
-        IO.puts("Using #{zip} from tmp/\n")
-        File.read!(path)
-      else
-        IO.puts("Fetching #{zip} from https://storage.googleapis.com/cvdf-datasets/mnist/\n")
-        :inets.start()
-        :ssl.start()
-
-        {:ok, {_status, _response, data}} = :httpc.request(base_url ++ zip)
-        File.mkdir_p!("tmp")
-        File.write!(path, data)
-
-        data
-      end
-
-    :zlib.gunzip(data)
-  end
-
-  def download(images, labels) do
-    <<_::32, n_images::32, n_rows::32, n_cols::32, images::binary>> =
-      unzip_cache_or_download(images)
-
-    train_images =
-      images
-      |> Nx.from_binary({:u, 8})
-      |> Nx.reshape({n_images, n_rows * n_cols})
-      |> Nx.divide(255)
-      |> Nx.to_batched_list(32)
-
-    IO.puts("#{n_images} #{n_rows}x#{n_cols} images\n")
-
-    <<_::32, n_labels::32, labels::binary>> = unzip_cache_or_download(labels)
-
-    train_labels =
-      labels
-      |> Nx.from_binary({:u, 8})
-      |> Nx.new_axis(-1)
-      |> Nx.equal(Nx.tensor(Enum.to_list(0..9)))
-      |> Nx.to_batched_list(32)
-
-    IO.puts("#{n_labels} labels\n")
-
-    {train_images, train_labels}
-  end
-end
-
 model =
   Axon.input({nil, 784})
   |> Axon.dense(128, activation: :relu)
@@ -59,7 +7,7 @@ model =
 
 IO.inspect model
 
-{train_images, train_labels} = MNIST.download('train-images-idx3-ubyte.gz', 'train-labels-idx1-ubyte.gz')
+{train_images, train_labels} = Axon.Data.MNIST.download()
 
 {final_params, _optimizer_state} =
   model

--- a/lib/axon/data/cifar.ex
+++ b/lib/axon/data/cifar.ex
@@ -1,5 +1,5 @@
 defmodule Axon.Data.CIFAR do
-  alias Data.Utils
+  alias Axon.Data.Utils
 
   @default_data_path "tmp/cifar"
   @base_url 'https://www.cs.toronto.edu/~kriz/'

--- a/lib/axon/data/cifar.ex
+++ b/lib/axon/data/cifar.ex
@@ -1,0 +1,74 @@
+defmodule Axon.Data.CIFAR do
+  alias Data.Utils
+
+  @default_data_path "tmp/cifar"
+  @base_url 'https://www.cs.toronto.edu/~kriz/'
+  @dataset_file 'cifar-10-binary.tar.gz'
+
+  defp parse_images(content) do
+    {imgs, labels} =
+      for <<example::size(3073)-binary <- content>>, reduce: {[], []} do
+        {imgs, labels} ->
+          <<label::size(8)-bitstring, image::size(3072)-binary>> = example
+          # In order to "stack" we need a leading batch dim,
+          # we can introduce an Nx.stack for this similar to
+          # torch.stack
+          img =
+            image
+            |> Nx.from_binary({:u, 8})
+            |> Nx.reshape({1, 3, 32, 32})
+
+          label =
+            label
+            |> Nx.from_binary({:u, 8})
+
+          {[img | imgs], [label | labels]}
+      end
+
+    {Nx.concatenate(imgs, axis: 0), Nx.concatenate(labels, axis: 0)}
+  end
+
+  def download(opts \\ []) do
+    batch_size = opts[:batch_size] || 32
+    data_path = opts[:data_path] || @default_data_path
+
+    gz = Utils.unzip_cache_or_download(@base_url, @dataset_file, data_path)
+
+    # Extract image and labels from tarfile, ideally we can also do this lazily
+    # such that we overlap training with IO - essentially have workers reading
+    # batches from the files and caching them in memory while the accelerator
+    # is busy doing actual training
+    with {:ok, files} <- :erl_tar.extract({:binary, gz}, [:memory, :compressed]) do
+      {imgs, labels} =
+        files
+        |> Enum.filter(fn {fname, _} -> String.match?(List.to_string(fname), ~r/data_batch/) end)
+        |> Enum.map(fn {_, content} -> Task.async(fn -> parse_images(content) end) end)
+        |> Enum.map(&Task.await(&1, :infinity))
+        |> Enum.unzip()
+
+      # Batch and one hot encode
+      #
+      # Ideally, we have something we can use as a batched stream
+      # such that we can lazily query for batches and avoid loading the
+      # entire dataset into memory, with this we could also apply lazy
+      # transformations enabling things like data echoing, see TFDS
+      imgs =
+        imgs
+        |> Nx.concatenate(axis: 0)
+        # We shouldn't have to do this, the batch should wrap or truncate
+        |> Nx.slice([0, 0, 0, 0], [49984, 3, 32, 32])
+        |> Nx.divide(255)
+        |> Nx.to_batched_list(batch_size)
+
+      labels =
+        labels
+        |> Nx.concatenate(axis: 0)
+        |> Nx.slice([0], [49984])
+        |> Nx.new_axis(-1)
+        |> Nx.equal(Nx.tensor(Enum.to_list(0..9)))
+        |> Nx.to_batched_list(batch_size)
+
+      {imgs, labels}
+    end
+  end
+end

--- a/lib/axon/data/fashionmnist.ex
+++ b/lib/axon/data/fashionmnist.ex
@@ -1,0 +1,50 @@
+defmodule Axon.Data.FashionMNIST do
+  alias Data.Utils
+
+  @default_data_path "tmp/fashionmnist"
+  @base_url 'http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/'
+  @image_file 'train-images-idx3-ubyte.gz'
+  @label_file 'train-labels-idx1-ubyte.gz'
+
+  def download_images(opts \\ []) do
+    batch_size = opts[:batch_size] || 32
+    data_path = opts[:data_path] || @default_data_path
+
+    <<_::32, n_images::32, n_rows::32, n_cols::32, images::binary>> =
+      Utils.unzip_cache_or_download(@base_url, @image_file, data_path, unzip: true)
+
+    batched_images =
+      images
+      |> Nx.from_binary({:u, 8})
+      |> Nx.reshape({n_images, n_rows * n_cols})
+      |> Nx.divide(255)
+      |> Nx.to_batched_list(batch_size)
+
+    IO.puts("#{n_images} #{n_rows}x#{n_cols} images\n")
+
+    batched_images
+  end
+
+  def download_labels(opts \\ []) do
+    batch_size = opts[:batch_size] || 32
+    data_path = opts[:data_path] || @default_data_path
+
+    batched_labels =
+      <<_::32, n_labels::32, labels::binary>> =
+      Utils.unzip_cache_or_download(@base_url, @label_file, data_path, unzip: true)
+
+    labels =
+      labels
+      |> Nx.from_binary({:u, 8})
+      |> Nx.new_axis(-1)
+      |> Nx.equal(Nx.tensor(Enum.to_list(0..9)))
+      |> Nx.to_batched_list(batch_size)
+
+    IO.puts("#{n_labels} labels\n")
+
+    labels
+  end
+
+  def download(opts \\ []),
+    do: {download_images(opts), download_labels(opts)}
+end

--- a/lib/axon/data/fashionmnist.ex
+++ b/lib/axon/data/fashionmnist.ex
@@ -1,5 +1,5 @@
 defmodule Axon.Data.FashionMNIST do
-  alias Data.Utils
+  alias Axon.Data.Utils
 
   @default_data_path "tmp/fashionmnist"
   @base_url 'http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/'

--- a/lib/axon/data/mnist.ex
+++ b/lib/axon/data/mnist.ex
@@ -36,6 +36,7 @@ defmodule Axon.Data.MNIST do
     batched_labels =
       labels
       |> Nx.from_binary({:u, 8})
+      |> Nx.slice([0], [60000])
       |> Nx.new_axis(-1)
       |> Nx.equal(Nx.tensor(Enum.to_list(0..9)))
       |> Nx.to_batched_list(batch_size)

--- a/lib/axon/data/mnist.ex
+++ b/lib/axon/data/mnist.ex
@@ -1,5 +1,5 @@
 defmodule Axon.Data.MNIST do
-  alias Data.Utils
+  alias Axon.Data.Utils
 
   @default_data_path "tmp/mnist"
   @base_url 'https://storage.googleapis.com/cvdf-datasets/mnist/'

--- a/lib/axon/data/mnist.ex
+++ b/lib/axon/data/mnist.ex
@@ -1,0 +1,50 @@
+defmodule Axon.Data.MNIST do
+  alias Data.Utils
+
+  @default_data_path "tmp/mnist"
+  @base_url 'https://storage.googleapis.com/cvdf-datasets/mnist/'
+  @image_file 'train-images-idx3-ubyte.gz'
+  @label_file 'train-labels-idx1-ubyte.gz'
+
+  def download_images(opts \\ []) do
+    batch_size = opts[:batch_size] || 32
+    data_path = opts[:data_path] || @default_data_path
+
+    <<_::32, n_images::32, n_rows::32, n_cols::32, images::binary>> =
+      Utils.unzip_cache_or_download(@base_url, @image_file, data_path, unzip: true)
+
+    batched_images =
+      images
+      |> Nx.from_binary({:u, 8})
+      |> Nx.reshape({n_images, n_rows * n_cols})
+      |> Nx.divide(255)
+      |> Nx.to_batched_list(batch_size)
+
+    IO.puts("#{n_images} #{n_rows}x#{n_cols} images\n")
+
+    batched_images
+  end
+
+  def download_labels(opts \\ []) do
+    batch_size = opts[:batch_size] || 32
+    data_path = opts[:data_path] || @default_data_path
+
+    labels =
+      <<_::32, n_labels::32, labels::binary>> =
+      Utils.unzip_cache_or_download(@base_url, @label_file, data_path, unzip: true)
+
+    batched_labels =
+      labels
+      |> Nx.from_binary({:u, 8})
+      |> Nx.new_axis(-1)
+      |> Nx.equal(Nx.tensor(Enum.to_list(0..9)))
+      |> Nx.to_batched_list(batch_size)
+
+    IO.puts("#{n_labels} labels\n")
+
+    batched_labels
+  end
+
+  def download(opts \\ []),
+    do: {download_images(opts), download_labels(opts)}
+end

--- a/lib/axon/data/utils.ex
+++ b/lib/axon/data/utils.ex
@@ -1,0 +1,25 @@
+defmodule Axon.Data.Utils do
+  def unzip_cache_or_download(base_url, zip, data_path, opts \\ [unzip: true]) do
+    unzip? = opts[:unzip] || false
+
+    path = Path.join(data_path, zip)
+
+    data =
+      if File.exists?(path) do
+        IO.puts("Using #{zip} from #{data_path}\n")
+        File.read!(path)
+      else
+        IO.puts("Fetching #{zip} from #{base_url}\n")
+        :inets.start()
+        :ssl.start()
+
+        {:ok, {_status, _response, data}} = :httpc.request(:get, {base_url ++ zip, []}, [], [])
+        File.mkdir_p!(data_path)
+        File.write!(path, data)
+
+        data
+      end
+
+    :zlib.gunzip(data)
+  end
+end


### PR DESCRIPTION
Here we've moved code for downloading and handling the CIFAR, MNIST, and FashionMNIST datasets used by the example scripts into separate modules under `Axon.Data`.

Most of the change are reorganization and de-duplication of code for downloading and processing datasets, but we also add options to change the batch size as well as the directory where datasets are stored. This allows for calls like

```elixir
Axon.Data.MNIST.download_images(data_path: 'tmp/my_data/mnist', batch_size: 200)
```

The API for `MNIST` and `FashionMNIST` looks like
```elixir
# Fetch images and labels together
{train_images, train_labels} = Axon.Data.MNIST.download()

# Or get them separately
train_images = Axon.Data.MNIST.download_images()
train_labels = Axon.Data.MNIST.download_labels()
```

Right now `Axon.Data.CIFAR` only supports `download/1` which returns the image/label tuple.

I'm not sure exactly where these modules should be located in the repo--I'd greatly appreciate feedback on that and any other suggestions!