### PR TITLE
log function improved

### DIFF
--- a/lib/axon/loop.ex
+++ b/lib/axon/loop.ex
@@ -531,12 +531,20 @@ defmodule Axon.Loop do
     end
   end
 
+  defp format_metric({name, val}) do
+    {type, _} = val.type
+    case type do
+      :s -> "#{name}: #{:io_lib.format('~.B', [Nx.to_number(val)])}"
+      :f -> "#{name}: #{:io_lib.format('~.7f', [Nx.to_number(val)])}"
+      _ -> "Unsupported type of metric"
+    end
+  end
+
   defp supervised_log_message_fn(state, log_epochs \\ true) do
     %State{metrics: metrics, epoch: epoch, iteration: iter} = state
-
     metrics =
       metrics
-      |> Enum.map(fn {k, v} -> "#{k}: #{:io_lib.format('~.5f', [Nx.to_number(v)])}" end)
+      |> Enum.map(&format_metric/1)
       |> Enum.join(" ")
 
     if log_epochs do
@@ -545,6 +553,7 @@ defmodule Axon.Loop do
       "\rBatch: #{Nx.to_number(iter)}, #{metrics}"
     end
   end
+
 
   @doc """
   Creates a supervised evaluator from a model and model state.

--- a/lib/axon/loop.ex
+++ b/lib/axon/loop.ex
@@ -534,7 +534,7 @@ defmodule Axon.Loop do
   defp format_metric({name, val}) do
     {type, _} = val.type
     case type do
-      :s, :u -> "#{name}: #{:io_lib.format('~.B', [Nx.to_number(val)])}"
+      t when t in [:s, :u] -> "#{name}: #{:io_lib.format('~.B', [Nx.to_number(val)])}"
       :f -> "#{name}: #{:io_lib.format('~.7f', [Nx.to_number(val)])}"
       :bf -> "#{name}: #{:io_lib.format('~.3f', [Nx.to_number(val)])}"
       _ -> "Unsupported type of metric"

--- a/lib/axon/loop.ex
+++ b/lib/axon/loop.ex
@@ -534,8 +534,9 @@ defmodule Axon.Loop do
   defp format_metric({name, val}) do
     {type, _} = val.type
     case type do
-      :s -> "#{name}: #{:io_lib.format('~.B', [Nx.to_number(val)])}"
+      :s, :u -> "#{name}: #{:io_lib.format('~.B', [Nx.to_number(val)])}"
       :f -> "#{name}: #{:io_lib.format('~.7f', [Nx.to_number(val)])}"
+      :bf -> "#{name}: #{:io_lib.format('~.3f', [Nx.to_number(val)])}"
       _ -> "Unsupported type of metric"
     end
   end


### PR DESCRIPTION
There is a problem with :io_lib.format in function supervised_log_message_fn/2. If a metric passed to the function is an integer type (like a number of true positive predictions), then :io_lib.format with options '~.5f' won't work correctly. To fix this I propose format_metric/1 which will handle this issue. I found the problem when I ran "credit_card_fraud.exs".