### PR TITLE
Fix Default Value of eps_root in Adam Documentation

### DIFF
--- a/lib/axon/optimizers.ex
+++ b/lib/axon/optimizers.ex
@@ -98,7 +98,7 @@ defmodule Axon.Optimizers do
     * `:b1` - first moment decay. Defaults to `0.9`
     * `:b2` - second moment decay. Defaults to `0.999`
     * `:eps` - numerical stability term. Defaults to `1.0e-8`
-    * `:eps_root` - numerical stability term. Defaults to `1.0e-9`
+    * `:eps_root` - numerical stability term. Defaults to `1.0e-15`
 
   ## References
 

--- a/lib/axon/updates.ex
+++ b/lib/axon/updates.ex
@@ -112,7 +112,7 @@ defmodule Axon.Updates do
       * `:b1` - first moment decay. Defaults to `0.9`
       * `:b2` - second moment decay. Defaults to `0.999`
       * `:eps` - numerical stability term. Defaults to `1.0e-8`
-      * `:eps_root` - numerical stability term. Defaults to `1.0e-10`
+      * `:eps_root` - numerical stability term. Defaults to `1.0e-15`
 
   ## References
 


### PR DESCRIPTION
Updates documentation to specify the true default value of `eps_root` used by the Adam optimizer.