### PR TITLE
Add compiler test

### DIFF
--- a/lib/axon.ex
+++ b/lib/axon.ex
@@ -835,9 +835,18 @@ defmodule Axon do
   end
 
   defp adaptative_pool(%Axon{output_shape: parent_shape} = x, pool, opts) do
+    output_size =
+      if size = opts[:output_size] do
+        size
+      else
+        parent_shape
+        |> Tuple.delete_at(0)
+        |> Tuple.delete_at(0)
+      end
+
     inner_rank = Nx.rank(parent_shape) - 2
 
-    output_size = tuple_or_duplicate(:output_size, opts[:output_size], inner_rank)
+    output_size = tuple_or_duplicate(:output_size, output_size, inner_rank)
     output_shape = Axon.Shape.adaptive_pool(parent_shape, output_size)
 
     layer(x, pool, output_shape, %{}, opts[:name], output_size: output_size)
@@ -846,7 +855,7 @@ defmodule Axon do
   ## Global Pooling
 
   @global_pooling_layers [
-    {:global_average_pool, "Global average pool"},
+    {:global_avg_pool, "Global average pool"},
     {:global_max_pool, "Global max pool"},
     {:global_lp_pool, "Global LP pool"}
   ]
@@ -879,7 +888,7 @@ defmodule Axon do
 
     opts =
       if pool == :global_lp_pool do
-        norm = opts[:norm]
+        norm = opts[:norm] || 1
         [keep_axes: keep_axes, norm: norm]
       else
         [keep_axes: keep_axes]

--- a/lib/axon.ex
+++ b/lib/axon.ex
@@ -447,7 +447,7 @@ defmodule Axon do
     kernel_regularizer = opts[:kernel_regularizer]
 
     kernel =
-      param("weight", kernel_shape,
+      param("kernel", kernel_shape,
         initializer: kernel_initializer,
         regularizer: kernel_regularizer
       )

--- a/lib/axon/compiler.ex
+++ b/lib/axon/compiler.ex
@@ -332,7 +332,7 @@ defmodule Axon.Compiler do
 
   defp recur_predict_fun(
          %Axon{
-           op: :separable_conv2d,
+           op: :separable_conv3d,
            parent: parent,
            opts: opts,
            params: %{

--- a/lib/axon/compiler.ex
+++ b/lib/axon/compiler.ex
@@ -33,10 +33,6 @@ defmodule Axon.Compiler do
     end
   end
 
-  defp to_init_fun(graph, cache) when is_list(graph) do
-    Enum.reduce(graph, cache, fn x, acc -> to_init_fun(x, acc) end)
-  end
-
   defp to_init_fun(graph, cache) when is_tuple(graph) do
     graph
     |> Tuple.to_list()
@@ -167,11 +163,6 @@ defmodule Axon.Compiler do
   end
 
   ## Input Ordering
-
-  defp get_inputs(graph, input_ids) when is_list(graph) do
-    graph
-    |> Enum.reduce(input_ids, fn x, acc -> get_inputs(x, acc) end)
-  end
 
   defp get_inputs(graph, input_ids) when is_tuple(graph) do
     graph

--- a/lib/axon/initializers.ex
+++ b/lib/axon/initializers.ex
@@ -184,7 +184,7 @@ defmodule Axon.Initializers do
 
   ## Options
 
-    * `:shape` - output shape. Must be at least rank `2`
+    * `:shape` - output shape
     * `:type` - output type. Defaults to `{:f, 32}`
     * `:scale` - scale of the output distribution. Defaults to `1.0`
 
@@ -201,11 +201,6 @@ defmodule Axon.Initializers do
       {2, 2}
       iex> Nx.type(t)
       {:bf, 16}
-
-  ### Error cases
-
-      iex> Axon.Initializers.lecun_uniform(shape: {2})
-      ** (ArgumentError) expected input shape to have at least rank 2, got rank 1
 
   ## References
 
@@ -233,7 +228,7 @@ defmodule Axon.Initializers do
 
   ## Options
 
-    * `:shape` - output shape. Must be at least rank `2`
+    * `:shape` - output shape
     * `:type` - output type. Defaults to `{:f, 32}`
     * `:scale` - scale of the output distribution. Defaults to `1.0`
 
@@ -250,11 +245,6 @@ defmodule Axon.Initializers do
       {2, 2}
       iex> Nx.type(t)
       {:bf, 16}
-
-  ### Error cases
-
-      iex> Axon.Initializers.lecun_normal(shape: {2})
-      ** (ArgumentError) expected input shape to have at least rank 2, got rank 1
 
   ## References
 
@@ -285,7 +275,7 @@ defmodule Axon.Initializers do
 
   ## Options
 
-    * `:shape` - output shape. Must be at least rank `2`
+    * `:shape` - output shape
     * `:type` - output type. Defaults to `{:f, 32}`
     * `:scale` - scale of the output distribution. Defaults to `1.0`
 
@@ -302,11 +292,6 @@ defmodule Axon.Initializers do
       {2, 2}
       iex> Nx.type(t)
       {:bf, 16}
-
-  ### Error cases
-
-      iex> Axon.Initializers.glorot_uniform(shape: {2})
-      ** (ArgumentError) expected input shape to have at least rank 2, got rank 1
 
   ## References
 
@@ -337,7 +322,7 @@ defmodule Axon.Initializers do
 
   ## Options
 
-    * `:shape` - output shape. Must be at least rank `2`
+    * `:shape` - output shape
     * `:type` - output type. Defaults to `{:f, 32}`
     * `:scale` - scale of the output distribution. Defaults to `1.0`
 
@@ -354,11 +339,6 @@ defmodule Axon.Initializers do
       {2, 2}
       iex> Nx.type(t)
       {:bf, 16}
-
-  ### Error cases
-
-      iex> Axon.Initializers.glorot_normal(shape: {2})
-      ** (ArgumentError) expected input shape to have at least rank 2, got rank 1
 
   ## References
 
@@ -386,7 +366,7 @@ defmodule Axon.Initializers do
 
   ## Options
 
-    * `:shape` - output shape. Must be at least rank `2`
+    * `:shape` - output shape
     * `:type` - output type. Defaults to `{:f, 32}`
     * `:scale` - scale of the output distribution. Defaults to `2.0`
 
@@ -403,11 +383,6 @@ defmodule Axon.Initializers do
       {2, 2}
       iex> Nx.type(t)
       {:bf, 16}
-
-  ### Error cases
-
-      iex> Axon.Initializers.he_uniform(shape: {2})
-      ** (ArgumentError) expected input shape to have at least rank 2, got rank 1
 
   ## References
 
@@ -435,7 +410,7 @@ defmodule Axon.Initializers do
 
   ## Options
 
-    * `:shape` - output shape. Must be at least rank `2`
+    * `:shape` - output shape
     * `:type` - output type. Defaults to `{:f, 32}`
     * `:scale` - scale of the output distribution. Defaults to `2.0`
 
@@ -452,11 +427,6 @@ defmodule Axon.Initializers do
       {2, 2}
       iex> Nx.type(t)
       {:bf, 16}
-
-  ### Error cases
-
-      iex> Axon.Initializers.he_normal(shape: {2})
-      ** (ArgumentError) expected input shape to have at least rank 2, got rank 1
 
   ## References
 
@@ -484,7 +454,7 @@ defmodule Axon.Initializers do
 
   ## Options
 
-    * `:shape` - output shape. Must be at least rank `2`
+    * `:shape` - output shape
     * `:type` - output type. Defaults to `{:f, 32}`
     * `:scale` - scale of the output distribution. Defaults to `1.0e-2`
     * `:mode` - compute fan mode. One of `:fan_in`, `:fan_out`, or `:fan_avg`.
@@ -512,11 +482,6 @@ defmodule Axon.Initializers do
       iex> Nx.type(t)
       {:f, 32}
 
-  ### Error cases
-
-      iex> Axon.Initializers.variance_scaling(shape: {2})
-      ** (ArgumentError) expected input shape to have at least rank 2, got rank 1
-
       iex> Axon.Initializers.variance_scaling(shape: {2, 2}, mode: :not_a_mode)
       ** (ArgumentError) invalid mode :not_a_mode passed to variance_scaling/1
 
@@ -527,8 +492,6 @@ defmodule Axon.Initializers do
   defn variance_scaling(opts \\ []) do
     opts =
       keyword!(opts, [:shape, type: {:f, 32}, scale: 1.0, mode: :fan_in, distribution: :normal])
-
-    assert_greater_equal_rank!(opts[:shape], 2)
 
     fans = transform(opts[:shape], &compute_fans/1)
 

--- a/lib/axon/layers.ex
+++ b/lib/axon/layers.ex
@@ -1072,7 +1072,8 @@ defmodule Axon.Layers do
     opts = keyword!(opts, [:group_size, epsilon: 1.0e-5, channel_index: 1])
 
     group_shape =
-      transform({Nx.shape(input), opts[:group_size], opts[:channel_index]}, fn {shape, groups, channel} ->
+      transform({Nx.shape(input), opts[:group_size], opts[:channel_index]}, fn {shape, groups,
+                                                                                channel} ->
         Axon.Shape.group_norm_shape(shape, groups, channel)
       end)
 

--- a/lib/axon/layers.ex
+++ b/lib/axon/layers.ex
@@ -1069,11 +1069,10 @@ defmodule Axon.Layers do
   """
   @doc type: :normalization
   defn group_norm(input, gamma, bias, opts \\ []) do
-    opts = keyword!(opts, [:group_size, epsilon: 1.0e-6, channel_index: 1])
+    opts = keyword!(opts, [:group_size, epsilon: 1.0e-5, channel_index: 1])
 
     group_shape =
-      transform({Nx.shape(input), opts[:group_size], opts[:channel_index]}, fn {shape, groups,
-                                                                                channel} ->
+      transform({Nx.shape(input), opts[:group_size], opts[:channel_index]}, fn {shape, groups, channel} ->
         Axon.Shape.group_norm_shape(shape, groups, channel)
       end)
 
@@ -1100,8 +1099,7 @@ defmodule Axon.Layers do
     x = Nx.reshape(input, group_shape)
     axes = transform(Nx.rank(x), &Axon.Shape.group_norm_axes/1)
     {mean, var} = mean_and_variance(x, axes: axes)
-    x = normalize(x, mean, var, gamma, bias)
-    Nx.reshape(x, Nx.shape(input)) * gamma + bias
+    normalize(Nx.reshape(x, input), mean, var, gamma, bias, epsilon: opts[:epsilon])
   end
 
   @doc """

--- a/lib/axon/layers.ex
+++ b/lib/axon/layers.ex
@@ -652,22 +652,22 @@ defmodule Axon.Layers do
         {Nx.rank(input), opts[:strides]},
         fn
           {_, [_ | _] = strides} -> [1, 1 | strides]
-          {rank, strides} -> [1, 1 | List.duplicate(rank - 2, strides)]
+          {rank, strides} -> [1, 1 | List.duplicate(strides, rank - 2)]
         end
       )
 
     padding =
       transform(
-        {Nx.rank(input), opts[:padding]},
+        opts[:padding],
         fn
-          {_, :same} ->
+          :same ->
             :same
 
-          {_, :valid} ->
+          :valid ->
             :valid
 
-          {rank, padding} ->
-            List.duplicate({0, 0}, rank - 2) ++ padding
+          padding ->
+            [{0, 0}, {0, 0} | padding]
         end
       )
 
@@ -731,22 +731,22 @@ defmodule Axon.Layers do
         {Nx.rank(input), opts[:strides]},
         fn
           {_, [_ | _] = strides} -> [1, 1 | strides]
-          {rank, strides} -> [1, 1 | List.duplicate(rank - 2, strides)]
+          {rank, strides} -> [1, 1 | List.duplicate(strides, rank - 2)]
         end
       )
 
     padding =
       transform(
-        {Nx.rank(input), opts[:padding]},
+        opts[:padding],
         fn
-          {_, :same} ->
+          :same ->
             :same
 
-          {_, :valid} ->
+          :valid ->
             :valid
 
-          {rank, padding} ->
-            List.duplicate({0, 0}, rank - 2) ++ padding
+          padding ->
+            [{0, 0}, {0, 0} | padding]
         end
       )
 
@@ -830,22 +830,22 @@ defmodule Axon.Layers do
         {Nx.rank(input), opts[:strides]},
         fn
           {_, [_ | _] = strides} -> [1, 1 | strides]
-          {rank, strides} -> [1, 1 | List.duplicate(rank - 2, strides)]
+          {rank, strides} -> [1, 1 | List.duplicate(strides, rank - 2)]
         end
       )
 
     padding =
       transform(
-        {Nx.rank(input), opts[:padding]},
+        opts[:padding],
         fn
-          {_, :same} ->
+          :same ->
             :same
 
-          {_, :valid} ->
+          :valid ->
             :valid
 
-          {rank, padding} ->
-            List.duplicate({0, 0}, rank - 2) ++ padding
+          padding ->
+            [{0, 0}, {0, 0} | padding]
         end
       )
 
@@ -1275,7 +1275,7 @@ defmodule Axon.Layers do
 
   ## Examples
 
-      iex> Axon.Layers.global_average_pool(Nx.iota({3, 2, 3}, type: {:f, 32}))
+      iex> Axon.Layers.global_avg_pool(Nx.iota({3, 2, 3}, type: {:f, 32}))
       #Nx.Tensor<
         f32[3][2]
         [
@@ -1285,7 +1285,7 @@ defmodule Axon.Layers do
         ]
       >
 
-      iex> Axon.Layers.global_average_pool(Nx.iota({1, 3, 2, 2}, type: {:f, 32}), keep_axes: true)
+      iex> Axon.Layers.global_avg_pool(Nx.iota({1, 3, 2, 2}, type: {:f, 32}), keep_axes: true)
       #Nx.Tensor<
         f32[1][3][1][1]
         [
@@ -1303,7 +1303,7 @@ defmodule Axon.Layers do
         ]
       >
   """
-  defn global_average_pool(input, opts \\ []) do
+  defn global_avg_pool(input, opts \\ []) do
     opts = keyword!(opts, keep_axes: false)
 
     all_but_batch_and_feature =

--- a/lib/axon/layers.ex
+++ b/lib/axon/layers.ex
@@ -968,6 +968,26 @@ defmodule Axon.Layers do
         Axon.Shape.batch_norm_axes(axes, channel)
       end)
 
+    channel_index = opts[:channel_index]
+
+    num_channels =
+      transform({input, channel_index}, fn {inp, channel_idx} ->
+        elem(Nx.shape(inp), channel_idx)
+      end)
+
+    {gamma, bias} =
+      transform({gamma, bias, Nx.rank(input), num_channels, channel_index}, fn {g, b, rank,
+                                                                                num_channels,
+                                                                                channel_idx} ->
+        new_shape =
+          1
+          |> List.duplicate(rank)
+          |> List.to_tuple()
+          |> put_elem(channel_idx, num_channels)
+
+        {Nx.reshape(g, new_shape), Nx.reshape(b, new_shape)}
+      end)
+
     {mean, var} = mean_and_variance(input, axes: axes)
     normalize(input, mean, var, gamma, bias, epsilon: opts[:epsilon])
   end
@@ -993,8 +1013,29 @@ defmodule Axon.Layers do
   """
   @doc type: :normalization
   defn layer_norm(input, gamma, bias, opts \\ []) do
-    opts = keyword!(opts, epsilon: 1.0e-6, channel_index: 1)
+    opts = keyword!(opts, epsilon: 1.0e-5, channel_index: 1)
     axes = opts[:channel_index]
+
+    channel_index = opts[:channel_index]
+
+    num_channels =
+      transform({input, channel_index}, fn {inp, channel_idx} ->
+        elem(Nx.shape(inp), channel_idx)
+      end)
+
+    {gamma, bias} =
+      transform({gamma, bias, Nx.rank(input), num_channels, channel_index}, fn {g, b, rank,
+                                                                                num_channels,
+                                                                                channel_idx} ->
+        new_shape =
+          1
+          |> List.duplicate(rank)
+          |> List.to_tuple()
+          |> put_elem(channel_idx, num_channels)
+
+        {Nx.reshape(g, new_shape), Nx.reshape(b, new_shape)}
+      end)
+
     {mean, var} = mean_and_variance(input, axes: [axes])
     normalize(input, mean, var, gamma, bias, epsilon: opts[:epsilon])
   end
@@ -1036,6 +1077,26 @@ defmodule Axon.Layers do
         Axon.Shape.group_norm_shape(shape, groups, channel)
       end)
 
+    channel_index = opts[:channel_index]
+
+    num_channels =
+      transform({input, channel_index}, fn {inp, channel_idx} ->
+        elem(Nx.shape(inp), channel_idx)
+      end)
+
+    {gamma, bias} =
+      transform({gamma, bias, Nx.rank(input), num_channels, channel_index}, fn {g, b, rank,
+                                                                                num_channels,
+                                                                                channel_idx} ->
+        new_shape =
+          1
+          |> List.duplicate(rank)
+          |> List.to_tuple()
+          |> put_elem(channel_idx, num_channels)
+
+        {Nx.reshape(g, new_shape), Nx.reshape(b, new_shape)}
+      end)
+
     x = Nx.reshape(input, group_shape)
     axes = transform(Nx.rank(x), &Axon.Shape.group_norm_axes/1)
     {mean, var} = mean_and_variance(x, axes: axes)
@@ -1068,11 +1129,31 @@ defmodule Axon.Layers do
   """
   @doc type: :normalization
   defn instance_norm(input, gamma, bias, opts \\ []) do
-    opts = keyword!(opts, epsilon: 1.0e-6, channel_index: 1)
+    opts = keyword!(opts, epsilon: 1.0e-5, channel_index: 1)
 
     axes =
       transform({Nx.axes(input), opts[:channel_index]}, fn {axes, channel} ->
         Axon.Shape.instance_norm_axes(axes, channel)
+      end)
+
+    channel_index = opts[:channel_index]
+
+    num_channels =
+      transform({input, channel_index}, fn {inp, channel_idx} ->
+        elem(Nx.shape(inp), channel_idx)
+      end)
+
+    {gamma, bias} =
+      transform({gamma, bias, Nx.rank(input), num_channels, channel_index}, fn {g, b, rank,
+                                                                                num_channels,
+                                                                                channel_idx} ->
+        new_shape =
+          1
+          |> List.duplicate(rank)
+          |> List.to_tuple()
+          |> put_elem(channel_idx, num_channels)
+
+        {Nx.reshape(g, new_shape), Nx.reshape(b, new_shape)}
       end)
 
     {mean, var} = mean_and_variance(input, axes: axes)

--- a/lib/axon/layers.ex
+++ b/lib/axon/layers.ex
@@ -372,11 +372,6 @@ defmodule Axon.Layers do
         kernel_dilation: 1
       )
 
-    bias_reshape =
-      transform({Nx.shape(bias), Nx.rank(input) - 2}, fn {bias_shape, rank} ->
-        Axon.Shape.conv_bias_reshape(bias_shape, rank)
-      end)
-
     strides =
       transform(
         {Nx.rank(input), opts[:strides]},
@@ -394,13 +389,11 @@ defmodule Axon.Layers do
         end
       )
 
-    input
-    |> Nx.conv(weight,
+    conv(input, weight, bias,
       strides: opts[:strides],
       padding: padding,
       kernel_dilation: opts[:kernel_dilation]
     )
-    |> Nx.add(Nx.reshape(bias, bias_reshape))
   end
 
   @doc """
@@ -456,31 +449,15 @@ defmodule Axon.Layers do
         kernel_dilation: 1
       )
 
-    strides =
-      transform(
-        {Nx.rank(input), opts[:strides]},
-        fn
-          {_, [_ | _] = strides} -> strides
-          {rank, strides} -> List.duplicate(strides, rank - 2)
-        end
-      )
-
     num_groups = transform(Nx.shape(input), &elem(&1, 1))
 
-    bias_reshape =
-      transform({Nx.shape(bias), Nx.rank(input) - 2}, fn {bias_shape, rank} ->
-        Axon.Shape.conv_bias_reshape(bias_shape, rank)
-      end)
-
-    input
-    |> Nx.conv(weight,
-      strides: strides,
+    conv(input, weight, bias,
+      strides: opts[:strides],
       padding: opts[:padding],
       input_dilation: opts[:input_dilation],
       kernel_dilation: opts[:kernel_dilation],
       feature_group_size: num_groups
     )
-    |> Nx.add(Nx.reshape(bias, bias_reshape))
   end
 
   @doc """

--- a/lib/axon/recurrent.ex
+++ b/lib/axon/recurrent.ex
@@ -69,7 +69,18 @@ defmodule Axon.Recurrent do
     {cell, hidden} = carry
     {wii, wif, wig, wio} = input_kernel
     {whi, whf, whg, who} = hidden_kernel
-    {bi, bf, bg, bo} = bias
+
+    {bi, bf, bg, bo} =
+      transform(bias, fn {bi, bf, bg, bo} ->
+        new_shape =
+          bi
+          |> Nx.shape()
+          |> Tuple.insert_at(0, 1)
+          |> Tuple.insert_at(0, 1)
+
+        {Nx.reshape(bi, new_shape), Nx.reshape(bf, new_shape), Nx.reshape(bg, new_shape),
+         Nx.reshape(bo, new_shape)}
+      end)
 
     i = gate_fn.(dense(input, wii, bi) + dense(hidden, whi, 0))
     f = gate_fn.(dense(input, wif, bf) + dense(hidden, whf, 0))

--- a/lib/axon/shape.ex
+++ b/lib/axon/shape.ex
@@ -979,7 +979,7 @@ defmodule Axon.Shape do
   ### Error cases
 
       iex> Axon.Shape.reshape({nil, 4, 2}, {9})
-      ** (ArgumentError) new shape invalid for reshape operation, layer shape {nil, 4, 2} is incompatible with new shape {9}, new shape must have same size as batch dimensions of old shape
+      ** (ArgumentError) new shape invalid for reshape operation, layer shape {nil, 4, 2} is incompatible with new shape {9}, new shape must have same size as non-batch dimensions of old shape
   """
   def reshape(shape, new_shape) do
     batch_size = elem(shape, 0)
@@ -990,7 +990,7 @@ defmodule Axon.Shape do
             "new shape invalid for reshape operation," <>
               " layer shape #{inspect(shape)} is incompatible" <>
               " with new shape #{inspect(new_shape)}, new shape" <>
-              " must have same size as batch dimensions of old shape"
+              " must have same size as non-batch dimensions of old shape"
     end
 
     Tuple.insert_at(new_shape, 0, batch_size)
@@ -1119,7 +1119,7 @@ defmodule Axon.Shape do
               " got #{inspect(shape)}"
     end
 
-    {1, 1, units}
+    {units}
   end
 
   @doc """

--- a/lib/axon/shape.ex
+++ b/lib/axon/shape.ex
@@ -526,10 +526,10 @@ defmodule Axon.Shape do
   ## Examples
 
       iex> Axon.Shape.separable_conv2d_bias({nil, 3, 32, 32}, 3, {3, 3})
-      {1, 9, 1, 1}
+      {9}
 
       iex> Axon.Shape.separable_conv2d_bias({nil, 3, 32, 32}, 4, {3, 3})
-      {1, 12, 1, 1}
+      {12}
 
   ### Error cases
 
@@ -543,7 +543,7 @@ defmodule Axon.Shape do
               " as number of spatial dimensions in the input (#{Nx.rank(input_shape) - 2})"
     end
 
-    {1, elem(input_shape, 1) * channel_multiplier, 1, 1}
+    {elem(input_shape, 1) * channel_multiplier}
   end
 
   @doc """
@@ -596,13 +596,13 @@ defmodule Axon.Shape do
   ## Examples
 
       iex> Axon.Shape.separable_conv3d_bias({nil, 3, 224, 224, 3}, 3, {3, 3, 2})
-      {1, 9, 1, 1, 1}
+      {9}
 
       iex> Axon.Shape.separable_conv3d_bias({nil, 3, 32, 32, 3}, 2, {2, 3, 2})
-      {1, 6, 1, 1, 1}
+      {6}
 
       iex> Axon.Shape.separable_conv3d_bias({nil, 1, 224, 224, 3}, 5, {3, 3, 1})
-      {1, 5, 1, 1, 1}
+      {5}
 
   ### Error cases
 
@@ -616,7 +616,7 @@ defmodule Axon.Shape do
               " as number of spatial dimensions in the input (#{Nx.rank(input_shape) - 2})"
     end
 
-    {1, elem(input_shape, 1) * channel_multiplier, 1, 1, 1}
+    {elem(input_shape, 1) * channel_multiplier}
   end
 
   @doc """
@@ -853,17 +853,13 @@ defmodule Axon.Shape do
   ## Examples
 
       iex> Axon.Shape.norm_param({nil, 3, 28, 28}, 1)
-      {1, 3, 1, 1}
+      {3}
 
       iex> Axon.Shape.norm_param({nil, 28, 28, 3}, 3)
-      {1, 1, 1, 3}
+      {3}
   """
   def norm_param(parent_shape, channel_index) do
-    parent_shape
-    |> Tuple.to_list()
-    |> Enum.with_index()
-    |> Enum.map(fn {x, i} -> if i == channel_index, do: x, else: 1 end)
-    |> List.to_tuple()
+    {elem(parent_shape, channel_index)}
   end
 
   @doc """

--- a/lib/axon/shape.ex
+++ b/lib/axon/shape.ex
@@ -160,13 +160,13 @@ defmodule Axon.Shape do
   ## Examples
 
       iex> Axon.Shape.conv_bias({nil, 3, 224, 224}, 32, {3, 3})
-      {1, 32, 1, 1}
+      {32}
 
       iex> Axon.Shape.conv_bias({nil, 3, 28}, 64, {2})
-      {1, 64, 1}
+      {64}
 
       iex> Axon.Shape.conv_bias({nil, 1, 32, 32, 10}, 32, {2, 1, 3})
-      {1, 32, 1, 1, 1}
+      {32}
 
   ### Error cases
 
@@ -180,8 +180,7 @@ defmodule Axon.Shape do
               " as number of spatial dimensions in the input (#{Nx.rank(input_shape) - 2})"
     end
 
-    spatial_dims = List.duplicate(1, Nx.rank(input_shape) - 2)
-    List.to_tuple([1, output_filters | spatial_dims])
+    {output_filters}
   end
 
   @doc """
@@ -394,13 +393,13 @@ defmodule Axon.Shape do
   ## Examples
 
       iex> Axon.Shape.depthwise_conv_bias({nil, 3, 224, 224}, 3, {3, 3})
-      {1, 9, 1, 1}
+      {9}
 
       iex> Axon.Shape.depthwise_conv_bias({nil, 3, 28}, 2, {2})
-      {1, 6, 1}
+      {6}
 
       iex> Axon.Shape.depthwise_conv_bias({nil, 1, 32, 32, 10}, 1, {2, 1, 3})
-      {1, 1, 1, 1, 1}
+      {1}
 
   ### Error cases
 
@@ -414,9 +413,7 @@ defmodule Axon.Shape do
               " as number of spatial dimensions in the input (#{Nx.rank(input_shape) - 2})"
     end
 
-    input_channels = elem(input_shape, 1)
-    spatial_dims = List.duplicate(1, Nx.rank(input_shape) - 2)
-    List.to_tuple([1, input_channels * channel_multiplier | spatial_dims])
+    {elem(input_shape, 1) * channel_multiplier}
   end
 
   @doc """

--- a/lib/axon/shape.ex
+++ b/lib/axon/shape.ex
@@ -83,16 +83,16 @@ defmodule Axon.Shape do
   ## Examples
 
       iex> Axon.Shape.dense_bias({nil, 784}, 128)
-      {1, 128}
+      {128}
 
       iex> Axon.Shape.dense_bias({nil, 128}, 256)
-      {1, 256}
+      {256}
 
       iex> Axon.Shape.dense_bias({nil, 3, 256, 256}, 128)
-      {1, 128}
+      {128}
   """
   def dense_bias(_input_shape, units) do
-    {1, units}
+    {units}
   end
 
   @doc """
@@ -800,9 +800,8 @@ defmodule Axon.Shape do
       end
 
     strides =
-      output_spatial
-      |> Enum.zip(input_spatial)
-      |> Enum.map(fn {input, output} -> div(input, output) end)
+      input_spatial
+      |> Enum.zip_with(output_spatial, &Kernel.div/2)
 
     [1, 1 | strides]
   end

--- a/test/axon_test.exs
+++ b/test/axon_test.exs
@@ -89,7 +89,7 @@ defmodule AxonTest do
       assert opts[:input_dilation] == [1, 1]
 
       assert %Axon.Parameter{shape: {64, 1, 2, 2}} = kernel
-      assert %Axon.Parameter{shape: {1, 64, 1, 1}} = bias
+      assert %Axon.Parameter{shape: {64}} = bias
     end
 
     test "fails on bad options" do
@@ -160,7 +160,7 @@ defmodule AxonTest do
       assert opts[:input_dilation] == [1, 1]
 
       assert %Axon.Parameter{shape: {3, 1, 2, 2}} = kernel
-      assert %Axon.Parameter{shape: {1, 3, 1, 1}} = bias
+      assert %Axon.Parameter{shape: {3}} = bias
     end
 
     test "fails on bad options" do

--- a/test/axon_test.exs
+++ b/test/axon_test.exs
@@ -241,8 +241,8 @@ defmodule AxonTest do
 
       assert %Axon.Parameter{shape: {3, 1, 2, 1}} = k1
       assert %Axon.Parameter{shape: {3, 1, 1, 2}} = k2
-      assert %Axon.Parameter{shape: {1, 3, 1, 1}} = b1
-      assert %Axon.Parameter{shape: {1, 3, 1, 1}} = b2
+      assert %Axon.Parameter{shape: {3}} = b1
+      assert %Axon.Parameter{shape: {3}} = b2
     end
 
     test "fails on bad options" do
@@ -331,9 +331,9 @@ defmodule AxonTest do
       assert %Axon.Parameter{shape: {3, 1, 2, 1, 1}} = k1
       assert %Axon.Parameter{shape: {3, 1, 1, 2, 1}} = k2
       assert %Axon.Parameter{shape: {3, 1, 1, 1, 2}} = k3
-      assert %Axon.Parameter{shape: {1, 3, 1, 1, 1}} = b1
-      assert %Axon.Parameter{shape: {1, 3, 1, 1, 1}} = b2
-      assert %Axon.Parameter{shape: {1, 3, 1, 1, 1}} = b3
+      assert %Axon.Parameter{shape: {3}} = b1
+      assert %Axon.Parameter{shape: {3}} = b2
+      assert %Axon.Parameter{shape: {3}} = b3
     end
 
     test "fails on bad options" do

--- a/test/compiler_test.exs
+++ b/test/compiler_test.exs
@@ -440,7 +440,8 @@ defmodule CompilerTest do
     end
 
     test "initializes with custom initializers" do
-      model1 = Axon.input({nil, 3, 32, 32}) |> Axon.conv(32, name: "conv", kernel_initializer: :zeros)
+      model1 =
+        Axon.input({nil, 3, 32, 32}) |> Axon.conv(32, name: "conv", kernel_initializer: :zeros)
 
       assert {init_fn, _predict_fn} = Axon.compile(model1)
       assert %{"conv_kernel" => kernel, "conv_bias" => bias} = init_fn.()
@@ -448,7 +449,8 @@ defmodule CompilerTest do
       assert Nx.shape(bias) == {32}
       assert Nx.type(bias) == {:f, 32}
 
-      model2 = Axon.input({nil, 3, 32, 32}) |> Axon.conv(32, name: "conv", bias_initializer: :zeros)
+      model2 =
+        Axon.input({nil, 3, 32, 32}) |> Axon.conv(32, name: "conv", bias_initializer: :zeros)
 
       assert {init_fn, _predict_fn} = Axon.compile(model2)
       assert %{"conv_kernel" => kernel, "conv_bias" => bias} = init_fn.()
@@ -490,7 +492,10 @@ defmodule CompilerTest do
       assert predict_fn.(params, input1) == Axon.Layers.conv(input1, kernel, bias, opts1)
 
       opts2 = [strides: [1, 2], padding: [{0, 1}, {1, 2}], kernel_dilation: 2]
-      model2 = Axon.input({nil, 1, 28, 28}) |> Axon.conv(32, [name: "conv", kernel_size: 2] ++ opts2)
+
+      model2 =
+        Axon.input({nil, 1, 28, 28}) |> Axon.conv(32, [name: "conv", kernel_size: 2] ++ opts2)
+
       input2 = Nx.random_uniform({1, 1, 28, 28})
 
       assert {init_fn, predict_fn} = Axon.compile(model2)
@@ -498,7 +503,11 @@ defmodule CompilerTest do
       assert predict_fn.(params, input2) == Axon.Layers.conv(input2, kernel, bias, opts2)
 
       opts3 = [strides: [2, 1, 1]]
-      model3 = Axon.input({nil, 1, 28, 28, 2}) |> Axon.conv(32, [name: "conv", kernel_size: {2, 1, 1}] ++ opts3)
+
+      model3 =
+        Axon.input({nil, 1, 28, 28, 2})
+        |> Axon.conv(32, [name: "conv", kernel_size: {2, 1, 1}] ++ opts3)
+
       input3 = Nx.random_uniform({1, 1, 28, 28, 2})
 
       assert {init_fn, predict_fn} = Axon.compile(model3)
@@ -559,7 +568,9 @@ defmodule CompilerTest do
     end
 
     test "initializes with custom initializers" do
-      model1 = Axon.input({nil, 3, 32, 32}) |> Axon.depthwise_conv(3, name: "conv", kernel_initializer: :zeros)
+      model1 =
+        Axon.input({nil, 3, 32, 32})
+        |> Axon.depthwise_conv(3, name: "conv", kernel_initializer: :zeros)
 
       assert {init_fn, _predict_fn} = Axon.compile(model1)
       assert %{"conv_kernel" => kernel, "conv_bias" => bias} = init_fn.()
@@ -567,7 +578,9 @@ defmodule CompilerTest do
       assert Nx.shape(bias) == {9}
       assert Nx.type(bias) == {:f, 32}
 
-      model2 = Axon.input({nil, 3, 32, 32}) |> Axon.depthwise_conv(3, name: "conv", bias_initializer: :zeros)
+      model2 =
+        Axon.input({nil, 3, 32, 32})
+        |> Axon.depthwise_conv(3, name: "conv", bias_initializer: :zeros)
 
       assert {init_fn, _predict_fn} = Axon.compile(model2)
       assert %{"conv_kernel" => kernel, "conv_bias" => bias} = init_fn.()
@@ -601,28 +614,46 @@ defmodule CompilerTest do
 
     test "computes forward pass with custom options" do
       opts1 = [strides: 2, padding: :same, input_dilation: 2]
-      model1 = Axon.input({nil, 1, 28}) |> Axon.depthwise_conv(1, [name: "conv", kernel_size: 2] ++ opts1)
+
+      model1 =
+        Axon.input({nil, 1, 28})
+        |> Axon.depthwise_conv(1, [name: "conv", kernel_size: 2] ++ opts1)
+
       input1 = Nx.random_uniform({1, 1, 28})
 
       assert {init_fn, predict_fn} = Axon.compile(model1)
       assert %{"conv_kernel" => kernel, "conv_bias" => bias} = params = init_fn.()
-      assert predict_fn.(params, input1) == Axon.Layers.depthwise_conv(input1, kernel, bias, opts1)
+
+      assert predict_fn.(params, input1) ==
+               Axon.Layers.depthwise_conv(input1, kernel, bias, opts1)
 
       opts2 = [strides: [1, 2], padding: [{0, 1}, {1, 2}], kernel_dilation: 2]
-      model2 = Axon.input({nil, 1, 28, 28}) |> Axon.depthwise_conv(8, [name: "conv", kernel_size: 2] ++ opts2)
+
+      model2 =
+        Axon.input({nil, 1, 28, 28})
+        |> Axon.depthwise_conv(8, [name: "conv", kernel_size: 2] ++ opts2)
+
       input2 = Nx.random_uniform({1, 1, 28, 28})
 
       assert {init_fn, predict_fn} = Axon.compile(model2)
       assert %{"conv_kernel" => kernel, "conv_bias" => bias} = params = init_fn.()
-      assert predict_fn.(params, input2) == Axon.Layers.depthwise_conv(input2, kernel, bias, opts2)
+
+      assert predict_fn.(params, input2) ==
+               Axon.Layers.depthwise_conv(input2, kernel, bias, opts2)
 
       opts3 = [strides: [2, 1, 1]]
-      model3 = Axon.input({nil, 1, 28, 28, 2}) |> Axon.depthwise_conv(2, [name: "conv", kernel_size: {2, 1, 1}] ++ opts3)
+
+      model3 =
+        Axon.input({nil, 1, 28, 28, 2})
+        |> Axon.depthwise_conv(2, [name: "conv", kernel_size: {2, 1, 1}] ++ opts3)
+
       input3 = Nx.random_uniform({1, 1, 28, 28, 2})
 
       assert {init_fn, predict_fn} = Axon.compile(model3)
       assert %{"conv_kernel" => kernel, "conv_bias" => bias} = params = init_fn.()
-      assert predict_fn.(params, input3) == Axon.Layers.depthwise_conv(input3, kernel, bias, opts3)
+
+      assert predict_fn.(params, input3) ==
+               Axon.Layers.depthwise_conv(input3, kernel, bias, opts3)
     end
 
     test "returns zero gradient for frozen parameters" do
@@ -678,7 +709,9 @@ defmodule CompilerTest do
     end
 
     test "initializes with custom initializers" do
-      model1 = Axon.input({nil, 3, 32, 32}) |> Axon.conv_transpose(32, name: "conv", kernel_initializer: :zeros)
+      model1 =
+        Axon.input({nil, 3, 32, 32})
+        |> Axon.conv_transpose(32, name: "conv", kernel_initializer: :zeros)
 
       assert {init_fn, _predict_fn} = Axon.compile(model1)
       assert %{"conv_kernel" => kernel, "conv_bias" => bias} = init_fn.()
@@ -686,7 +719,9 @@ defmodule CompilerTest do
       assert Nx.shape(bias) == {32}
       assert Nx.type(bias) == {:f, 32}
 
-      model2 = Axon.input({nil, 3, 32, 32}) |> Axon.conv_transpose(32, name: "conv", bias_initializer: :zeros)
+      model2 =
+        Axon.input({nil, 3, 32, 32})
+        |> Axon.conv_transpose(32, name: "conv", bias_initializer: :zeros)
 
       assert {init_fn, _predict_fn} = Axon.compile(model2)
       assert %{"conv_kernel" => kernel, "conv_bias" => bias} = init_fn.()
@@ -720,28 +755,46 @@ defmodule CompilerTest do
 
     test "computes forward pass with custom options" do
       opts1 = [strides: 2, kernel_dilation: 1]
-      model1 = Axon.input({nil, 1, 28}) |> Axon.conv_transpose(1, [name: "conv", kernel_size: 2] ++ opts1)
+
+      model1 =
+        Axon.input({nil, 1, 28})
+        |> Axon.conv_transpose(1, [name: "conv", kernel_size: 2] ++ opts1)
+
       input1 = Nx.random_uniform({1, 1, 28})
 
       assert {init_fn, predict_fn} = Axon.compile(model1)
       assert %{"conv_kernel" => kernel, "conv_bias" => bias} = params = init_fn.()
-      assert predict_fn.(params, input1) == Axon.Layers.conv_transpose(input1, kernel, bias, opts1)
+
+      assert predict_fn.(params, input1) ==
+               Axon.Layers.conv_transpose(input1, kernel, bias, opts1)
 
       opts2 = [strides: [1, 2], padding: [{0, 1}, {1, 2}], kernel_dilation: 2]
-      model2 = Axon.input({nil, 1, 28, 28}) |> Axon.conv_transpose(8, [name: "conv", kernel_size: 2] ++ opts2)
+
+      model2 =
+        Axon.input({nil, 1, 28, 28})
+        |> Axon.conv_transpose(8, [name: "conv", kernel_size: 2] ++ opts2)
+
       input2 = Nx.random_uniform({1, 1, 28, 28})
 
       assert {init_fn, predict_fn} = Axon.compile(model2)
       assert %{"conv_kernel" => kernel, "conv_bias" => bias} = params = init_fn.()
-      assert predict_fn.(params, input2) == Axon.Layers.conv_transpose(input2, kernel, bias, opts2)
+
+      assert predict_fn.(params, input2) ==
+               Axon.Layers.conv_transpose(input2, kernel, bias, opts2)
 
       opts3 = [strides: [2, 1, 1]]
-      model3 = Axon.input({nil, 1, 28, 28, 2}) |> Axon.conv_transpose(2, [name: "conv", kernel_size: {2, 1, 1}] ++ opts3)
+
+      model3 =
+        Axon.input({nil, 1, 28, 28, 2})
+        |> Axon.conv_transpose(2, [name: "conv", kernel_size: {2, 1, 1}] ++ opts3)
+
       input3 = Nx.random_uniform({1, 1, 28, 28, 2})
 
       assert {init_fn, predict_fn} = Axon.compile(model3)
       assert %{"conv_kernel" => kernel, "conv_bias" => bias} = params = init_fn.()
-      assert predict_fn.(params, input3) == Axon.Layers.conv_transpose(input3, kernel, bias, opts3)
+
+      assert predict_fn.(params, input3) ==
+               Axon.Layers.conv_transpose(input3, kernel, bias, opts3)
     end
 
     test "returns zero gradient for frozen parameters" do

--- a/test/compiler_test.exs
+++ b/test/compiler_test.exs
@@ -1369,14 +1369,18 @@ defmodule CompilerTest do
 
       assert {init_fn, predict_fn} = Axon.compile(model1)
       assert %{"norm_gamma" => gamma, "norm_beta" => beta} = params = init_fn.()
-      assert predict_fn.(params, input1) == Axon.Layers.group_norm(input1, gamma, beta, group_size: 2)
+
+      assert predict_fn.(params, input1) ==
+               Axon.Layers.group_norm(input1, gamma, beta, group_size: 2)
 
       model2 = Axon.input({nil, 3, 16, 16}) |> Axon.group_norm(3, name: "norm")
       input2 = Nx.random_uniform({1, 3, 16, 16})
 
       assert {init_fn, predict_fn} = Axon.compile(model2)
       assert %{"norm_gamma" => gamma, "norm_beta" => beta} = params = init_fn.()
-      assert predict_fn.(params, input2) == Axon.Layers.group_norm(input2, gamma, beta, group_size: 3)
+
+      assert predict_fn.(params, input2) ==
+               Axon.Layers.group_norm(input2, gamma, beta, group_size: 3)
     end
 
     test "computes forward pass with custom options" do
@@ -1386,7 +1390,9 @@ defmodule CompilerTest do
 
       assert {init_fn, predict_fn} = Axon.compile(model)
       assert %{"norm_gamma" => gamma, "norm_beta" => beta} = params = init_fn.()
-      assert predict_fn.(params, input) == Axon.Layers.group_norm(input, gamma, beta, [group_size: 3] ++ opts)
+
+      assert predict_fn.(params, input) ==
+               Axon.Layers.group_norm(input, gamma, beta, [group_size: 3] ++ opts)
     end
 
     test "returns zero gradient for frozen parameters" do


### PR DESCRIPTION
The purpose of this is to add some basic tests of compilation of each layer before building up more complex integration tests. The focus is mainly to make sure that initialization and forward pass, as well as more complex things like model freezing and parameter policies work as expected. I'm pretty much testing models exactly against their implementation in `Axon.Layer` as the implementations should be tested individually in the layer test.