### PR TITLE
Fixed max_iteration parameter updates in the loop module

### DIFF
--- a/lib/axon/loop.ex
+++ b/lib/axon/loop.ex
@@ -823,8 +823,6 @@ defmodule Axon.Loop do
                           {:halt, {:halted, final_metrics_map, state}}
 
                         {:continue, state} ->
-                          max_iter = state.iteration
-
                           zero_metrics =
                             Map.new(metric_fns, fn {k, _} ->
                               {k, 0}
@@ -840,7 +838,7 @@ defmodule Axon.Loop do
                               | epoch: epoch + 1,
                                 metrics: zero_metrics,
                                 iteration: 0,
-                                max_iteration: max_iter
+                                max_iteration: state.max_iteration
                             }}}
                       end
                   end


### PR DESCRIPTION
In exisiting implementation value `state.max_iteration` is different depending on the epoch number. Precisely, it is equal to `initial_max_iteration + epoch_index` because after each epoch variable `state.iteration` accepts value of the corresponding `state.max_iteration` incremented by 1. Probably there is a problem in some internal loop over training batches, but solution proposed in this pull request seems simple and effective.