### PR TITLE
Update Scidata version and callbacks examples

### DIFF
--- a/examples/generative/fashionmnist_autoencoder.exs
+++ b/examples/generative/fashionmnist_autoencoder.exs
@@ -2,7 +2,7 @@ Mix.install([
   {:axon, "~> 0.1.0-dev", github: "elixir-nx/axon"},
   {:exla, github: "elixir-nx/exla", sparse: "exla"},
   {:nx, "~> 0.1.0-dev", github: "elixir-nx/nx", sparse: "nx", override: true},
-  {:scidata, "~> 0.1.1"},
+  {:scidata, "~> 0.1.3"},
 ])
 
 # Configure default platform with accelerator precedence as tpu > cuda > rocm > host
@@ -48,7 +48,9 @@ defmodule Fashionmist do
   end
 
   def run do
-    {train_images, _} = Scidata.FashionMNIST.download(transform_images: &transform_images/1)
+    {images, _} = Scidata.FashionMNIST.download()
+
+    train_images = transform_images(images)
 
     model = Autoencoder.build_model({nil, 1, 28, 28}, 64) |> IO.inspect
 

--- a/examples/generative/mnist_gan.exs
+++ b/examples/generative/mnist_gan.exs
@@ -2,7 +2,7 @@ Mix.install([
   {:axon, github: "elixir-nx/axon"},
   {:exla, github: "elixir-nx/nx", sparse: "exla"},
   {:nx, github: "elixir-nx/nx", sparse: "nx", override: true},
-  {:scidata, "~> 0.1.0"}
+  {:scidata, "~> 0.1.3"}
 ])
 
 EXLA.set_preferred_defn_options([:tpu, :cuda, :rocm, :host])
@@ -162,14 +162,15 @@ defmodule MNISTGAN do
   end
 
   def run() do
-    {images, _} = Scidata.MNIST.download(transform_images: &transform_images/1)
+    {train_images, _} = Scidata.MNIST.download()
+    images = transform_images(train_images)
 
     generator = build_generator(100)
     discriminator = build_discriminator({nil, 1, 28, 28})
 
     discriminator
     |> train_loop(generator)
-    |> Axon.Loop.log(&log_iteration/1, :stdio, every: 50)
+    |> Axon.Loop.log(:iteration_completed, &log_iteration/1, :stdio, every: 50)
     |> Axon.Loop.handle(:epoch_completed, &view_generated_images(generator, 3, &1))
     |> Axon.Loop.run(images, epochs: 10, compiler: EXLA)
   end

--- a/examples/generative/mnist_gan.exs
+++ b/examples/generative/mnist_gan.exs
@@ -162,8 +162,8 @@ defmodule MNISTGAN do
   end
 
   def run() do
-    {train_images, _} = Scidata.MNIST.download()
-    images = transform_images(train_images)
+    {images, _} = Scidata.MNIST.download()
+    train_images = transform_images(images)
 
     generator = build_generator(100)
     discriminator = build_discriminator({nil, 1, 28, 28})
@@ -172,7 +172,7 @@ defmodule MNISTGAN do
     |> train_loop(generator)
     |> Axon.Loop.log(:iteration_completed, &log_iteration/1, :stdio, every: 50)
     |> Axon.Loop.handle(:epoch_completed, &view_generated_images(generator, 3, &1))
-    |> Axon.Loop.run(images, epochs: 10, compiler: EXLA)
+    |> Axon.Loop.run(train_images, epochs: 10, compiler: EXLA)
   end
 end
 

--- a/examples/structured/credit_card_fraud.exs
+++ b/examples/structured/credit_card_fraud.exs
@@ -122,7 +122,6 @@ defmodule CreditCardFraud do
     model
     |> Axon.Loop.trainer(loss, optimizer)
     |> metrics()
-    |> Axon.Loop.handle(:iteration_completed, &log_metrics(&1, :train), every: 10)
     |> Axon.Loop.run(train_data, epochs: 30, compiler: EXLA)
   end
 

--- a/examples/vision/cifar10.exs
+++ b/examples/vision/cifar10.exs
@@ -2,7 +2,7 @@ Mix.install([
   {:axon, "~> 0.1.0-dev", github: "elixir-nx/axon"},
   {:exla, github: "elixir-nx/exla", sparse: "exla"},
   {:nx, "~> 0.1.0-dev", github: "elixir-nx/nx", sparse: "nx", override: true},
-  {:scidata, "~> 0.1.1"}
+  {:scidata, "~> 0.1.3"}
 ])
 
 # Configure default platform with accelerator precedence as tpu > cuda > rocm > host
@@ -10,7 +10,6 @@ EXLA.set_preferred_defn_options([:tpu, :cuda, :rocm, :host])
 
 defmodule Cifar do
   require Axon
-  alias Axon.Loop.State
 
   defp transform_images({bin, type, shape}) do
     bin
@@ -59,14 +58,10 @@ defmodule Cifar do
   end
 
   def run do
-    {images, labels} =
-      Scidata.CIFAR10.download(
-        transform_images: &transform_images/1,
-        transform_labels: &transform_labels/1
-      )
+    {images, labels} = Scidata.CIFAR10.download()
 
-    {train_images, test_images} = images
-    {train_labels, test_labels} = labels
+    {train_images, test_images} = transform_images(images)
+    {train_labels, test_labels} = transform_labels(labels)
 
     model = build_model({nil, 3, 32, 32}) |> IO.inspect()
 

--- a/examples/vision/cnn_image_denoising.exs
+++ b/examples/vision/cnn_image_denoising.exs
@@ -8,17 +8,17 @@ Mix.install([
 EXLA.set_preferred_defn_options([:tpu, :cuda, :rocm, :host])
 
 defmodule MnistDenoising do
+  require Axon
   import Nx.Defn
-  alias Axon.Loop.State
 
   @noise_factor 0.4
   @batch_size 32
   @epochs 25
 
   def run do
-    {{train_images, test_images}, _} =
-      Scidata.MNIST.download(transform_images: &transform_images/1)
+    {images, _} = Scidata.MNIST.download()
 
+    {train_images, test_images} = transform_images(images)
     noisy_train_images = Stream.map(train_images, &add_noise/1)
     noisy_test_images = Stream.map(test_images, &add_noise/1)
     train_data = Stream.zip(train_images, noisy_train_images)

--- a/examples/vision/mnist.exs
+++ b/examples/vision/mnist.exs
@@ -2,7 +2,7 @@ Mix.install([
   {:axon, "~> 0.1.0-dev", github: "elixir-nx/axon"},
   {:exla, "~> 0.1.0-dev", github: "elixir-nx/nx", sparse: "exla"},
   {:nx, "~> 0.1.0-dev", github: "elixir-nx/nx", sparse: "nx", override: true},
-  {:scidata, "~> 0.1.1"}
+  {:scidata, "~> 0.1.3"}
 ])
 
 # Configure default platform with accelerator precedence as tpu > cuda > rocm > host
@@ -55,8 +55,7 @@ defmodule Mnist do
   end
 
   def run do
-    {images, labels} =
-      Scidata.MNIST.download()
+    {images, labels} = Scidata.MNIST.download()
 
     {train_images, test_images} = transform_images(images)
     {train_labels, test_labels} = transform_labels(labels)


### PR DESCRIPTION
Scidata `download/0` API [has changed slightly](https://github.com/elixir-nx/scidata/pull/18) and no longer accepts transform callbacks, so we can apply transformations to inputs and outputs after downloading.