### PR TITLE
Improve inspect

### DIFF
--- a/lib/axon/compiler.ex
+++ b/lib/axon/compiler.ex
@@ -606,7 +606,7 @@ defmodule Axon.Compiler do
        ) do
     {res, {cache, op_counts}} =
       to_predict_fun(parent, cache_and_counts, input_map, params, inputs, mode)
-    
+
     name = name_fn.(:dense, op_counts)
 
     op_counts = Map.update(op_counts, :dense, 1, fn x -> x + 1 end)

--- a/lib/axon/mixed_precision/policy.ex
+++ b/lib/axon/mixed_precision/policy.ex
@@ -3,4 +3,32 @@ defmodule Axon.MixedPrecision.Policy do
 
   # Represents a mixed precision policy for a single layer
   defstruct params: {:f, 32}, compute: {:f, 32}, output: {:f, 32}
+
+  defimpl Inspect do
+    import Inspect.Algebra
+
+    def inspect(policy, opts) do
+      inner =
+        concat([
+          line(),
+          color("params: ", :atom, opts),
+          "#{inspect(policy.params)},",
+          line(),
+          color("compute: ", :atom, opts),
+          "#{inspect(policy.compute)},",
+          line(),
+          color("output: ", :atom, opts),
+          "#{inspect(policy.output)}"
+        ])
+
+      force_unfit(
+        concat([
+          color("#Axon.MixedPrecision.Policy<", :map, opts),
+          nest(inner, 2),
+          line(),
+          color(">", :map, opts)
+        ])
+      )
+    end
+  end
 end

--- a/lib/axon/mixed_precision/policy.ex
+++ b/lib/axon/mixed_precision/policy.ex
@@ -7,26 +7,12 @@ defmodule Axon.MixedPrecision.Policy do
   defimpl Inspect do
     import Inspect.Algebra
 
-    def inspect(policy, opts) do
-      inner =
-        concat([
-          line(),
-          color("params: ", :atom, opts),
-          "#{inspect(policy.params)},",
-          line(),
-          color("compute: ", :atom, opts),
-          "#{inspect(policy.compute)},",
-          line(),
-          color("output: ", :atom, opts),
-          "#{inspect(policy.output)}"
-        ])
-
+    def inspect(policy, _opts) do
       force_unfit(
         concat([
-          color("#Axon.MixedPrecision.Policy<", :map, opts),
-          nest(inner, 2),
-          line(),
-          color(">", :map, opts)
+          "p=#{Nx.Type.to_string(policy.params)} ",
+          "c=#{Nx.Type.to_string(policy.compute)} ",
+          "o=#{Nx.Type.to_string(policy.output)}"
         ])
       )
     end

--- a/test/axon_test.exs
+++ b/test/axon_test.exs
@@ -727,32 +727,16 @@ defmodule AxonTest do
         |> Axon.softmax(name: "softmax")
 
       assert inspect(model) == """
-             --------------------------------------------------------------------------------------------------------------
-                                                                 Model
-             ==============================================================================================================
-              Layer                             Shape        Policy                         Parameters   Parameters Memory
-             ==============================================================================================================
-              input ( input )                   {nil, 784}   #Axon.MixedPrecision.Policy<   0            0 bytes           
-                                                               params: {:f, 32},                                           
-                                                               compute: {:f, 32},                                          
-                                                               output: {:f, 32}                                            
-                                                             >
-              dense1 ( dense[ "input" ] )       {nil, 128}   #Axon.MixedPrecision.Policy<   100480       401920 bytes      
-                                                               params: {:f, 32},                                           
-                                                               compute: {:f, 32},                                          
-                                                               output: {:f, 32}                                            
-                                                             >
-              dense2 ( dense[ "dense1" ] )      {nil, 10}    #Axon.MixedPrecision.Policy<   1290         5160 bytes        
-                                                               params: {:f, 32},                                           
-                                                               compute: {:f, 32},                                          
-                                                               output: {:f, 32}                                            
-                                                             >
-              softmax ( softmax[ "dense2" ] )   {nil, 10}    #Axon.MixedPrecision.Policy<   0            0 bytes           
-                                                               params: {:f, 32},                                           
-                                                               compute: {:f, 32},                                          
-                                                               output: {:f, 32}                                            
-                                                             >
-             --------------------------------------------------------------------------------------------------------------
+             ---------------------------------------------------------------------------------------------------
+                                                            Model
+             ===================================================================================================
+              Layer                             Shape        Policy              Parameters   Parameters Memory
+             ===================================================================================================
+              input ( input )                   {nil, 784}   p=f32 c=f32 o=f32   0            0 bytes
+              dense1 ( dense[ "input" ] )       {nil, 128}   p=f32 c=f32 o=f32   100480       401920 bytes
+              dense2 ( dense[ "dense1" ] )      {nil, 10}    p=f32 c=f32 o=f32   1290         5160 bytes
+              softmax ( softmax[ "dense2" ] )   {nil, 10}    p=f32 c=f32 o=f32   0            0 bytes
+             ---------------------------------------------------------------------------------------------------
              """
     end
 
@@ -771,42 +755,18 @@ defmodule AxonTest do
         |> Axon.softmax(name: "softmax")
 
       assert inspect(model) == """
-             -------------------------------------------------------------------------------------------------------------------------------
-                                                                          Model
-             ===============================================================================================================================
-              Layer                                              Shape        Policy                         Parameters   Parameters Memory
-             ===============================================================================================================================
-              input ( input )                                    {nil, 784}   #Axon.MixedPrecision.Policy<   0            0 bytes           
-                                                                                params: {:f, 32},                                           
-                                                                                compute: {:f, 32},                                          
-                                                                                output: {:f, 32}                                            
-                                                                              >
-              dense ( dense[ "input" ] )                         {nil, 128}   #Axon.MixedPrecision.Policy<   100480       401920 bytes      
-                                                                                params: {:f, 32},                                           
-                                                                                compute: {:f, 32},                                          
-                                                                                output: {:f, 32}                                            
-                                                                              >
-              residual_dense ( dense[ "dense" ] )                {nil, 128}   #Axon.MixedPrecision.Policy<   16512        66048 bytes       
-                                                                                params: {:f, 32},                                           
-                                                                                compute: {:f, 32},                                          
-                                                                                output: {:f, 32}                                            
-                                                                              >
-              residual_add ( add ["residual_dense", "dense"] )   {nil, 128}   #Axon.MixedPrecision.Policy<   0            0 bytes           
-                                                                                params: {:f, 32},                                           
-                                                                                compute: {:f, 32},                                          
-                                                                                output: {:f, 32}                                            
-                                                                              >
-              dense2 ( dense[ "residual_add" ] )                 {nil, 10}    #Axon.MixedPrecision.Policy<   1290         5160 bytes        
-                                                                                params: {:f, 32},                                           
-                                                                                compute: {:f, 32},                                          
-                                                                                output: {:f, 32}                                            
-                                                                              >
-              softmax ( softmax[ "dense2" ] )                    {nil, 10}    #Axon.MixedPrecision.Policy<   0            0 bytes           
-                                                                                params: {:f, 32},                                           
-                                                                                compute: {:f, 32},                                          
-                                                                                output: {:f, 32}                                            
-                                                                              >
-             -------------------------------------------------------------------------------------------------------------------------------
+             --------------------------------------------------------------------------------------------------------------------
+                                                                    Model
+             ====================================================================================================================
+              Layer                                              Shape        Policy              Parameters   Parameters Memory
+             ====================================================================================================================
+              input ( input )                                    {nil, 784}   p=f32 c=f32 o=f32   0            0 bytes
+              dense ( dense[ "input" ] )                         {nil, 128}   p=f32 c=f32 o=f32   100480       401920 bytes
+              residual_dense ( dense[ "dense" ] )                {nil, 128}   p=f32 c=f32 o=f32   16512        66048 bytes
+              residual_add ( add ["residual_dense", "dense"] )   {nil, 128}   p=f32 c=f32 o=f32   0            0 bytes
+              dense2 ( dense[ "residual_add" ] )                 {nil, 10}    p=f32 c=f32 o=f32   1290         5160 bytes
+              softmax ( softmax[ "dense2" ] )                    {nil, 10}    p=f32 c=f32 o=f32   0            0 bytes
+             --------------------------------------------------------------------------------------------------------------------
              """
     end
   end

--- a/test/axon_test.exs
+++ b/test/axon_test.exs
@@ -727,16 +727,32 @@ defmodule AxonTest do
         |> Axon.softmax(name: "softmax")
 
       assert inspect(model) == """
-             -----------------------------------------------------------
-                                        Model
-             ===========================================================
-              Layer                             Shape        Parameters
-             ===========================================================
-              input ( input )                   {nil, 784}   0
-              dense1 ( dense[ "input" ] )       {nil, 128}   100480
-              dense2 ( dense[ "dense1" ] )      {nil, 10}    1290
-              softmax ( softmax[ "dense2" ] )   {nil, 10}    0
-             -----------------------------------------------------------
+             --------------------------------------------------------------------------------------------------------------
+                                                                 Model
+             ==============================================================================================================
+              Layer                             Shape        Policy                         Parameters   Parameters Memory
+             ==============================================================================================================
+              input ( input )                   {nil, 784}   #Axon.MixedPrecision.Policy<   0            0 bytes           
+                                                               params: {:f, 32},                                           
+                                                               compute: {:f, 32},                                          
+                                                               output: {:f, 32}                                            
+                                                             >
+              dense1 ( dense[ "input" ] )       {nil, 128}   #Axon.MixedPrecision.Policy<   100480       401920 bytes      
+                                                               params: {:f, 32},                                           
+                                                               compute: {:f, 32},                                          
+                                                               output: {:f, 32}                                            
+                                                             >
+              dense2 ( dense[ "dense1" ] )      {nil, 10}    #Axon.MixedPrecision.Policy<   1290         5160 bytes        
+                                                               params: {:f, 32},                                           
+                                                               compute: {:f, 32},                                          
+                                                               output: {:f, 32}                                            
+                                                             >
+              softmax ( softmax[ "dense2" ] )   {nil, 10}    #Axon.MixedPrecision.Policy<   0            0 bytes           
+                                                               params: {:f, 32},                                           
+                                                               compute: {:f, 32},                                          
+                                                               output: {:f, 32}                                            
+                                                             >
+             --------------------------------------------------------------------------------------------------------------
              """
     end
 
@@ -755,18 +771,42 @@ defmodule AxonTest do
         |> Axon.softmax(name: "softmax")
 
       assert inspect(model) == """
-             ----------------------------------------------------------------------------
-                                                Model
-             ============================================================================
-              Layer                                              Shape        Parameters
-             ============================================================================
-              input ( input )                                    {nil, 784}   0
-              dense ( dense[ "input" ] )                         {nil, 128}   100480
-              residual_dense ( dense[ "dense" ] )                {nil, 128}   16512
-              residual_add ( add ["residual_dense", "dense"] )   {nil, 128}   0
-              dense2 ( dense[ "residual_add" ] )                 {nil, 10}    1290
-              softmax ( softmax[ "dense2" ] )                    {nil, 10}    0
-             ----------------------------------------------------------------------------
+             -------------------------------------------------------------------------------------------------------------------------------
+                                                                          Model
+             ===============================================================================================================================
+              Layer                                              Shape        Policy                         Parameters   Parameters Memory
+             ===============================================================================================================================
+              input ( input )                                    {nil, 784}   #Axon.MixedPrecision.Policy<   0            0 bytes           
+                                                                                params: {:f, 32},                                           
+                                                                                compute: {:f, 32},                                          
+                                                                                output: {:f, 32}                                            
+                                                                              >
+              dense ( dense[ "input" ] )                         {nil, 128}   #Axon.MixedPrecision.Policy<   100480       401920 bytes      
+                                                                                params: {:f, 32},                                           
+                                                                                compute: {:f, 32},                                          
+                                                                                output: {:f, 32}                                            
+                                                                              >
+              residual_dense ( dense[ "dense" ] )                {nil, 128}   #Axon.MixedPrecision.Policy<   16512        66048 bytes       
+                                                                                params: {:f, 32},                                           
+                                                                                compute: {:f, 32},                                          
+                                                                                output: {:f, 32}                                            
+                                                                              >
+              residual_add ( add ["residual_dense", "dense"] )   {nil, 128}   #Axon.MixedPrecision.Policy<   0            0 bytes           
+                                                                                params: {:f, 32},                                           
+                                                                                compute: {:f, 32},                                          
+                                                                                output: {:f, 32}                                            
+                                                                              >
+              dense2 ( dense[ "residual_add" ] )                 {nil, 10}    #Axon.MixedPrecision.Policy<   1290         5160 bytes        
+                                                                                params: {:f, 32},                                           
+                                                                                compute: {:f, 32},                                          
+                                                                                output: {:f, 32}                                            
+                                                                              >
+              softmax ( softmax[ "dense2" ] )                    {nil, 10}    #Axon.MixedPrecision.Policy<   0            0 bytes           
+                                                                                params: {:f, 32},                                           
+                                                                                compute: {:f, 32},                                          
+                                                                                output: {:f, 32}                                            
+                                                                              >
+             -------------------------------------------------------------------------------------------------------------------------------
              """
     end
   end

--- a/test/compiler_test.exs
+++ b/test/compiler_test.exs
@@ -3941,8 +3941,7 @@ defmodule CompilerTest do
         |> Axon.dense(8)
         |> Axon.dense(1)
 
-      assert %{"dense_0" => dense_0_params, "dense_1" => dense_1_params} =
-        Axon.init(model)
+      assert %{"dense_0" => dense_0_params, "dense_1" => dense_1_params} = Axon.init(model)
 
       assert %{"kernel" => k0, "bias" => b0} = dense_0_params
       assert %{"kernel" => k1, "bias" => b1} = dense_1_params
@@ -3958,23 +3957,22 @@ defmodule CompilerTest do
       {state, _} = input |> Axon.lstm(4)
       {_, out} = input |> Axon.lstm(8, hidden_state: state)
 
-      assert %{"lstm_0" => lstm_0_params, "lstm_1" => lstm_1_params} =
-        Axon.init(out)
+      assert %{"lstm_0" => lstm_0_params, "lstm_1" => lstm_1_params} = Axon.init(out)
 
       assert %{
-                "wii" => wii_0,
-                "wif" => wif_0,
-                "wig" => wig_0,
-                "wio" => wio_0,
-                "whi" => whi_0,
-                "whf" => whf_0,
-                "whg" => whg_0,
-                "who" => who_0,
-                "bi" => bi_0,
-                "bf" => bf_0,
-                "bg" => bg_0,
-                "bo" => bo_0
-               } = lstm_0_params
+               "wii" => wii_0,
+               "wif" => wif_0,
+               "wig" => wig_0,
+               "wio" => wio_0,
+               "whi" => whi_0,
+               "whf" => whf_0,
+               "whg" => whg_0,
+               "who" => who_0,
+               "bi" => bi_0,
+               "bf" => bf_0,
+               "bg" => bg_0,
+               "bo" => bo_0
+             } = lstm_0_params
 
       assert Nx.shape(wii_0) == {2, 4}
       assert Nx.shape(wif_0) == {2, 4}
@@ -3990,19 +3988,19 @@ defmodule CompilerTest do
       assert Nx.shape(bo_0) == {4}
 
       assert %{
-          "wii" => wii_1,
-          "wif" => wif_1,
-          "wig" => wig_1,
-          "wio" => wio_1,
-          "whi" => whi_1,
-          "whf" => whf_1,
-          "whg" => whg_1,
-          "who" => who_1,
-          "bi" => bi_1,
-          "bf" => bf_1,
-          "bg" => bg_1,
-          "bo" => bo_1
-         } = lstm_1_params
+               "wii" => wii_1,
+               "wif" => wif_1,
+               "wig" => wig_1,
+               "wio" => wio_1,
+               "whi" => whi_1,
+               "whf" => whf_1,
+               "whg" => whg_1,
+               "who" => who_1,
+               "bi" => bi_1,
+               "bf" => bf_1,
+               "bg" => bg_1,
+               "bo" => bo_1
+             } = lstm_1_params
 
       assert Nx.shape(wii_1) == {2, 8}
       assert Nx.shape(wif_1) == {2, 8}

--- a/test/mixed_precision_test.exs
+++ b/test/mixed_precision_test.exs
@@ -65,4 +65,18 @@ defmodule MixedPrecisionTest do
       assert Nx.type(params["batch_norm"]["beta"]) == {:f, 32}
     end
   end
+
+  describe "inspection" do
+    test "works" do
+      policy = AMP.create_policy()
+
+      assert inspect(policy) == """
+             #Axon.MixedPrecision.Policy<
+               params: {:f, 32},
+               compute: {:f, 32},
+               output: {:f, 32}
+             >\
+             """
+    end
+  end
 end

--- a/test/mixed_precision_test.exs
+++ b/test/mixed_precision_test.exs
@@ -71,11 +71,7 @@ defmodule MixedPrecisionTest do
       policy = AMP.create_policy()
 
       assert inspect(policy) == """
-             #Axon.MixedPrecision.Policy<
-               params: {:f, 32},
-               compute: {:f, 32},
-               output: {:f, 32}
-             >\
+             p=f32 c=f32 o=f32\
              """
     end
   end


### PR DESCRIPTION
New model inspection includes memory space and layer policies so you have a better idea of space requirements and types. Example:

```elixir
model =
  Axon.input({nil, 784}, name: "input")
  |> Axon.dense(128, name: "dense1")
  |> Axon.dense(10, name: "dense2")
  |> Axon.softmax(name: "softmax")
```

Inspected:

```
--------------------------------------------------------------------------------------------------------------
                                                    Model
==============================================================================================================
 Layer                             Shape        Policy                         Parameters   Parameters Memory
==============================================================================================================
 input ( input )                   {nil, 784}   #Axon.MixedPrecision.Policy<   0            0 bytes           
                                                  params: {:f, 32},                                           
                                                  compute: {:f, 32},                                          
                                                  output: {:f, 32}                                            
                                                >
 dense1 ( dense[ "input" ] )       {nil, 128}   #Axon.MixedPrecision.Policy<   100480       401920 bytes      
                                                  params: {:f, 32},                                           
                                                  compute: {:f, 32},                                          
                                                  output: {:f, 32}                                            
                                                >
 dense2 ( dense[ "dense1" ] )      {nil, 10}    #Axon.MixedPrecision.Policy<   1290         5160 bytes        
                                                  params: {:f, 32},                                           
                                                  compute: {:f, 32},                                          
                                                  output: {:f, 32}                                            
                                                >
 softmax ( softmax[ "dense2" ] )   {nil, 10}    #Axon.MixedPrecision.Policy<   0            0 bytes           
                                                  params: {:f, 32},                                           
                                                  compute: {:f, 32},                                          
                                                  output: {:f, 32}                                            
                                                >
--------------------------------------------------------------------------------------------------------------
```

Thoughts @josevalim @polvalente @cigrainger ?