### PR TITLE
Fix: typo

### DIFF
--- a/lib/axon/losses.ex
+++ b/lib/axon/losses.ex
@@ -75,8 +75,8 @@ defmodule Axon.Losses do
 
   ## Argument Shapes
 
-    * `y_true` - $\(d_0, d_1, ..., d_n\)$
-    * `y_pred` - $\(d_0, d_1, ..., d_n\)$
+    * `y_true` - $(d_0, d_1, ..., d_n)$
+    * `y_pred` - $(d_0, d_1, ..., d_n)$
 
   ## Options
 
@@ -242,8 +242,8 @@ defmodule Axon.Losses do
 
   ## Argument Shapes
 
-    * `y_true` - $\(d_0, d_1, ..., d_n\)$
-    * `y_pred` - $\(d_0, d_1, ..., d_n\)$
+    * `y_true` - $(d_0, d_1, ..., d_n)$
+    * `y_pred` - $(d_0, d_1, ..., d_n)$
 
   ## Options
 
@@ -458,8 +458,8 @@ defmodule Axon.Losses do
 
   ## Argument Shapes
 
-    * `y_true` - $\(d_0, d_1, ..., d_n\)$
-    * `y_pred` - $\(d_0, d_1, ..., d_n\)$
+    * `y_true` - $(d_0, d_1, ..., d_n)$
+    * `y_pred` - $(d_0, d_1, ..., d_n)$
 
   ## Options
 
@@ -526,8 +526,8 @@ defmodule Axon.Losses do
 
   ## Argument Shapes
 
-    * `y_true` - $\(d_0, d_1, ..., d_n\)$
-    * `y_pred` - $\(d_0, d_1, ..., d_n\)$
+    * `y_true` - $(d_0, d_1, ..., d_n)$
+    * `y_pred` - $(d_0, d_1, ..., d_n)$
 
   ## Examples
 
@@ -585,8 +585,8 @@ defmodule Axon.Losses do
 
   ## Argument Shapes
 
-    * `y_true` - $\(d_0, d_1, ..., d_n\)$
-    * `y_pred` - $\(d_0, d_1, ..., d_n\)$
+    * `y_true` - $(d_0, d_1, ..., d_n)$
+    * `y_pred` - $(d_0, d_1, ..., d_n)$
 
   ## Options
 
@@ -652,8 +652,8 @@ defmodule Axon.Losses do
 
   ## Argument Shapes
 
-    * `y_true` - $\(d_0, d_1, ..., d_n\)$
-    * `y_pred` - $\(d_0, d_1, ..., d_n\)$
+    * `y_true` - $(d_0, d_1, ..., d_n)$
+    * `y_pred` - $(d_0, d_1, ..., d_n)$
 
   ## Options
 
@@ -841,8 +841,8 @@ defmodule Axon.Losses do
 
   ## Argument Shapes
 
-    * `y_true` - $\(d_0, d_1, ..., d_n\)$
-    * `y_pred` - $\(d_0, d_1, ..., d_n\)$
+    * `y_true` - $(d_0, d_1, ..., d_n)$
+    * `y_pred` - $(d_0, d_1, ..., d_n)$
 
   ## Options
 
@@ -903,8 +903,8 @@ defmodule Axon.Losses do
 
   ## Argument Shapes
 
-    * `y_true` - $\(d_0, d_1, ..., d_n\)$
-    * `y_pred` - $\(d_0, d_1, ..., d_n\)$
+    * `y_true` - $(d_0, d_1, ..., d_n)$
+    * `y_pred` - $(d_0, d_1, ..., d_n)$
 
   ## Options
 
@@ -965,8 +965,8 @@ defmodule Axon.Losses do
 
   ## Argument Shapes
 
-    * `y_true` - $\(d_0, d_1, ..., d_n\)$
-    * `y_pred` - $\(d_0, d_1, ..., d_n\)$
+    * `y_true` - $(d_0, d_1, ..., d_n)$
+    * `y_pred` - $(d_0, d_1, ..., d_n)$
 
   ## Options
 


### PR DESCRIPTION
"KaTeX parse error: Can't use function '\\(' in math mode..."