### PR TITLE
Make Loop.checkpoint `file_pattern` function more flexible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ examples/vision/humans/
 # Temporary files for e.g. tests
 /tmp/
 /config/
+
+/checkpoint/


### PR DESCRIPTION
Currently in the `file_pattern` function of `Loop.checkpoint` only epoch and iteration get passed through. This limitation makes it impossible to include metrics like loss in the filename which can be helpful. 
To solve this we can pass the whole loop state to the `file_pattern` function.

With this change we can specify the file_pattern like this.

```elixir
Axon.input({nil, 1})
|> Axon.dense(1)
|> Loop.trainer(:binary_cross_entropy, :sgd, log: 0)
|> Loop.checkpoint(file_pattern: fn state -> "epoch_#{state.epoch}_#{state.metrics["loss"]}.ckpt" end)
|> Loop.run([{Nx.tensor([[1]]), Nx.tensor([[2]])}], epochs: 3)
```

This PR also adds tests for checkpoint.