### PR TITLE
Update broadcasting semantics in element-wise operations

### DIFF
--- a/lib/axon/shape.ex
+++ b/lib/axon/shape.ex
@@ -1363,4 +1363,36 @@ defmodule Axon.Shape do
 
     {slice_size, put_elem(shape, axis, slice_size)}
   end
+
+  @doc """
+  Checks if input shapes are broadcast compatible and returns
+  the output shape of the element-wise operation.
+
+  ## Examples
+
+      iex> Axon.Shape.element_wise([{1, 128}, {128, 128}])
+      {128, 128}
+
+      iex> Axon.Shape.element_wise([{1, 32, 1}, {28, 1, 1}, {28, 1, 14}])
+      {28, 32, 14}
+
+      iex> Axon.Shape.element_wise([{nil, 32}, {nil, 32}])
+      {nil, 32}
+
+  ### Error cases
+
+      iex> Axon.Shape.element_wise([{128, 1}, {nil, 32}])
+      ** (ArgumentError) cannot broadcast tensor of dimensions {nil, 32} to {128, 1}
+
+  """
+  def element_wise([first | rest]) do
+    Enum.reduce(rest, first, fn shape, target_shape ->
+      lnames = List.duplicate(nil, tuple_size(shape))
+      rnames = List.duplicate(nil, tuple_size(target_shape))
+      # TODO(seanmor5): If this fails, I wonder if it's better to rescue
+      # and re-raise with Axon specific messages?
+      {out_shape, _} = Nx.Shape.binary_broadcast(shape, lnames, target_shape, rnames)
+      out_shape
+    end)
+  end
 end

--- a/test/axon_test.exs
+++ b/test/axon_test.exs
@@ -681,7 +681,7 @@ defmodule AxonTest do
 
     test "raises on bad shapes" do
       for op <- @element_wise_layers do
-        assert_raise ArgumentError, ~r/all input shapes must match/, fn ->
+        assert_raise ArgumentError, ~r/cannot broadcast tensor/, fn ->
           apply(Axon, op, [[Axon.input({nil, 32}), Axon.input({nil, 64})]])
         end
       end

--- a/test/compiler_test.exs
+++ b/test/compiler_test.exs
@@ -3302,6 +3302,18 @@ defmodule CompilerTest do
         assert Nx.type(predict_fn.(%{}, input)) == {:bf, 16}
       end
     end
+
+    test "computes forward pass with broadcasting" do
+      inp1 = Nx.random_uniform({1, 1})
+      inp2 = Nx.random_uniform({1, 2})
+
+      for op <- @binary_layers do
+        model = apply(Axon, op, [Axon.input({nil, 1}), Axon.input({nil, 2})])
+
+        assert {_, predict_fn} = Axon.compile(model)
+        assert predict_fn.(%{}, {inp1, inp2}) == apply(Nx, op, [inp1, inp2])
+      end
+    end
   end
 
   describe "concatenate" do


### PR DESCRIPTION
This is to match Nx and to make it easy to implement these layers in ONNX because ONNX has different broadcasting semantics than ours.