### PR TITLE
Fix: predict input tensor shape

### DIFF
--- a/examples/xor.exs
+++ b/examples/xor.exs
@@ -2,8 +2,8 @@
 # multi input models as just using `input` many times
 require Axon
 
-inp1 = Axon.input({32, 1})
-inp2 = Axon.input({32, 1})
+inp1 = Axon.input({:nil, 1})
+inp2 = Axon.input({:nil, 1})
 
 model =
   inp1


### PR DESCRIPTION
Issue:
(ArgumentError) invalid input shape given to model, expected input with shape {32, 1}, but got input with shape {1, 1}

If I understand this one correctly, we're XORing numbers, not vectors, and 32-split of input is just for batching.