### PR TITLE
Allow maps as inputs to predict

### DIFF
--- a/examples/basics/multi_input_example.exs
+++ b/examples/basics/multi_input_example.exs
@@ -8,8 +8,8 @@ defmodule XOR do
   require Axon
 
   defp build_model(input_shape1, input_shape2) do
-    inp1 = Axon.input(input_shape1)
-    inp2 = Axon.input(input_shape2)
+    inp1 = Axon.input(input_shape1, name: :x1)
+    inp2 = Axon.input(input_shape2, name: :x2)
     inp1
     |> Axon.concatenate(inp2)
     |> Axon.dense(8, activation: :tanh)
@@ -20,7 +20,7 @@ defmodule XOR do
     x1 = Nx.tensor(for _ <- 1..32, do: [Enum.random(0..1)])
     x2 = Nx.tensor(for _ <- 1..32, do: [Enum.random(0..1)])
     y = Nx.logical_xor(x1, x2)
-    {{x1, x2}, y}
+    {%{x1: x1, x2: x2}, y}
   end
 
   defp train_model(model, data, epochs) do

--- a/test/axon/compiler_test.exs
+++ b/test/axon/compiler_test.exs
@@ -57,6 +57,19 @@ defmodule CompilerTest do
       assert predict_fn.(%{}, input2) == input2
     end
 
+    test "multi-input, map" do
+      model1 = {Axon.input({nil, 1}), Axon.input({nil, 1})}
+
+      input1 = Nx.random_uniform({1, 1})
+      input2 = Nx.random_uniform({1, 1})
+
+      assert {init_fn, predict_fn} = Axon.compile(model1)
+      assert %{} = init_fn.()
+      assert {output1, output2} = predict_fn.(%{}, %{"input_0" => input1, "input_1" => input2})
+      assert output1 == input1
+      assert output2 == input2
+    end
+
     test "raises on bad input shape" do
       model = Axon.input({nil, 32})
       input = Nx.random_uniform({1, 16})

--- a/test/axon/compiler_test.exs
+++ b/test/axon/compiler_test.exs
@@ -57,7 +57,7 @@ defmodule CompilerTest do
       assert predict_fn.(%{}, input2) == input2
     end
 
-    test "multi-input, map" do
+    test "multi-input, map with default names" do
       model1 = {Axon.input({nil, 1}), Axon.input({nil, 1})}
 
       input1 = Nx.random_uniform({1, 1})
@@ -68,6 +68,24 @@ defmodule CompilerTest do
       assert {output1, output2} = predict_fn.(%{}, %{"input_0" => input1, "input_1" => input2})
       assert output1 == input1
       assert output2 == input2
+    end
+
+    test "multi-input, map with custom names" do
+      x = Axon.input({nil, 1}, name: :x)
+      y = Axon.input({nil, 1}, name: :y)
+      z = Axon.input({nil, 1}, name: :z)
+      model = {z, x, y}
+
+      x_val = Nx.random_uniform({1, 1})
+      y_val = Nx.random_uniform({1, 1})
+      z_val = Nx.random_uniform({1, 1})
+
+      assert {init_fn, predict_fn} = Axon.compile(model)
+      assert %{} = init_fn.()
+      assert {z_act, x_act, y_act} = predict_fn.(%{}, %{x: x_val, y: y_val, z: z_val})
+      assert x_act == x_val
+      assert y_act == y_val
+      assert z_act == z_val
     end
 
     test "raises on bad input shape" do

--- a/test/axon/loop_test.exs
+++ b/test/axon/loop_test.exs
@@ -130,7 +130,8 @@ defmodule Axon.LoopTest do
 
       assert %{model_state: %{}, y_true: tar, y_pred: pred, loss: loss} =
                Nx.Defn.jit(update_fn, [
-                 {{Nx.tensor([[1]]), Nx.tensor([[1]])}, {Nx.tensor([[2]]), Nx.tensor([[2]])}},
+                 {%{"input_0" => Nx.tensor([[1]]), "input_1" => Nx.tensor([[1]])},
+                  {Nx.tensor([[2]]), Nx.tensor([[2]])}},
                  pstate
                ])
 


### PR DESCRIPTION
Resolves #218 

The initial way to work with multi-input models was to pass a tuple to `Axon.predict` where the order of inputs corresponded to the order inputs we're declared. So if you had a model:

```elixir
x = Axon.input({nil, 1})
y = Axon.input({nil, 1})
z = Axon.input({nil, 1})
model = Axon.add([x, y, z])
```

You would pass values for `x`, `y`, and `z` in order as:

```
Axon.predict(model, params, {x_val, y_val, z_val})
```

Because `x` was declared before `y` was declared before `z`. This was done before Nx supported maps, so it was the easiest way to accomplish multi-inputs. We sort inputs by the Layer's ID because it's a monotonically increasing random integer, and this was the easiest way to ensure inputs we're mapped correctly.

I think now because we support generic containers it makes sense to instead pass multiple inputs strictly with maps. In my opinion the code is more explicit and readable, and you don't have to go to the docs to figure out how to pass multiple inputs in when looking at a multi-input example:

```elixir
x = Axon.input({nil, 1}, name: :x)
y = Axon.input({nil, 1}, name: :y)
z = Axon.input({nil, 1}, name: :z)
model = Axon.add([x, y, z])

Axon.predict(model, params, %{x: x_val, y: y_val, z: z_val})
```