### PR TITLE
Add validation handler

### DIFF
--- a/lib/axon/loop.ex
+++ b/lib/axon/loop.ex
@@ -574,6 +574,7 @@ defmodule Axon.Loop do
   def evaluator(model, model_state) do
     {init_fn, step_fn} = eval_step(model, model_state)
     output_transform = fn state -> state.metrics end
+
     loop(step_fn, init_fn, output_transform)
     |> log(:iteration_completed, &supervised_log_message_fn(&1, false), :stdio)
   end
@@ -1304,6 +1305,7 @@ defmodule Axon.Loop do
             output
             |> transform_fn.()
             |> then(&apply(metric_fn, &1))
+
             # |> List.wrap()
           end
 

--- a/test/loop_test.exs
+++ b/test/loop_test.exs
@@ -219,7 +219,7 @@ defmodule Axon.LoopTest do
         |> Loop.loop()
         |> Loop.metric(:accuracy)
 
-      assert %Loop{metrics: %{"accuracy" => avg_acc_fun}} = loop
+      assert %Loop{metrics: %{"accuracy" => {avg_acc_fun, _}}} = loop
 
       output = %{foo: 1, y_true: Nx.tensor([1, 0, 1]), y_pred: Nx.tensor([0.8, 0.2, 0.8])}
       cur_avg_acc = 0.5
@@ -236,7 +236,7 @@ defmodule Axon.LoopTest do
         |> Loop.loop()
         |> Loop.metric(:true_positives, "tp", :running_sum, &Tuple.to_list/1)
 
-      assert %Loop{metrics: %{"tp" => sum_tp_fun}} = loop
+      assert %Loop{metrics: %{"tp" => {sum_tp_fun, _}}} = loop
 
       output = {Nx.tensor([1, 0, 1]), Nx.tensor([0, 1, 1])}
       cur_sum = 25


### PR DESCRIPTION
WIP to add a validation API to Axon loops. Validation sets are used as a "holdout" set to monitor and prevent overfitting. There are a few unresolved issues as of now:

1) How do we or do we even need to forward the outer loops compilation options to this inner loop?
2) Should we forward the model as well so it does not need to be explicitly specified? This would require adding some sort of `metadata` field to loop state.
3) How do we initialize state such that we are not changing the form of it and recompiling our train step after the first epoch because state now includes additional fields? I think this would probably go somewhat along with 1 and some sort of metadata field.

I'm also exploring different forms of this function to offer maximum control over the process. Overall though I think the base of how this works (e.g. computing the same metrics present in the loop and forwarding those for use in later handlers) is the way to go and I think it will make it easy to implement many other handlers.