### PR TITLE
Fix: Nx.to_scalar in examples

### DIFF
--- a/examples/generative/mnist_gan.exs
+++ b/examples/generative/mnist_gan.exs
@@ -142,10 +142,10 @@ defmodule MNISTGAN do
   defp log_iteration(state) do
     %State{epoch: epoch, iteration: iter, step_state: pstate} = state
 
-    g_loss = "G: #{:io_lib.format('~.5f', [Nx.to_scalar(pstate[:generator][:loss])])}"
-    d_loss = "D: #{:io_lib.format('~.5f', [Nx.to_scalar(pstate[:discriminator][:loss])])}"
+    g_loss = "G: #{:io_lib.format('~.5f', [Nx.to_number(pstate[:generator][:loss])])}"
+    d_loss = "D: #{:io_lib.format('~.5f', [Nx.to_number(pstate[:discriminator][:loss])])}"
 
-    "\rEpoch: #{Nx.to_scalar(epoch)}, batch: #{Nx.to_scalar(iter)} #{g_loss} #{d_loss}"
+    "\rEpoch: #{Nx.to_number(epoch)}, batch: #{Nx.to_number(iter)} #{g_loss} #{d_loss}"
   end
 
   defp view_generated_images(model, batch_size, state) do

--- a/examples/structured/credit_card_fraud.exs
+++ b/examples/structured/credit_card_fraud.exs
@@ -103,7 +103,7 @@ defmodule CreditCardFraud do
   end
 
   defp metrics(loop) do
-  	loop
+    loop
     |> Axon.Loop.metric(:true_positives, "tp", :running_sum)
     |> Axon.Loop.metric(:true_negatives, "tn", :running_sum)
     |> Axon.Loop.metric(:false_positives, "fp", :running_sum)

--- a/examples/structured/credit_card_fraud.exs
+++ b/examples/structured/credit_card_fraud.exs
@@ -83,10 +83,10 @@ defmodule CreditCardFraud do
   defp summarize(%State{metrics: metrics} = state) do
     IO.write("\n\n")
 
-    legit_transactions_declined = Nx.to_scalar(metrics["fp"])
-    legit_transactions_accepted = Nx.to_scalar(metrics["tn"])
-    fraud_transactions_accepted = Nx.to_scalar(metrics["fn"])
-    fraud_transactions_declined = Nx.to_scalar(metrics["tp"])
+    legit_transactions_declined = Nx.to_number(metrics["fp"])
+    legit_transactions_accepted = Nx.to_number(metrics["tn"])
+    fraud_transactions_accepted = Nx.to_number(metrics["fn"])
+    fraud_transactions_declined = Nx.to_number(metrics["tp"])
     total_fraud = fraud_transactions_declined + fraud_transactions_accepted
     total_legit = legit_transactions_declined + legit_transactions_accepted
 
@@ -130,7 +130,7 @@ defmodule CreditCardFraud do
     {train_inputs, train_targets} = train
     {test_inputs, test_targets} = test
 
-    fraud = Nx.sum(train_targets) |> Nx.to_scalar()
+    fraud = Nx.sum(train_targets) |> Nx.to_number()
     legit = Nx.size(train_targets) - fraud
 
     batched_train_inputs = Nx.to_batched_list(train_inputs, 2048)

--- a/examples/xor.exs
+++ b/examples/xor.exs
@@ -32,7 +32,7 @@ defmodule XOR do
       case mode do
         :train ->
           %{loss: loss} = pstate
-          "Loss: #{:io_lib.format('~.5f', [Nx.to_scalar(loss)])}"
+          "Loss: #{:io_lib.format('~.5f', [Nx.to_number(loss)])}"
 
         :test ->
           ""
@@ -40,10 +40,10 @@ defmodule XOR do
 
     metrics =
       metrics
-      |> Enum.map(fn {k, v} -> "#{k}: #{:io_lib.format('~.5f', [Nx.to_scalar(v)])}" end)
+      |> Enum.map(fn {k, v} -> "#{k}: #{:io_lib.format('~.5f', [Nx.to_number(v)])}" end)
       |> Enum.join(" ")
 
-    IO.write("\rEpoch: #{Nx.to_scalar(epoch)}, Batch: #{Nx.to_scalar(iter)}, #{loss} #{metrics}")
+    IO.write("\rEpoch: #{Nx.to_number(epoch)}, Batch: #{Nx.to_number(iter)}, #{loss} #{metrics}")
 
     {:continue, state}
   end

--- a/examples/xor.exs
+++ b/examples/xor.exs
@@ -24,34 +24,9 @@ defmodule XOR do
     {{x1, x2}, y}
   end
 
-  defp log_metrics(
-         %State{epoch: epoch, iteration: iter, metrics: metrics, step_state: pstate} = state,
-         mode
-       ) do
-    loss =
-      case mode do
-        :train ->
-          %{loss: loss} = pstate
-          "Loss: #{:io_lib.format('~.5f', [Nx.to_number(loss)])}"
-
-        :test ->
-          ""
-      end
-
-    metrics =
-      metrics
-      |> Enum.map(fn {k, v} -> "#{k}: #{:io_lib.format('~.5f', [Nx.to_number(v)])}" end)
-      |> Enum.join(" ")
-
-    IO.write("\rEpoch: #{Nx.to_number(epoch)}, Batch: #{Nx.to_number(iter)}, #{loss} #{metrics}")
-
-    {:continue, state}
-  end
-
   defp train_model(model, data, epochs) do
     model
     |> Axon.Loop.trainer(:binary_cross_entropy, :sgd)
-    |> Axon.Loop.handle(:iteration_completed, &log_metrics(&1, :train), every: 50)
     |> Axon.Loop.run(data, epochs: epochs, iterations: 1000)
   end
 

--- a/examples/xor.exs
+++ b/examples/xor.exs
@@ -6,7 +6,6 @@ Mix.install([
 
 defmodule XOR do
   require Axon
-  alias Axon.Loop.State
 
   defp build_model(input_shape1, input_shape2) do
     inp1 = Axon.input(input_shape1)

--- a/examples/xor.exs
+++ b/examples/xor.exs
@@ -25,7 +25,7 @@ defmodule XOR do
   end
 
   defp log_metrics(
-         %State{epoch: epoch, iteration: iter, metrics: metrics, process_state: pstate} = state,
+         %State{epoch: epoch, iteration: iter, metrics: metrics, step_state: pstate} = state,
          mode
        ) do
     loss =


### PR DESCRIPTION
`Nx.to_scalar/1` has been renamed to `Nx.to_number/1`