### PR TITLE
Allow user-defined values in the `step_state` to propagate across iterations

### DIFF
--- a/lib/axon/loop.ex
+++ b/lib/axon/loop.ex
@@ -823,8 +823,6 @@ defmodule Axon.Loop do
                           {:halt, {:halted, final_metrics_map, state}}
 
                         {:continue, state} ->
-                          max_iter = state.iteration
-
                           zero_metrics =
                             Map.new(metric_fns, fn {k, _} ->
                               {k, 0}
@@ -840,7 +838,7 @@ defmodule Axon.Loop do
                               | epoch: epoch + 1,
                                 metrics: zero_metrics,
                                 iteration: 0,
-                                max_iteration: max_iter
+                                max_iteration: state.max_iteration
                             }}}
                       end
                   end

--- a/lib/axon/loop.ex
+++ b/lib/axon/loop.ex
@@ -345,13 +345,13 @@ defmodule Axon.Loop do
         update_optimizer_fn.(gradients, optimizer_state, model_state)
 
       %{
-        state |
-        i: Nx.add(i, 1),
-        y_true: tar,
-        y_pred: preds,
-        loss: new_loss,
-        model_state: Axon.Updates.apply_updates(model_state, updates),
-        optimizer_state: new_optimizer_state
+        state
+        | i: Nx.add(i, 1),
+          y_true: tar,
+          y_pred: preds,
+          loss: new_loss,
+          model_state: Axon.Updates.apply_updates(model_state, updates),
+          optimizer_state: new_optimizer_state
       }
     end
 

--- a/lib/axon/loop.ex
+++ b/lib/axon/loop.ex
@@ -345,6 +345,7 @@ defmodule Axon.Loop do
         update_optimizer_fn.(gradients, optimizer_state, model_state)
 
       %{
+        state |
         i: Nx.add(i, 1),
         y_true: tar,
         y_pred: preds,

--- a/test/loop_test.exs
+++ b/test/loop_test.exs
@@ -261,8 +261,6 @@ defmodule Axon.LoopTest do
     end
 
     test "propagates user-defined numerical data inside step_state" do
-      Nx.tensor(0)
-
       Axon.input({nil, 1})
       |> Axon.dense(1)
       |> Loop.trainer(:binary_cross_entropy, :sgd)
@@ -297,8 +295,6 @@ defmodule Axon.LoopTest do
     end
 
     test "propagates user-defined numerical data inside step_state when it is nested into a tuple" do
-      Nx.tensor(0)
-
       Axon.input({nil, 1})
       |> Axon.dense(1)
       |> Loop.trainer(:binary_cross_entropy, :sgd)

--- a/test/loop_test.exs
+++ b/test/loop_test.exs
@@ -262,26 +262,29 @@ defmodule Axon.LoopTest do
 
     test "propagates user-defined numerical data inside step_state" do
       Nx.tensor(0)
+
       Axon.input({nil, 1})
       |> Axon.dense(1)
       |> Loop.trainer(:binary_cross_entropy, :sgd)
       |> Loop.handle(
         :epoch_completed,
-        fn(%State{step_state: pstate} = state) ->
+        fn %State{step_state: pstate} = state ->
           {
-            :continue, %State{
+            :continue,
+            %State{
               state
-              | step_state: case pstate[:counter] do
-                nil -> Map.put(pstate, :counter, 0)
-                counter -> %{pstate | counter: Nx.to_scalar(counter) + 1}
-              end
+              | step_state:
+                  case pstate[:counter] do
+                    nil -> Map.put(pstate, :counter, 0)
+                    counter -> %{pstate | counter: Nx.to_scalar(counter) + 1}
+                  end
             }
           }
         end
       )
       |> Loop.handle(
         :completed,
-        fn(%State{step_state: %{counter: counter}} = state) ->
+        fn %State{step_state: %{counter: counter}} = state ->
           assert 4 = counter
 
           {:continue, state}
@@ -295,28 +298,33 @@ defmodule Axon.LoopTest do
 
     test "propagates user-defined numerical data inside step_state when it is nested into a tuple" do
       Nx.tensor(0)
+
       Axon.input({nil, 1})
       |> Axon.dense(1)
       |> Loop.trainer(:binary_cross_entropy, :sgd)
       |> Loop.handle(
         :epoch_completed,
-        fn(%State{step_state: pstate} = state) ->
+        fn %State{step_state: pstate} = state ->
           {
-            :continue, %State{
+            :continue,
+            %State{
               state
-              | step_state: case pstate[:counter] do
-                nil -> Map.put(pstate, :counter, {{0}, 0})
-                {{counter}, _} -> 
-                  next_counter_value = Nx.to_scalar(counter) + 1
-                  %{pstate | counter: {{next_counter_value}, next_counter_value}}
-              end
+              | step_state:
+                  case pstate[:counter] do
+                    nil ->
+                      Map.put(pstate, :counter, {{0}, 0})
+
+                    {{counter}, _} ->
+                      next_counter_value = Nx.to_scalar(counter) + 1
+                      %{pstate | counter: {{next_counter_value}, next_counter_value}}
+                  end
             }
           }
         end
       )
       |> Loop.handle(
         :completed,
-        fn(%State{step_state: %{counter: counter}} = state) ->
+        fn %State{step_state: %{counter: counter}} = state ->
           assert {{4}, 4} = counter
 
           {:continue, state}


### PR DESCRIPTION
This change allows to take values which remain unchanged in comparison to the result of the previous iteration and pass them to the next iteration. It can be useful in cases, when custom loop handlers keep some data in training state (for instance, minimum or maximum loss).