### PR TITLE
feat: add orthogonal initializer

### DIFF
--- a/lib/axon/initializers.ex
+++ b/lib/axon/initializers.ex
@@ -577,16 +577,14 @@ defmodule Axon.Initializers do
   Initializes a tensor with an orthogonal distribution.
 
   For 2-D tensors, the initialization is generated through the QR decomposition of a random distribution
-  For tensors with more than 2 dimensions, a 2-D tensor with shape `{shape[0] * shape[1] * ... shape[n-2], shape[n-1]}`
+  For tensors with more than 2 dimensions, a 2-D tensor with shape `{shape[0] * shape[1] * ... * shape[n-2], shape[n-1]}`
   is initialized and then reshaped accordingly.
 
   ## Options
 
     * `:shape` - output shape. Must be at least rank `2`
-    * `:type` - output type. Defaults to `{:f, 32}`
-    * `:scale` - scale of the output distribution. Defaults to `1.0e-2`
-    * `:distribution` - output distribution. One of `:normal`, `:truncated_normal`,
-      or `:uniform`. Defaults to `:normal`
+    * `:type` - random seed's type. Defaults to `{:f, 32}`
+    * `:distribution` - output distribution. One of [`:normal`, `:uniform`]. Defaults to `:normal`
 
   ## Examples
 
@@ -595,23 +593,63 @@ defmodule Axon.Initializers do
       {:f, 32}
       iex> Nx.shape(t)
       {3, 3}
-      iex> identity = t |> Nx.transpose() |> Nx.dot(t)
-      iex> Nx.all_close?(identity, Nx.eye(t), atol: 1.0e-3, rtol: 1.0e-3)
-      #Nx.Tensor<
-        u8
-        1
-      >
+
+      iex> t = Axon.Initializers.orthogonal(shape: {1, 2, 3, 4}, type: {:f, 64})
+      iex> Nx.type(t)
+      {:f, 64}
+      iex> Nx.shape(t)
+      {1, 2, 3, 4}
   """
   defn orthogonal(opts \\ []) do
     opts = keyword!(opts, [:shape, type: {:f, 32}, distribution: :normal])
 
-    assert_greater_equal_rank!(opts[:shape], 2)
+    shape = opts[:shape]
+    distribution = opts[:distribution]
+    type = opts[:type]
 
-    random_seed = Nx.random_normal(opts[:shape])
+    assert_greater_equal_rank!(shape, 2)
 
-    {q, _r} = Nx.LinAlg.qr(random_seed)
+    {{m, n}, random_seed} =
+      transform({shape, distribution, type}, fn {shape, distribution, type} ->
+        flat_shape =
+          if tuple_size(shape) > 2 do
+            tuple_list = shape |> Tuple.to_list() |> Enum.reverse()
+            n = hd(tuple_list)
+            m = Enum.reduce(tl(tuple_list), 1, &(&1 * &2))
+            {m, n}
+          else
+            shape
+          end
+
+        random_seed =
+          case distribution do
+            :uniform ->
+              orthogonal_random_uniform(flat_shape, type)
+
+            :normal ->
+              orthogonal_random_normal(flat_shape, type)
+
+            dist ->
+              raise ArgumentError,
+                    "invalid distribution #{inspect(dist)} passed to orthogonal/1"
+          end
+
+        {flat_shape, random_seed}
+      end)
+
+    {q, _r} = Nx.LinAlg.qr(random_seed, mode: :complete)
 
     q
+    |> Nx.slice([0, 0], [m, n])
+    |> Nx.reshape(shape)
+  end
+
+  defnp orthogonal_random_normal(shape, type) do
+    Nx.random_normal(shape, type: type)
+  end
+
+  defnp orthogonal_random_uniform(shape, type) do
+    Nx.random_uniform(shape, type: type)
   end
 
   # Variance scaling branches

--- a/lib/axon/initializers.ex
+++ b/lib/axon/initializers.ex
@@ -624,10 +624,10 @@ defmodule Axon.Initializers do
         random_seed =
           case distribution do
             :uniform ->
-              orthogonal_random_uniform(flat_shape, type)
+              Nx.random_uniform(flat_shape, type: type, backend: Nx.Defn.Expr)
 
             :normal ->
-              orthogonal_random_normal(flat_shape, type)
+              Nx.random_normal(flat_shape, type: type, backend: Nx.Defn.Expr)
 
             dist ->
               raise ArgumentError,
@@ -642,14 +642,6 @@ defmodule Axon.Initializers do
     q
     |> Nx.slice([0, 0], [m, n])
     |> Nx.reshape(shape)
-  end
-
-  defnp orthogonal_random_normal(shape, type) do
-    Nx.random_normal(shape, type: type)
-  end
-
-  defnp orthogonal_random_uniform(shape, type) do
-    Nx.random_uniform(shape, type: type)
   end
 
   # Variance scaling branches

--- a/lib/axon/initializers.ex
+++ b/lib/axon/initializers.ex
@@ -585,8 +585,6 @@ defmodule Axon.Initializers do
     * `:shape` - output shape. Must be at least rank `2`
     * `:type` - output type. Defaults to `{:f, 32}`
     * `:scale` - scale of the output distribution. Defaults to `1.0e-2`
-    * `:mode` - compute fan mode. One of `:fan_in`, `:fan_out`, or `:fan_avg`.
-      Defaults to `:fan_in`
     * `:distribution` - output distribution. One of `:normal`, `:truncated_normal`,
       or `:uniform`. Defaults to `:normal`
 

--- a/test/initializers_test.exs
+++ b/test/initializers_test.exs
@@ -1,4 +1,38 @@
 defmodule Axon.InitializersTest do
   use ExUnit.Case, async: true
   doctest Axon.Initializers
+
+  describe "orthogonal/1" do
+    test "property" do
+      t1 = Axon.Initializers.orthogonal(shape: {3, 3})
+      identity_left_t1 = t1 |> Nx.transpose() |> Nx.dot(t1)
+
+      assert Nx.all_close?(identity_left_t1, Nx.eye(identity_left_t1), atol: 1.0e-3, rtol: 1.0e-3) ==
+               Nx.tensor(1, type: {:u, 8})
+
+      identity_right_t1 = t1 |> Nx.dot(t1 |> Nx.transpose())
+
+      assert Nx.all_close?(identity_right_t1, Nx.eye(identity_right_t1),
+               atol: 1.0e-3,
+               rtol: 1.0e-3
+             ) ==
+               Nx.tensor(1, type: {:u, 8})
+
+      t2 = Axon.Initializers.orthogonal(shape: {1, 2, 3, 4, 5}) |> Nx.reshape({24, 5})
+
+      identity_left_t2 = t2 |> Nx.transpose() |> Nx.dot(t2)
+
+      assert Nx.all_close?(identity_left_t2, Nx.eye(identity_left_t2), atol: 1.0e-3, rtol: 1.0e-3) ==
+               Nx.tensor(1, type: {:u, 8})
+
+      # Since the matrix is "tall", it's transpose will only be it's left inverse
+      identity_right_t2 = t2 |> Nx.dot(Nx.transpose(t2))
+
+      assert Nx.all_close?(identity_right_t2, Nx.eye(identity_right_t2),
+               atol: 1.0e-3,
+               rtol: 1.0e-3
+             ) ==
+               Nx.tensor(0, type: {:u, 8})
+    end
+  end
 end


### PR DESCRIPTION
This PR aims to add `Axon.Initializers.orthogonal/1` for #1

From what I read in https://www.tensorflow.org/api_docs/python/tf/keras/initializers/Orthogonal, we can implement this through Nx.LinAlg.qr + Nx.reshape in some combination.

@seanmor5 is this the right path? I've only added this base case as a proof of concept