### PR TITLE
Fix: sample image shape

### DIFF
--- a/examples/fashionmnist_autoencoder.exs
+++ b/examples/fashionmnist_autoencoder.exs
@@ -35,7 +35,7 @@ sample_image =
   train_images
   |> hd()
   |> Nx.slice_axis(0, 1, 0)
-  |> Nx.reshape({1, 28, 28})
+  |> Nx.reshape({1, 1, 28, 28})
 
 sample_image |> Nx.to_heatmap() |> IO.inspect
 


### PR DESCRIPTION
Issue:
(ArgumentError) invalid input shape given to model, expected input with shape {nil, 1, 28, 28}, but got input with shape {1, 28, 28}