### PR TITLE
Fix: test images tesor shape

### DIFF
--- a/examples/cifar10.exs
+++ b/examples/cifar10.exs
@@ -55,7 +55,7 @@ final_training_state =
 
 test_images = train_images |> hd() |> Nx.slice_axis(10, 3, 0)
 
-IO.inspect test_images |> Nx.reshape({3, 28, 28}) |> Nx.to_heatmap()
+IO.inspect test_images |> Nx.mean(axes: [1], keep_axes: true) |> Nx.to_heatmap()
 
 prediction =
   model


### PR DESCRIPTION
Issue:
(ArgumentError) cannot reshape, current shape {3, 3, 32, 32} is not compatible with new shape {3, 28, 28}