### PR TITLE
Add Axon ONNX workflow to CI/CD

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,3 +20,29 @@ jobs:
         run: mix format --check-formatted
       - name: Run tests
         run: MIX_ENV=test mix do compile --warnings-as-errors, test
+  onnx_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Erlang & Elixir
+        uses: erlef/setup-elixir@v1
+        with:
+          otp-version: '24.0'
+          elixir-version: '1.12.0'
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Install ONNX
+        run: pip install numpy onnx onnxruntime
+      - name: Install mix dependencies
+        run: mix deps.get
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          version: '3.x'
+      - name: Run ONNX tests
+        with:
+          repository: elixir-nx/axon_onnx
+          ref: refs/heads/origin
+        run: MIX_ENV=test mix do compile --warnings-as-errors, test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,10 +43,12 @@ jobs:
         uses: arduino/setup-protoc@v1
         with:
           version: '3.x'
-      - name: Run ONNX tests
+      - name: Checkout AxonOnnx
+        uses: actions/checkout@v2
         with:
           repository: elixir-nx/axon_onnx
           ref: refs/heads/master
+      - name: Run ONNX tests
         run: |
           AXON_CHECKOUT=${{ steps.extract_branch.outputs.branch }} mix deps.get
           MIX_ENV=test mix do compile --warnings-as-errors, test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,11 +23,6 @@ jobs:
   onnx_check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Extract branch name
-        shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-        id: extract_branch
       - name: Install Erlang & Elixir
         uses: erlef/setup-elixir@v1
         with:
@@ -50,5 +45,5 @@ jobs:
           ref: refs/heads/master
       - name: Run ONNX tests
         run: |
-          AXON_CHECKOUT=${{ steps.extract_branch.outputs.branch }} mix deps.get
+          AXON_CHECKOUT=${{ github.head_ref }} mix deps.get
           MIX_ENV=test mix do compile --warnings-as-errors, test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,5 +45,7 @@ jobs:
           ref: refs/heads/master
       - name: Run ONNX tests
         run: |
-          AXON_CHECKOUT=${{ github.head_ref }} mix deps.get
-          MIX_ENV=test mix do compile --warnings-as-errors, test
+          AXON_CHECKOUT=${{ github.head_ref }} MIX_ENV=test \
+            mix do deps.get, \
+            compile --warnings-as-errors, \
+            test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,6 +23,10 @@ jobs:
   onnx_check:
     runs-on: ubuntu-latest
     steps:
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
       - uses: actions/checkout@v2
       - name: Install Erlang & Elixir
         uses: erlef/setup-elixir@v1
@@ -35,8 +39,6 @@ jobs:
           python-version: '3.x'
       - name: Install ONNX
         run: pip install numpy onnx onnxruntime
-      - name: Install mix dependencies
-        run: mix deps.get
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
         with:
@@ -44,5 +46,7 @@ jobs:
       - name: Run ONNX tests
         with:
           repository: elixir-nx/axon_onnx
-          ref: refs/heads/origin
-        run: MIX_ENV=test mix do compile --warnings-as-errors, test
+          ref: refs/heads/master
+        run: |
+          AXON_CHECKOUT=${{ steps.extract_branch.outputs.branch }} mix deps.get
+          MIX_ENV=test mix do compile --warnings-as-errors, test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,11 +23,11 @@ jobs:
   onnx_check:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - name: Extract branch name
         shell: bash
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         id: extract_branch
-      - uses: actions/checkout@v2
       - name: Install Erlang & Elixir
         uses: erlef/setup-elixir@v1
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,7 +44,6 @@ jobs:
         with:
           version: '3.x'
       - name: Run ONNX tests
-        uses: actions/checkout@v2
         with:
           repository: elixir-nx/axon_onnx
           ref: refs/heads/master

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,6 +44,7 @@ jobs:
         with:
           version: '3.x'
       - name: Run ONNX tests
+        uses: actions/checkout@v2
         with:
           repository: elixir-nx/axon_onnx
           ref: refs/heads/master


### PR DESCRIPTION
This checks out the Axon Onnx repository and runs the tests using the current branch as the Axon dependency. This will provide immediate feedback if an update in Axon breaks something in the AxonOnnx project.