### PR TITLE
fix inspect of operation

### DIFF
--- a/lib/axon.ex
+++ b/lib/axon.ex
@@ -1594,8 +1594,14 @@ defmodule Axon do
       num_params =
         params
         |> Enum.reduce(0, fn {_, %Axon.Parameter{shape: shape}}, acc -> acc + Nx.size(shape) end)
-
-      row = [name <> " ( #{Atom.to_string(op)} )", "#{inspect(shape)}", "#{num_params}"]
+        
+      op_inspect = 
+        case op do
+          op when is_atom(op) -> Atom.to_string(op)
+          _ -> "custom"
+         end
+         
+      row = [name <> " ( #{op_inspect} )", "#{inspect(shape)}", "#{num_params}"]
       {row, cache}
     end
   end


### PR DESCRIPTION
The inspect module expects the operation to be an atom but in LSTM model has some operation as a function.