### PR TITLE
Variable name typo and invalid function arity in Axon.Loop

### DIFF
--- a/lib/axon/loop.ex
+++ b/lib/axon/loop.ex
@@ -1043,7 +1043,7 @@ defmodule Axon.Loop do
             |> Map.replace(monitor, cur_criteria_value)
             |> Map.replace(:since_last_improvement, 0)
 
-          {:continue, %{state | handler_metadata: updated_handle_meta}}
+          {:continue, %{state | handler_metadata: updated_handler_meta}}
 
         not improved? and not over_patience? ->
           updated_handle_meta =

--- a/lib/axon/loop.ex
+++ b/lib/axon/loop.ex
@@ -1047,7 +1047,7 @@ defmodule Axon.Loop do
 
         not improved? and not over_patience? ->
           updated_handle_meta =
-            Map.update(handler_meta, :since_last_improvement, fn x -> x + 1 end)
+            Map.update(handler_meta, :since_last_improvement, 0, fn x -> x + 1 end)
 
           {:continue, %{state | handler_metadata: updated_handle_meta}}
 


### PR DESCRIPTION
See each commit for more information.

This allows Axon to compile.  Tests are now working locally.

Fixes: #211