### PR TITLE
Fixed reported epoch number in metrics logging (off-by-one)

### DIFF
--- a/lib/axon/training/callbacks.ex
+++ b/lib/axon/training/callbacks.ex
@@ -59,7 +59,7 @@ defmodule Axon.Training.Callbacks do
 
     train_state[:metrics]
     |> Enum.each(fn {k, v} ->
-      IO.puts("Epoch #{epoch} #{Atom.to_string(k)}: #{:io_lib.format("~.5f", [Nx.to_scalar(v)])}")
+      IO.puts("Epoch #{epoch + 1} #{Atom.to_string(k)}: #{:io_lib.format("~.5f", [Nx.to_scalar(v)])}")
     end)
 
     IO.puts("\n")


### PR DESCRIPTION
There was an off-by-one error in the metrics logging output; fixed!