### PR TITLE
Simplify compiler

### DIFF
--- a/lib/axon.ex
+++ b/lib/axon.ex
@@ -473,7 +473,8 @@ defmodule Axon do
         [x, kernel]
       end
 
-    node = layer(:dense, inputs, name: opts[:name], shape: output_shape)
+    op = if use_bias, do: :dense, else: &Axon.Layers.dense(&1, &2, 0, &3)
+    node = layer(op, inputs, name: opts[:name], shape: output_shape)
 
     if activation do
       activation(node, activation)
@@ -538,7 +539,8 @@ defmodule Axon do
         [input1, input2, kernel]
       end
 
-    node = layer(:bilinear, inputs, name: opts[:name], shape: output_shape)
+    op = if use_bias, do: :bilinear, else: &Axon.Layers.bilinear(&1, &2, &3, 0, &4)
+    node = layer(op, inputs, name: opts[:name], shape: output_shape)
 
     if activation do
       activation(node, activation)
@@ -618,8 +620,10 @@ defmodule Axon do
         [x, kernel]
       end
 
+    op = if use_bias, do: :conv, else: &Axon.Layers.conv(&1, &2, 0, &3)
+
     node =
-      layer(:conv, inputs,
+      layer(op, inputs,
         name: opts[:name],
         strides: strides,
         padding: padding,
@@ -691,6 +695,8 @@ defmodule Axon do
         [x, kernel]
       end
 
+    op = if use_bias, do: :conv_transpose, else: &Axon.Layers.conv_transpose(&1, &2, 0, &3)
+
     output_shape =
       Axon.Shape.conv_transpose(
         parent_shape,
@@ -702,7 +708,7 @@ defmodule Axon do
       )
 
     node =
-      layer(:conv_transpose, inputs,
+      layer(op, inputs,
         name: opts[:name],
         strides: strides,
         padding: padding,
@@ -797,8 +803,10 @@ defmodule Axon do
         [x, kernel]
       end
 
+    op = if use_bias, do: :depthwise_conv, else: &Axon.Layers.depthwise_conv(&1, &2, 0, &3)
+
     node =
-      layer(:depthwise_conv, inputs,
+      layer(op, inputs,
         name: opts[:name],
         strides: strides,
         padding: padding,

--- a/lib/axon.ex
+++ b/lib/axon.ex
@@ -129,9 +129,15 @@ defmodule Axon do
   """
   @doc type: :special
   def layer(parent, op, parameters, name \\ nil, opts \\ [])
-      when is_atom(op) or (is_function(op) and is_map(parameters)) do
+      when is_atom(op) or (is_function(op) and is_list(parameters)) do
     layer_op = opts[:layer_op] || :layer
-    {shape, opts} = Keyword.pop(opts, :shape)
+
+    {shape, opts} =
+      if op in [:reshape, :resize] do
+        {opts[:shape], opts}
+      else
+        Keyword.pop(opts, :shape)
+      end
 
     op_name = if is_atom(op), do: op, else: layer_op
 
@@ -184,25 +190,25 @@ defmodule Axon do
         {[{k, param} | params], count + 1}
       end)
 
-    param_map = params |> Enum.reverse() |> Map.new()
+    params = params |> Enum.reverse()
 
     args =
       case opts do
         [] ->
-          inputs ++ [param_map]
+          inputs ++ params
 
         [_ | _] = opts ->
-          inputs ++ [param_map, opts]
+          inputs ++ params ++ [opts]
       end
 
-    {tensors, [param_map | opts]} = Enum.split_while(args, &is_struct(&1, Nx.Tensor))
+    {tensors, opts} = Enum.split_while(args, &is_struct(&1, Nx.Tensor))
 
-    wrapper_fun = fn tensors, params ->
+    wrapper_fun = fn tensors ->
       tensors = Tuple.to_list(tensors)
-      apply(fun, tensors ++ [params] ++ opts)
+      apply(fun, tensors ++ [opts])
     end
 
-    expr = Nx.Defn.jit(wrapper_fun, [List.to_tuple(tensors), param_map], compiler: Axon.Defn)
+    expr = Nx.Defn.jit(wrapper_fun, [List.to_tuple(tensors)], compiler: Axon.Defn)
 
     indices = Enum.map(indices, &MapSet.new/1)
 
@@ -273,7 +279,7 @@ defmodule Axon do
   @doc type: :special
   def input(input_shape, opts \\ []) do
     output_shape = Axon.Shape.input(input_shape)
-    layer(nil, :input, %{}, opts[:name], shape: output_shape)
+    layer(nil, :input, [], opts[:name], shape: output_shape)
   end
 
   @doc """
@@ -300,7 +306,7 @@ defmodule Axon do
 
   @doc type: :special
   def constant(%Nx.Tensor{shape: output_shape} = tensor, opts) do
-    layer(nil, :constant, %{}, opts[:name], value: tensor, shape: output_shape)
+    layer(nil, :constant, [], opts[:name], value: tensor, shape: output_shape)
   end
 
   def constant(value, _) do
@@ -329,7 +335,7 @@ defmodule Axon do
       iex> inp1 = Axon.input({nil, 1})
       iex> inp2 = Axon.input({nil, 2})
       iex> model = Axon.container(%{a: inp1, b: inp2})
-      iex> %{a: a, b: b} = Axon.predict(model, %{}, %{
+      iex> %{a: a, b: b} = Axon.predict(model, [], %{
       ...>    "input_0" => Nx.tensor([[1.0]]),
       ...>    "input_1" => Nx.tensor([[1.0, 2.0]])
       ...> })
@@ -355,7 +361,7 @@ defmodule Axon do
         shape
       end)
 
-    layer(container, :container, %{}, opts[:name], shape: output_shape)
+    layer(container, :container, [], opts[:name], shape: output_shape)
   end
 
   # TODO: This should not be duplicated
@@ -418,16 +424,15 @@ defmodule Axon do
 
         bias = param("bias", bias_shape, initializer: bias_initializer)
 
-        %{"kernel" => kernel, "bias" => bias}
+        [kernel, bias]
       else
-        %{"kernel" => kernel}
+        [kernel]
       end
 
-    node = layer(x, :dense, params, opts[:name], use_bias: use_bias, shape: output_shape)
+    node = layer(x, :dense, params, opts[:name], shape: output_shape)
 
     if activation do
-      node
-      |> activation(activation)
+      activation(node, activation)
     else
       node
     end
@@ -484,16 +489,12 @@ defmodule Axon do
 
         bias = param("bias", bias_shape, initializer: bias_initializer)
 
-        %{"kernel" => kernel, "bias" => bias}
+        [kernel, bias]
       else
-        %{"kernel" => kernel}
+        [kernel]
       end
 
-    node =
-      layer([input1, input2], :bilinear, params, opts[:name],
-        use_bias: use_bias,
-        shape: output_shape
-      )
+    node = layer([input1, input2], :bilinear, params, opts[:name], shape: output_shape)
 
     if activation do
       node
@@ -569,9 +570,9 @@ defmodule Axon do
 
         bias = param("bias", bias_shape, initializer: bias_initializer)
 
-        %{"kernel" => kernel, "bias" => bias}
+        [kernel, bias]
       else
-        %{"kernel" => kernel}
+        [kernel]
       end
 
     node =
@@ -580,7 +581,6 @@ defmodule Axon do
         padding: padding,
         input_dilation: input_dilation,
         kernel_dilation: kernel_dilation,
-        use_bias: use_bias,
         channels: channels,
         shape: output_shape
       )
@@ -643,9 +643,9 @@ defmodule Axon do
 
         bias = param("bias", bias_shape, initializer: bias_initializer)
 
-        %{"kernel" => kernel, "bias" => bias}
+        [kernel, bias]
       else
-        %{"kernel" => kernel}
+        [kernel]
       end
 
     output_shape =
@@ -663,7 +663,6 @@ defmodule Axon do
         strides: strides,
         padding: padding,
         kernel_dilation: kernel_dilation,
-        use_bias: use_bias,
         channels: channels,
         shape: output_shape
       )
@@ -750,9 +749,9 @@ defmodule Axon do
 
         bias = param("bias", bias_shape, initializer: bias_initializer)
 
-        %{"kernel" => kernel, "bias" => bias}
+        [kernel, bias]
       else
-        %{"kernel" => kernel}
+        [kernel]
       end
 
     node =
@@ -761,14 +760,12 @@ defmodule Axon do
         padding: padding,
         input_dilation: input_dilation,
         kernel_dilation: kernel_dilation,
-        use_bias: use_bias,
         channels: channels,
         shape: output_shape
       )
 
     if activation do
-      node
-      |> activation(activation)
+      activation(node, activation)
     else
       node
     end
@@ -865,9 +862,9 @@ defmodule Axon do
         b1 = param("bias_1", b1_shape, initializer: bias_initializer)
         b2 = param("bias_2", b2_shape, initializer: bias_initializer)
 
-        %{"k1" => k1, "b1" => b1, "k2" => k2, "b2" => b2}
+        [k1, b1, k2, b2]
       else
-        %{"k1" => k1, "k2" => k2}
+        [k1, k2]
       end
 
     node =
@@ -880,14 +877,12 @@ defmodule Axon do
         padding: padding,
         input_dilation: input_dilation,
         kernel_dilation: kernel_dilation,
-        use_bias: use_bias,
         channels: channels,
         shape: output_shape
       )
 
     if activation do
-      node
-      |> activation(activation)
+      activation(node, activation)
     else
       node
     end
@@ -998,9 +993,9 @@ defmodule Axon do
         b2 = param("bias_2", b2_shape, initializer: bias_initializer)
         b3 = param("bias_3", b3_shape, initializer: bias_initializer)
 
-        %{"k1" => k1, "b1" => b1, "k2" => k2, "b2" => b2, "k3" => k3, "b3" => b3}
+        [k1, b1, k2, b2, k3, b3]
       else
-        %{"k1" => k1, "k2" => k2, "k3" => k3}
+        [k1, k2, k3]
       end
 
     node =
@@ -1013,14 +1008,12 @@ defmodule Axon do
         padding: padding,
         input_dilation: input_dilation,
         kernel_dilation: kernel_dilation,
-        use_bias: use_bias,
         channels: channels,
         shape: output_shape
       )
 
     if activation do
-      node
-      |> activation(activation)
+      activation(node, activation)
     else
       node
     end
@@ -1067,12 +1060,12 @@ defmodule Axon do
   def activation(%Axon{output_shape: shape} = x, activation, opts) when is_atom(activation) do
     {name, opts} = Keyword.pop(opts, :name, nil)
     opts = [shape: shape] ++ opts
-    layer(x, activation, %{}, name, opts)
+    layer(x, activation, [], name, opts)
   end
 
   def activation(%Axon{output_shape: shape} = x, activation, opts)
       when is_function(activation, 1) do
-    layer(x, activation, %{}, opts[:name], opts ++ [shape: shape])
+    layer(x, activation, [], opts[:name], opts ++ [shape: shape])
   end
 
   ## Activation
@@ -1123,7 +1116,7 @@ defmodule Axon do
 
   defp dropout(%Axon{output_shape: parent_shape} = x, dropout, opts) do
     rate = opts[:rate] || 0.5
-    layer(x, dropout, %{}, opts[:name], rate: rate, shape: parent_shape)
+    layer(x, dropout, [], opts[:name], rate: rate, shape: parent_shape)
   end
 
   ## Pooling
@@ -1199,7 +1192,7 @@ defmodule Axon do
         ]
       end
 
-    layer(x, pool, %{}, name, opts)
+    layer(x, pool, [], name, opts)
   end
 
   ## Adaptive Pooling
@@ -1264,7 +1257,7 @@ defmodule Axon do
         [output_size: output_size, channels: channels, shape: output_shape]
       end
 
-    layer(x, pool, %{}, name, opts)
+    layer(x, pool, [], name, opts)
   end
 
   ## Global Pooling
@@ -1314,7 +1307,7 @@ defmodule Axon do
         [channels: channels, keep_axes: keep_axes, shape: output_shape]
       end
 
-    layer(x, pool, %{}, name, opts)
+    layer(x, pool, [], name, opts)
   end
 
   ## Normalization
@@ -1370,7 +1363,7 @@ defmodule Axon do
     layer(
       x,
       norm,
-      %{"gamma" => gamma, "beta" => beta, "mean" => mean, "var" => var},
+      [gamma, beta, mean, var],
       opts[:name],
       epsilon: epsilon,
       channel_index: channel_index,
@@ -1419,7 +1412,7 @@ defmodule Axon do
     beta_initializer = opts[:beta_initializer] || :zeros
     beta = param("beta", beta_shape, initializer: beta_initializer)
 
-    layer(x, norm, %{"gamma" => gamma, "beta" => beta}, opts[:name],
+    layer(x, norm, [gamma, beta], opts[:name],
       epsilon: epsilon,
       channel_index: channel_index,
       shape: shape
@@ -1458,7 +1451,7 @@ defmodule Axon do
 
     beta = param("beta", beta_shape, initializer: beta_initializer)
 
-    layer(x, :group_norm, %{"gamma" => gamma, "beta" => beta}, opts[:name],
+    layer(x, :group_norm, [gamma, beta], opts[:name],
       epsilon: epsilon,
       channel_index: channel_index,
       group_size: group_size,
@@ -1479,9 +1472,9 @@ defmodule Axon do
   @doc type: :special
   def nx(%Axon{output_shape: input_shape} = x, fun, opts) when is_function(fun, 1) do
     {name, opts} = Keyword.pop(opts, :name)
-    fun_with_params = fn x, _params -> fun.(x) end
-    output_shape = infer_shape([input_shape], fun_with_params, %{}, opts)
-    layer(x, :nx, %{}, name, fun: fun, shape: output_shape)
+    fun_with_params = fn x, _opts -> fun.(x) end
+    output_shape = infer_shape([input_shape], fun_with_params, [], opts)
+    layer(x, fun, [], name, shape: output_shape)
   end
 
   @doc """
@@ -1500,7 +1493,7 @@ defmodule Axon do
   def flatten(%Axon{op: op, output_shape: shape} = x, opts \\ []) do
     ignore_batch? = Keyword.get(opts, :ignore_batch?, op != :constant)
     output_shape = Axon.Shape.flatten(shape, ignore_batch?)
-    layer(x, :flatten, %{}, opts[:name], ignore_batch?: ignore_batch?, shape: output_shape)
+    layer(x, :flatten, [], opts[:name], ignore_batch?: ignore_batch?, shape: output_shape)
   end
 
   @doc """
@@ -1523,8 +1516,7 @@ defmodule Axon do
     ignore_batch? = Keyword.get(opts, :ignore_batch?, op != :constant)
     output_shape = Axon.Shape.reshape(shape, new_shape, ignore_batch?)
 
-    layer(x, :reshape, %{}, opts[:name],
-      reshape_shape: output_shape,
+    layer(x, :reshape, [], opts[:name],
       ignore_batch?: ignore_batch?,
       shape: output_shape
     )
@@ -1544,7 +1536,7 @@ defmodule Axon do
     ignore_batch? = Keyword.get(opts, :ignore_batch?, op != :constant)
     output_shape = Axon.Shape.transpose(shape, permutation, ignore_batch?)
 
-    layer(x, :transpose, %{}, opts[:name],
+    layer(x, :transpose, [], opts[:name],
       axes: permutation,
       ignore_batch?: ignore_batch?,
       shape: output_shape
@@ -1570,7 +1562,7 @@ defmodule Axon do
     channels = opts[:channels] || :first
     output_shape = Axon.Shape.pad(shape, config)
 
-    layer(x, :pad, %{}, opts[:name],
+    layer(x, :pad, [], opts[:name],
       padding_config: config,
       value: value,
       channels: channels,
@@ -1602,8 +1594,7 @@ defmodule Axon do
     channels = opts[:channels] || :first
     output_shape = Axon.Shape.resize(shape, resize_shape, channels)
 
-    layer(x, :resize, %{}, opts[:name],
-      resize_shape: resize_shape,
+    layer(x, :resize, [], opts[:name],
       method: method,
       channels: channels,
       shape: output_shape
@@ -1628,7 +1619,7 @@ defmodule Axon do
     axis = opts[:axis] || Nx.rank(x_shape) - 1
     output_shape = Axon.Shape.concatenate([x_shape, y_shape], axis)
 
-    layer([x, y], :concatenate, %{}, opts[:name], axis: axis, shape: output_shape)
+    layer([x, y], :concatenate, [], opts[:name], axis: axis, shape: output_shape)
   end
 
   @doc type: :composition
@@ -1638,7 +1629,7 @@ defmodule Axon do
     input_shapes = inputs |> Enum.map(fn %Axon{output_shape: shape} -> shape end)
     output_shape = Axon.Shape.concatenate(input_shapes, axis)
 
-    layer(inputs, :concatenate, %{}, opts[:name], axis: axis, shape: output_shape)
+    layer(inputs, :concatenate, [], opts[:name], axis: axis, shape: output_shape)
   end
 
   @doc false
@@ -1668,7 +1659,7 @@ defmodule Axon do
     @doc type: :composition
     def unquote(op)(%Axon{output_shape: lhs_shape} = x, %Axon{output_shape: rhs_shape} = y, opts) do
       output_shape = Axon.Shape.element_wise([lhs_shape, rhs_shape])
-      layer([x, y], unquote(op), %{}, opts[:name], shape: output_shape)
+      layer([x, y], unquote(op), [], opts[:name], shape: output_shape)
     end
 
     @doc """
@@ -1692,7 +1683,7 @@ defmodule Axon do
         end)
 
       output_shape = Axon.Shape.element_wise(shapes)
-      layer(inputs, unquote(op), %{}, opts[:name], shape: output_shape)
+      layer(inputs, unquote(op), [], opts[:name], shape: output_shape)
     end
 
     @doc false
@@ -1722,7 +1713,7 @@ defmodule Axon do
         opts \\ []
       )
       when is_function(cond_fn, 1) do
-    layer([parent, true_graph, false_graph], :cond, %{}, opts[:name],
+    layer([parent, true_graph, false_graph], :cond, [], opts[:name],
       cond: cond_fn,
       shape: out_shape
     )
@@ -1753,7 +1744,7 @@ defmodule Axon do
             layer(
               parent,
               fn x, _ -> Nx.slice_along_axis(x, num_split, split, axis: axis) end,
-              %{},
+              [],
               name
             )
 
@@ -1781,7 +1772,7 @@ defmodule Axon do
         layer(
           parent,
           fn x, _ -> Nx.slice_along_axis(x, i * slice_size, slice_size, axis: axis) end,
-          %{},
+          [],
           name,
           shape: split_shape
         )
@@ -1960,12 +1951,12 @@ defmodule Axon do
           "#{name}_output_sequence"
       end
 
-    new_c = layer(output, fn x, _ -> elem(elem(x, 0), 0) end, %{}, new_c_name, shape: h_shape)
+    new_c = layer(output, fn x, _ -> elem(elem(x, 0), 0) end, [], new_c_name, shape: h_shape)
 
-    new_h = layer(output, fn x, _ -> elem(elem(x, 0), 1) end, %{}, new_h_name, shape: h_shape)
+    new_h = layer(output, fn x, _ -> elem(elem(x, 0), 1) end, [], new_h_name, shape: h_shape)
 
     output_sequence =
-      layer(output, fn x, _ -> elem(x, 1) end, %{}, output_sequence_name, shape: output_shape)
+      layer(output, fn x, _ -> elem(x, 1) end, [], output_sequence_name, shape: output_shape)
 
     {{new_c, new_h}, output_sequence}
   end
@@ -2066,16 +2057,9 @@ defmodule Axon do
         bin = param("bin", bias_shape, initializer: bias_initializer)
         bhn = param("bhn", bias_shape, initializer: bias_initializer)
 
-        %{
-          "input_kernel" => {wir, wiz, win},
-          "hidden_kernel" => {whr, whz, whn},
-          "bias" => {br, bz, bin, bhn}
-        }
+        [{wir, wiz, win}, {whr, whz, whn}, {br, bz, bin, bhn}]
       else
-        %{
-          "input_kernel" => {wir, wiz, win},
-          "hidden_kernel" => {whr, whz, whn}
-        }
+        [{wir, wiz, win}, {whr, whz, whn}]
       end
 
     hidden_state_name =
@@ -2124,10 +2108,10 @@ defmodule Axon do
           "#{name}_output_sequence"
       end
 
-    new_h = layer(output, fn x, _ -> elem(elem(x, 0), 0) end, %{}, new_h_name, shape: h_shape)
+    new_h = layer(output, fn x, _ -> elem(elem(x, 0), 0) end, [], new_h_name, shape: h_shape)
 
     output_sequence =
-      layer(output, fn x, _ -> elem(x, 1) end, %{}, output_sequence_name, shape: output_shape)
+      layer(output, fn x, _ -> elem(x, 1) end, [], output_sequence_name, shape: output_shape)
 
     {{new_h}, output_sequence}
   end
@@ -2309,12 +2293,12 @@ defmodule Axon do
           "#{name}_output_sequence"
       end
 
-    new_c = layer(output, fn x, _ -> elem(elem(x, 0), 0) end, %{}, new_c_name, shape: h_shape)
+    new_c = layer(output, fn x, _ -> elem(elem(x, 0), 0) end, [], new_c_name, shape: h_shape)
 
-    new_h = layer(output, fn x, _ -> elem(elem(x, 0), 1) end, %{}, new_h_name, shape: h_shape)
+    new_h = layer(output, fn x, _ -> elem(elem(x, 0), 1) end, [], new_h_name, shape: h_shape)
 
     output_sequence =
-      layer(output, fn x, _ -> elem(x, 1) end, %{}, output_sequence_name, shape: output_shape)
+      layer(output, fn x, _ -> elem(x, 1) end, [], output_sequence_name, shape: output_shape)
 
     {{new_c, new_h}, output_sequence}
   end
@@ -2347,7 +2331,7 @@ defmodule Axon do
       end
     end
 
-    layer(x, fun, %{}, name, layer_op: :recurrent_state)
+    layer(x, fun, [], name, layer_op: :recurrent_state)
   end
 
   @doc """
@@ -2366,7 +2350,7 @@ defmodule Axon do
     kernel_initializer = opts[:kernel_initializer] || :uniform
     kernel = param("kernel", kernel_shape, initializer: kernel_initializer)
 
-    layer(x, :embedding, %{"kernel" => kernel}, opts[:name], shape: output_shape)
+    layer(x, :embedding, [kernel], opts[:name], shape: output_shape)
   end
 
   @doc """
@@ -2381,7 +2365,7 @@ defmodule Axon do
     bias_initializer = opts[:bias_initializer] || :zeros
     bias = param("bias", bias_shape, initializer: bias_initializer)
 
-    layer(x, :bias, %{"bias" => bias}, opts[:name], shape: shape)
+    layer(x, :bias, [bias], opts[:name], shape: shape)
   end
 
   @doc """
@@ -2421,7 +2405,7 @@ defmodule Axon do
   def freeze(%Axon{} = model, fun \\ & &1) when is_function(fun, 1) do
     parameters =
       tree_reduce(model, MapSet.new(), fn %Axon{params: params}, acc ->
-        Enum.reduce(params, acc, fn {_, param}, acc ->
+        Enum.reduce(params, acc, fn param, acc ->
           MapSet.put(acc, param)
         end)
       end)
@@ -2430,12 +2414,11 @@ defmodule Axon do
 
     tree_map(model, fn %Axon{params: params} = axon ->
       frozen_params =
-        params
-        |> Map.new(fn {k, %{name: param_name} = v} ->
+        Enum.map(params, fn %{name: param_name} = v ->
           if Enum.any?(parameters_to_freeze, fn %{name: name} -> name == param_name end) do
-            {k, %{v | frozen: true}}
+            %{v | frozen: true}
           else
-            {k, v}
+            v
           end
         end)
 
@@ -2653,7 +2636,7 @@ defmodule Axon do
     def inspect(axon, _opts) do
       title = "Model"
       header = ["Layer", "Shape", "Policy", "Parameters", "Parameters Memory"]
-      {_, _, cache, _} = axon_to_rows(axon, %{}, %{})
+      {_, _, cache, _} = axon_to_rows(axon, [], [])
 
       rows =
         cache
@@ -2677,7 +2660,7 @@ defmodule Axon do
         %{^id => {row, name}} ->
           {row, name, cache, op_counts}
 
-        %{} ->
+        [] ->
           {row, name, cache, op_counts} = do_axon_to_rows(graph, cache, op_counts)
           cache = Map.put(cache, id, {row, name})
           op_counts = Map.update(op_counts, op, 1, fn x -> x + 1 end)

--- a/lib/axon.ex
+++ b/lib/axon.ex
@@ -200,6 +200,7 @@ defmodule Axon do
       tuple
       |> Tuple.to_list()
       |> Enum.reduce(acc, &recur_break_shapes/2)
+
     {:container, shape}
   end
 

--- a/lib/axon.ex
+++ b/lib/axon.ex
@@ -1659,7 +1659,7 @@ defmodule Axon do
     @doc type: :composition
     def unquote(op)(%Axon{output_shape: lhs_shape} = x, %Axon{output_shape: rhs_shape} = y, opts) do
       output_shape = Axon.Shape.element_wise([lhs_shape, rhs_shape])
-      layer([x, y], unquote(op), [], opts[:name], shape: output_shape)
+      layer(container({x, y}), unquote(op), [], opts[:name], shape: output_shape)
     end
 
     @doc """
@@ -1683,7 +1683,7 @@ defmodule Axon do
         end)
 
       output_shape = Axon.Shape.element_wise(shapes)
-      layer(inputs, unquote(op), [], opts[:name], shape: output_shape)
+      layer(container(List.to_tuple(inputs)), unquote(op), [], opts[:name], shape: output_shape)
     end
 
     @doc false

--- a/lib/axon/activations.ex
+++ b/lib/axon/activations.ex
@@ -257,9 +257,9 @@ defmodule Axon.Activations do
       >
 
   """
-  defn hard_silu(x) do
+  defn hard_silu(x, opts \\ []) do
     x
-    |> hard_sigmoid()
+    |> hard_sigmoid(opts)
     |> Nx.multiply(x)
   end
 

--- a/lib/axon/compiler.ex
+++ b/lib/axon/compiler.ex
@@ -46,7 +46,6 @@ defmodule Axon.Compiler do
            op: op,
            name: name_fn,
            params: params,
-           opts: opts,
            policy: %{params: dtype},
            hooks: hooks
          },
@@ -62,17 +61,6 @@ defmodule Axon.Compiler do
 
         {_, parents} ->
           Enum.reduce(parents, cache_and_counts, &to_init_fun/2)
-      end
-
-    {cache, op_counts} =
-      case opts[:hidden_state] do
-        state when is_tuple(state) ->
-          state
-          |> Tuple.to_list()
-          |> Enum.reduce({cache, op_counts}, &to_init_fun/2)
-
-        nil ->
-          {cache, op_counts}
       end
 
     case cache do

--- a/lib/axon/compiler.ex
+++ b/lib/axon/compiler.ex
@@ -59,8 +59,11 @@ defmodule Axon.Compiler do
         {_, nil} ->
           cache_and_counts
 
-        {_, parents} ->
+        {_, parents} when is_list(parents) ->
           Enum.reduce(parents, cache_and_counts, &to_init_fun/2)
+
+        {_, parents} when is_tuple(parents) ->
+          deep_reduce(parents, cache_and_counts, &to_init_fun/2)
       end
 
     case cache do
@@ -151,17 +154,18 @@ defmodule Axon.Compiler do
     end
   end
 
-  defp call_cache(parent_id, params, inputs, state, cache) do
+  defp call_cache(parent_id, params, inputs, state, cache, result_cache) do
     key = {:cache, parent_id}
 
-    case state do
-      %{^key => expr} ->
-        {expr, state}
+    case result_cache do
+      %{^key => {expr, state}} ->
+        {expr, {state, result_cache}}
 
       %{} ->
-        {expr, state} = cache[parent_id].(params, inputs, state, cache)
+        {expr, {state, result_cache}} =
+          cache[parent_id].(params, inputs, state, cache, result_cache)
 
-        {expr, Map.put(state, key, expr)}
+        {expr, {state, Map.put(result_cache, key, {expr, state})}}
     end
   end
 
@@ -175,9 +179,9 @@ defmodule Axon.Compiler do
 
     op_counts = Map.update(op_counts, :container, 1, fn x -> x + 1 end)
 
-    fun = fn params, inputs, state, cache ->
-      deep_map_reduce(parent_ids, state, fn parent_id, state ->
-        call_cache(parent_id, params, inputs, state, cache)
+    fun = fn params, inputs, state, cache, result_cache ->
+      deep_map_reduce(parent_ids, {state, result_cache}, fn parent_id, {state, result_cache} ->
+        call_cache(parent_id, params, inputs, state, cache, result_cache)
       end)
     end
 
@@ -218,11 +222,11 @@ defmodule Axon.Compiler do
         {k, {v, frz}}
       end)
 
-    fun = fn params, inputs, state, cache ->
-      {layer_inputs, state} =
+    fun = fn params, inputs, state, cache, result_cache ->
+      {res, {state, result_cache}} =
         parent_ids
-        |> Enum.map_reduce(state, fn parent_id, state ->
-          call_cache(parent_id, params, inputs, state, cache)
+        |> Enum.map_reduce({state, result_cache}, fn parent_id, {state, result_cache} ->
+          call_cache(parent_id, params, inputs, state, cache, result_cache)
         end)
 
       inp_params =
@@ -231,7 +235,7 @@ defmodule Axon.Compiler do
         end)
 
       inputs =
-        layer_inputs
+        res
         |> Enum.map(&safe_as_type(&1, compute))
         |> Enum.map(&apply_hooks(&1, :pre_forward, mode, hooks))
 
@@ -251,7 +255,7 @@ defmodule Axon.Compiler do
         |> apply_hooks(:backward, mode, hooks)
         |> safe_as_type(output)
 
-      {out, state}
+      {out, {state, result_cache}}
     end
 
     {id, {Map.put(cache, id, fun), op_counts}}
@@ -281,21 +285,22 @@ defmodule Axon.Compiler do
 
     op_counts = Map.update(op_counts, op, 1, fn x -> x + 1 end)
 
-    fun = fn params, inputs, state, cache ->
-      {input, state} = call_cache(parent_id, params, inputs, state, cache)
+    fun = fn params, inputs, state, cache, result_cache ->
+      {res, {state, result_cache}} =
+        call_cache(parent_id, params, inputs, state, cache, result_cache)
 
-      input =
-        input
+      res =
+        res
         |> safe_as_type(compute)
         |> apply_hooks(:pre_forward, mode, hooks)
 
       args =
         case opts do
           [] ->
-            [input]
+            [res]
 
           [_ | _] ->
-            [input, opts]
+            [res, opts]
         end
 
       res =
@@ -305,7 +310,7 @@ defmodule Axon.Compiler do
         |> apply_hooks(:forward, mode, hooks)
         |> apply_hooks(:backward, mode, hooks)
 
-      {res, state}
+      {res, {state, result_cache}}
     end
 
     {id, {Map.put(cache, id, fun), op_counts}}
@@ -337,16 +342,19 @@ defmodule Axon.Compiler do
         &to_predict_fun(&1, &2, mode)
       )
 
-    name = name_fn.(op, op_counts)
+    layer_name = name_fn.(op, op_counts)
     op_counts = Map.update(op_counts, op, 1, fn x -> x + 1 end)
 
     {use_bias, opts} = Keyword.pop(opts, :use_bias, true)
 
-    fun = fn params, inputs, state, cache ->
-      {res, state} =
+    %{frozen: w_frz} = layer_params["kernel"]
+    %{frozen: b_frz} = if use_bias, do: layer_params["bias"], else: %{frozen: false}
+
+    fun = fn params, inputs, state, cache, result_cache ->
+      {res, {state, result_cache}} =
         parent_ids
-        |> Enum.map_reduce(state, fn parent_id, state ->
-          call_cache(parent_id, params, inputs, state, cache)
+        |> Enum.map_reduce({state, result_cache}, fn parent_id, {state, result_cache} ->
+          call_cache(parent_id, params, inputs, state, cache, result_cache)
         end)
 
       inputs =
@@ -354,11 +362,11 @@ defmodule Axon.Compiler do
         |> Enum.map(&safe_as_type(&1, compute))
         |> Enum.map(&apply_hooks(&1, :pre_forward, mode, hooks))
 
-      w = layer_param(layer_params, "kernel", params[name], compute)
+      w = get_param(params, layer_name, "kernel", w_frz, compute)
 
       b =
         if use_bias do
-          layer_param(layer_params, "bias", params[name], compute)
+          get_param(params, layer_name, "bias", b_frz, compute)
         else
           Nx.tensor(0.0, type: compute)
         end
@@ -379,7 +387,7 @@ defmodule Axon.Compiler do
         |> apply_hooks(:forward, mode, hooks)
         |> apply_hooks(:backward, mode, hooks)
 
-      {res, state}
+      {res, {state, result_cache}}
     end
 
     {id, {Map.put(cache, id, fun), op_counts}}
@@ -405,20 +413,22 @@ defmodule Axon.Compiler do
         &to_predict_fun(&1, &2, mode)
       )
 
-    name = name_fn.(:bias, op_counts)
+    layer_name = name_fn.(:bias, op_counts)
     op_counts = Map.update(op_counts, :bias, 1, fn x -> x + 1 end)
 
-    fun = fn params, inputs, state, cache ->
-      {inputs, state} =
+    %{frozen: b_frz} = layer_params["bias"]
+
+    fun = fn params, inputs, state, cache, result_cache ->
+      {res, {state, result_cache}} =
         parent_ids
-        |> Enum.map_reduce(state, fn parent_id, state ->
-          call_cache(parent_id, params, inputs, state, cache)
+        |> Enum.map_reduce({state, result_cache}, fn parent_id, {state, result_cache} ->
+          call_cache(parent_id, params, inputs, state, cache, result_cache)
         end)
 
-      b = layer_param(layer_params, "bias", params[name], compute)
+      b = get_param(params, layer_name, "bias", b_frz, compute)
 
       inputs =
-        inputs
+        res
         |> Enum.map(&safe_as_type(&1, compute))
         |> Enum.map(&apply_hooks(&1, :pre_forward, mode, hooks))
 
@@ -431,7 +441,7 @@ defmodule Axon.Compiler do
         |> apply_hooks(:forward, mode, hooks)
         |> apply_hooks(:backward, mode, hooks)
 
-      {res, state}
+      {res, {state, result_cache}}
     end
 
     {id, {Map.put(cache, id, fun), op_counts}}
@@ -454,13 +464,16 @@ defmodule Axon.Compiler do
        ) do
     {parent_id, {cache, op_counts}} = to_predict_fun(parent, cache_and_counts, mode)
 
-    name = name_fn.(:embedding, op_counts)
+    layer_name = name_fn.(:embedding, op_counts)
     op_counts = Map.update(op_counts, :embedding, 1, fn x -> x + 1 end)
 
-    fun = fn params, inputs, state, cache ->
-      {res, state} = call_cache(parent_id, params, inputs, state, cache)
+    %{frozen: w_frz} = layer_params["kernel"]
 
-      w = layer_param(layer_params, "kernel", params[name], compute)
+    fun = fn params, inputs, state, cache, result_cache ->
+      {res, {state, result_cache}} =
+        call_cache(parent_id, params, inputs, state, cache, result_cache)
+
+      w = get_param(params, layer_name, "kernel", w_frz, compute)
 
       res =
         res
@@ -471,7 +484,7 @@ defmodule Axon.Compiler do
         |> apply_hooks(:forward, :inference, hooks)
         |> apply_hooks(:backward, :inference, hooks)
 
-      {res, state}
+      {res, {state, result_cache}}
     end
 
     {id, {Map.put(cache, id, fun), op_counts}}
@@ -500,8 +513,9 @@ defmodule Axon.Compiler do
 
     op_counts = Map.update(op_counts, op, 1, fn x -> x + 1 end)
 
-    fun = fn params, inputs, state, cache ->
-      {res, state} = call_cache(parent_id, params, inputs, state, cache)
+    fun = fn params, inputs, state, cache, result_cache ->
+      {res, {state, result_cache}} =
+        call_cache(parent_id, params, inputs, state, cache, result_cache)
 
       res =
         res
@@ -512,7 +526,7 @@ defmodule Axon.Compiler do
         |> apply_hooks(:forward, :inference, hooks)
         |> apply_hooks(:backward, :inference, hooks)
 
-      {res, state}
+      {res, {state, result_cache}}
     end
 
     {id, {Map.put(cache, id, fun), op_counts}}
@@ -539,8 +553,9 @@ defmodule Axon.Compiler do
 
     op_counts = Map.update(op_counts, op, 1, fn x -> x + 1 end)
 
-    fun = fn params, inputs, state, cache ->
-      {inputs, state} = call_cache(parent_id, params, inputs, state, cache)
+    fun = fn params, inputs, state, cache, result_cache ->
+      {inputs, {state, result_cache}} =
+        call_cache(parent_id, params, inputs, state, cache, result_cache)
 
       res =
         case mode do
@@ -558,7 +573,7 @@ defmodule Axon.Compiler do
             safe_as_type(inputs, output)
         end
 
-      {res, state}
+      {res, {state, result_cache}}
     end
 
     {id, {Map.put(cache, id, fun), op_counts}}
@@ -584,17 +599,22 @@ defmodule Axon.Compiler do
     op_counts = Map.update(op_counts, :separable_conv2d, 1, fn x -> x + 1 end)
 
     {use_bias, opts} = Keyword.pop!(opts, :use_bias)
+    %{frozen: k1_frz} = layer_params["k1"]
+    %{frozen: k2_frz} = layer_params["k2"]
+    %{frozen: b1_frz} = if use_bias, do: layer_params["b1"], else: %{frozen: false}
+    %{frozen: b2_frz} = if use_bias, do: layer_params["b2"], else: %{frozen: false}
 
-    fun = fn params, inputs, state, cache ->
-      {inputs, state} = call_cache(parent_id, params, inputs, state, cache)
+    fun = fn params, inputs, state, cache, result_cache ->
+      {inputs, {state, result_cache}} =
+        call_cache(parent_id, params, inputs, state, cache, result_cache)
 
-      k1 = layer_param(layer_params, "k1", params[name], compute)
-      k2 = layer_param(layer_params, "k2", params[name], compute)
+      k1 = get_param(params, name, "kernel_1", k1_frz, compute)
+      k2 = get_param(params, name, "kernel_2", k2_frz, compute)
 
       {b1, b2} =
         if use_bias do
-          {layer_param(layer_params, "b1", params[name], compute),
-           layer_param(layer_params, "b2", params[name], compute)}
+          {get_param(params, name, "bias_1", b1_frz, compute),
+           get_param(params, name, "bias_2", b2_frz, compute)}
         else
           {Nx.tensor(0, type: compute), Nx.tensor(0, type: compute)}
         end
@@ -608,7 +628,7 @@ defmodule Axon.Compiler do
         |> apply_hooks(:forward, mode, hooks)
         |> apply_hooks(:backward, mode, hooks)
 
-      {res, state}
+      {res, {state, result_cache}}
     end
 
     {id, {Map.put(cache, id, fun), op_counts}}
@@ -635,18 +655,26 @@ defmodule Axon.Compiler do
 
     {use_bias, opts} = Keyword.pop!(opts, :use_bias)
 
-    fun = fn params, inputs, state, cache ->
-      {inputs, state} = call_cache(parent_id, params, inputs, state, cache)
+    %{frozen: k1_frz} = layer_params["k1"]
+    %{frozen: k2_frz} = layer_params["k2"]
+    %{frozen: k3_frz} = layer_params["k3"]
+    %{frozen: b1_frz} = if use_bias, do: layer_params["b1"], else: %{frozen: false}
+    %{frozen: b2_frz} = if use_bias, do: layer_params["b2"], else: %{frozen: false}
+    %{frozen: b3_frz} = if use_bias, do: layer_params["b3"], else: %{frozen: false}
 
-      k1 = layer_param(layer_params, "k1", params[name], compute)
-      k2 = layer_param(layer_params, "k2", params[name], compute)
-      k3 = layer_param(layer_params, "k3", params[name], compute)
+    fun = fn params, inputs, state, cache, result_cache ->
+      {inputs, {state, result_cache}} =
+        call_cache(parent_id, params, inputs, state, cache, result_cache)
+
+      k1 = get_param(params, name, "kernel_1", k1_frz, compute)
+      k2 = get_param(params, name, "kernel_2", k2_frz, compute)
+      k3 = get_param(params, name, "kernel_3", k3_frz, compute)
 
       {b1, b2, b3} =
         if use_bias do
-          {layer_param(layer_params, "b1", params[name], compute),
-           layer_param(layer_params, "b2", params[name], compute),
-           layer_param(layer_params, "b3", params[name], compute)}
+          {get_param(params, name, "bias_1", b1_frz, compute),
+           get_param(params, name, "bias_2", b2_frz, compute),
+           get_param(params, name, "bias_3", b3_frz, compute)}
         else
           {Nx.tensor(0, type: compute), Nx.tensor(0, type: compute), Nx.tensor(0, type: compute)}
         end
@@ -660,7 +688,7 @@ defmodule Axon.Compiler do
         |> apply_hooks(:forward, mode, hooks)
         |> apply_hooks(:backward, mode, hooks)
 
-      {res, state}
+      {res, {state, result_cache}}
     end
 
     {id, {Map.put(cache, id, fun), op_counts}}
@@ -699,13 +727,19 @@ defmodule Axon.Compiler do
       training?: training?
     ]
 
-    fun = fn params, inputs, state, cache ->
-      {inputs, state} = call_cache(parent_id, params, inputs, state, cache)
+    %{frozen: g_frz} = layer_params["gamma"]
+    %{frozen: b_frz} = layer_params["beta"]
+    %{frozen: mean_frz} = layer_params["mean"]
+    %{frozen: var_frz} = layer_params["var"]
 
-      g = layer_param(layer_params, "gamma", params[name], compute)
-      b = layer_param(layer_params, "beta", params[name], compute)
-      mean = layer_param(layer_params, "mean", params[name], compute)
-      var = layer_param(layer_params, "var", params[name], compute)
+    fun = fn params, inputs, state, cache, result_cache ->
+      {inputs, {state, result_cache}} =
+        call_cache(parent_id, params, inputs, state, cache, result_cache)
+
+      g = get_param(params, name, "gamma", g_frz, compute)
+      b = get_param(params, name, "beta", b_frz, compute)
+      mean = get_param(params, name, "mean", mean_frz, compute)
+      var = get_param(params, name, "var", var_frz, compute)
 
       case mode do
         :train ->
@@ -721,7 +755,7 @@ defmodule Axon.Compiler do
           res = safe_as_type(out, output)
           state = Map.put(state, name, %{"mean" => ra_mean, "var" => ra_var})
 
-          {res, state}
+          {res, {state, result_cache}}
 
         :inference ->
           res =
@@ -733,7 +767,7 @@ defmodule Axon.Compiler do
             |> apply_hooks(:forward, :inference, hooks)
             |> apply_hooks(:backward, :inference, hooks)
 
-          {res, state}
+          {res, {state, result_cache}}
       end
     end
 
@@ -762,11 +796,15 @@ defmodule Axon.Compiler do
     name = name_fn.(op, op_counts)
     op_counts = Map.update(op_counts, op, 1, fn x -> x + 1 end)
 
-    fun = fn params, inputs, state, cache ->
-      {inputs, state} = call_cache(parent_id, params, inputs, state, cache)
+    %{frozen: g_frz} = layer_params["gamma"]
+    %{frozen: b_frz} = layer_params["beta"]
 
-      g = layer_param(layer_params, "gamma", params[name], compute)
-      b = layer_param(layer_params, "beta", params[name], compute)
+    fun = fn params, inputs, state, cache, result_cache ->
+      {inputs, {state, result_cache}} =
+        call_cache(parent_id, params, inputs, state, cache, result_cache)
+
+      g = get_param(params, name, "gamma", g_frz, compute)
+      b = get_param(params, name, "beta", b_frz, compute)
 
       res =
         inputs
@@ -777,7 +815,7 @@ defmodule Axon.Compiler do
         |> apply_hooks(:forward, mode, hooks)
         |> apply_hooks(:backward, mode, hooks)
 
-      {res, state}
+      {res, {state, result_cache}}
     end
 
     {id, {Map.put(cache, id, fun), op_counts}}
@@ -815,17 +853,45 @@ defmodule Axon.Compiler do
     name = name_fn.(op, op_counts)
     op_counts = Map.update(op_counts, op, 1, fn x -> x + 1 end)
 
-    fun = fn params, inputs, state, cache ->
-      {input, state} = call_cache(input_id, params, inputs, state, cache)
+    input_kernel = layer_params["input_kernel"]
+    hidden_kernel = layer_params["hidden_kernel"]
 
-      {hidden_state, state} = call_cache(hidden_state_id, params, inputs, state, cache)
+    bias =
+      if use_bias,
+        do: layer_params["bias"],
+        else: List.to_tuple(List.duplicate(%{frozen: false}, num_bias))
 
-      input_kernel = layer_param(layer_params, "input_kernel", params[name], compute)
-      hidden_kernel = layer_param(layer_params, "hidden_kernel", params[name], compute)
+    input_kernel_frozen =
+      input_kernel
+      |> Tuple.to_list()
+      |> Enum.map(fn %{frozen: frz} -> frz end)
+      |> List.to_tuple()
+
+    hidden_kernel_frozen =
+      hidden_kernel
+      |> Tuple.to_list()
+      |> Enum.map(fn %{frozen: frz} -> frz end)
+      |> List.to_tuple()
+
+    bias_frozen =
+      bias
+      |> Tuple.to_list()
+      |> Enum.map(fn %{frozen: frz} -> frz end)
+      |> List.to_tuple()
+
+    fun = fn params, inputs, state, cache, result_cache ->
+      {input, {state, result_cache}} =
+        call_cache(input_id, params, inputs, state, cache, result_cache)
+
+      {hidden_state, {state, result_cache}} =
+        call_cache(hidden_state_id, params, inputs, state, cache, result_cache)
+
+      input_kernel = get_param(params, name, "input_kernel", input_kernel_frozen, compute)
+      hidden_kernel = get_param(params, name, "hidden_kernel", hidden_kernel_frozen, compute)
 
       bias =
         if use_bias do
-          layer_param(layer_params, "bias", params[name], compute)
+          get_param(params, name, "bias", bias_frozen, compute)
         else
           List.duplicate(Nx.tensor(0, type: compute), num_bias)
           |> List.to_tuple()
@@ -866,7 +932,7 @@ defmodule Axon.Compiler do
       res = apply_hooks(res, :forward, mode, hooks)
       res = apply_hooks(res, :backward, mode, hooks)
 
-      {res, state}
+      {res, {state, result_cache}}
     end
 
     {id, {Map.put(cache, id, fun), op_counts}}
@@ -897,10 +963,10 @@ defmodule Axon.Compiler do
 
     op_counts = Map.update(op_counts, op, 1, fn x -> x + 1 end)
 
-    fun = fn params, inputs, state, cache ->
-      {[expr | exprs], state} =
-        Enum.map_reduce(parent_ids, state, fn parent_id, state ->
-          call_cache(parent_id, params, inputs, state, cache)
+    fun = fn params, inputs, state, cache, result_cache ->
+      {[expr | exprs], {state, result_cache}} =
+        Enum.map_reduce(parent_ids, {state, result_cache}, fn parent_id, {state, result_cache} ->
+          call_cache(parent_id, params, inputs, state, cache, result_cache)
         end)
 
       [expr | exprs] =
@@ -919,7 +985,7 @@ defmodule Axon.Compiler do
       res = apply_hooks(res, :forward, mode, hooks)
       res = apply_hooks(res, :backward, mode, hooks)
 
-      {res, state}
+      {res, {state, result_cache}}
     end
 
     {id, {Map.put(cache, id, fun), op_counts}}
@@ -960,8 +1026,9 @@ defmodule Axon.Compiler do
           opts
       end
 
-    fun = fn params, inputs, state, cache ->
-      {res, state} = call_cache(parent_id, params, inputs, state, cache)
+    fun = fn params, inputs, state, cache, result_cache ->
+      {res, {state, result_cache}} =
+        call_cache(parent_id, params, inputs, state, cache, result_cache)
 
       res =
         res
@@ -972,7 +1039,7 @@ defmodule Axon.Compiler do
         |> apply_hooks(:backward, mode, hooks)
         |> safe_as_type(output)
 
-      {res, state}
+      {res, {state, result_cache}}
     end
 
     {id, {Map.put(cache, id, fun), op_counts}}
@@ -999,10 +1066,10 @@ defmodule Axon.Compiler do
 
     op_counts = Map.update(op_counts, :concatenate, 1, fn x -> x + 1 end)
 
-    fun = fn params, inputs, state, cache ->
-      {exprs, state} =
-        Enum.map_reduce(parent_ids, state, fn parent_id, state ->
-          call_cache(parent_id, params, inputs, state, cache)
+    fun = fn params, inputs, state, cache, result_cache ->
+      {exprs, {state, result_cache}} =
+        Enum.map_reduce(parent_ids, {state, result_cache}, fn parent_id, {state, result_cache} ->
+          call_cache(parent_id, params, inputs, state, cache, result_cache)
         end)
 
       inps = Enum.map(exprs, &safe_as_type(&1, compute))
@@ -1020,7 +1087,7 @@ defmodule Axon.Compiler do
         |> apply_hooks(:forward, mode, hooks)
         |> apply_hooks(:backward, mode, hooks)
 
-      {res, state}
+      {res, {state, result_cache}}
     end
 
     {id, {Map.put(cache, id, fun), op_counts}}
@@ -1047,10 +1114,10 @@ defmodule Axon.Compiler do
 
     op_counts = Map.update(op_counts, :cond, 1, fn x -> x + 1 end)
 
-    fun = fn params, inputs, state, cache ->
-      {exprs, state} =
-        Enum.map_reduce(parent_ids, state, fn parent_id, state ->
-          call_cache(parent_id, params, inputs, state, cache)
+    fun = fn params, inputs, state, cache, result_cache ->
+      {exprs, {state, result_cache}} =
+        Enum.map_reduce(parent_ids, {state, result_cache}, fn parent_id, {state, result_cache} ->
+          call_cache(parent_id, params, inputs, state, cache, result_cache)
         end)
 
       [cond_input_expr, true_expr, false_expr] = exprs
@@ -1081,7 +1148,7 @@ defmodule Axon.Compiler do
       res = safe_as_type(res, output)
       res = apply_hooks(res, :forward, mode, hooks)
       res = apply_hooks(res, :backward, mode, hooks)
-      {res, state}
+      {res, {state, result_cache}}
     end
 
     {id, {Map.put(cache, id, fun), op_counts}}
@@ -1105,8 +1172,9 @@ defmodule Axon.Compiler do
 
     op_counts = Map.update(op_counts, :nx, 1, fn x -> x + 1 end)
 
-    fun = fn params, inputs, state, cache ->
-      {res, state} = call_cache(parent_id, params, inputs, state, cache)
+    fun = fn params, inputs, state, cache, result_cache ->
+      {res, {state, result_cache}} =
+        call_cache(parent_id, params, inputs, state, cache, result_cache)
 
       res =
         res
@@ -1117,7 +1185,7 @@ defmodule Axon.Compiler do
         |> apply_hooks(:forward, mode, hooks)
         |> apply_hooks(:backward, mode, hooks)
 
-      {res, state}
+      {res, {state, result_cache}}
     end
 
     {id, {Map.put(cache, id, fun), op_counts}}
@@ -1128,9 +1196,9 @@ defmodule Axon.Compiler do
          {cache, op_counts},
          _
        ) do
-    fun = fn _params, _inputs, state, _cache ->
+    fun = fn _params, _inputs, state, _cache, result_cache ->
       out = safe_as_type(tensor, output)
-      {out, state}
+      {out, {state, result_cache}}
     end
 
     op_counts = Map.update(op_counts, :constant, 1, fn x -> x + 1 end)
@@ -1146,7 +1214,7 @@ defmodule Axon.Compiler do
     name = name_fn.(:input, op_counts)
     op_counts = Map.update(op_counts, :input, 1, fn x -> x + 1 end)
 
-    fun = fn _params, inputs, state, _cache ->
+    fun = fn _params, inputs, state, _cache, result_cache ->
       res =
         case inputs do
           %Nx.Tensor{} = inputs ->
@@ -1181,7 +1249,7 @@ defmodule Axon.Compiler do
         |> apply_hooks(:forward, mode, hooks)
         |> apply_hooks(:backward, mode, hooks)
 
-      {res, state}
+      {res, {state, result_cache}}
     end
 
     {id, {Map.put(cache, id, fun), op_counts}}
@@ -1231,19 +1299,19 @@ defmodule Axon.Compiler do
     end
   end
 
-  defp layer_param(layer_params, key, param_name, compute) do
-    case layer_params[key] do
-      %{name: p, frozen: frozen} ->
-        safe_as_type(maybe_freeze(param_name[p], frozen), compute)
-
-      params when is_tuple(params) ->
-        params
+  defp get_param(params, layer_name, param_name, frozen?, type) do
+    case params[layer_name][param_name] do
+      tuple when is_tuple(tuple) ->
+        tuple
         |> Tuple.to_list()
-        |> Enum.with_index(fn param, i ->
-          %{frozen: frozen} = param
-          safe_as_type(maybe_freeze(elem(param_name[key], i), frozen), compute)
-        end)
+        |> Enum.zip_with(Tuple.to_list(frozen?), &maybe_freeze/2)
         |> List.to_tuple()
+        |> safe_as_type(type)
+
+      param ->
+        param
+        |> maybe_freeze(frozen?)
+        |> safe_as_type(type)
     end
   end
 

--- a/lib/axon/layers.ex
+++ b/lib/axon/layers.ex
@@ -813,7 +813,14 @@ defmodule Axon.Layers do
     opts =
       keyword!(
         opts,
-        [:kernel_size, strides: nil, padding: :valid, window_dilations: 1, channels: :first, mode: :inference]
+        [
+          :kernel_size,
+          strides: nil,
+          padding: :valid,
+          window_dilations: 1,
+          channels: :first,
+          mode: :inference
+        ]
       )
 
     window_dimensions =
@@ -1190,10 +1197,11 @@ defmodule Axon.Layers do
   defn batch_norm(input, gamma, beta, ra_mean, ra_var, opts \\ []) do
     opts = keyword!(opts, epsilon: 1.0e-5, channel_index: 1, momentum: 0.1, mode: :inference)
 
-    training? = transform(opts[:mode], fn
-      :inference -> false
-      :train -> true
-    end)
+    training? =
+      transform(opts[:mode], fn
+        :inference -> false
+        :train -> true
+      end)
 
     axes =
       transform({Nx.axes(input), opts[:channel_index]}, fn {axes, channel} ->
@@ -1223,8 +1231,7 @@ defmodule Axon.Layers do
       )
 
     transform(
-      {input, gamma, beta, ra_mean, ra_var, axes, opts[:epsilon], opts[:momentum],
-       training?},
+      {input, gamma, beta, ra_mean, ra_var, axes, opts[:epsilon], opts[:momentum], training?},
       fn
         {x, g, b, m, v, axes, eps, alpha, true} ->
           {new_mean, new_var} = mean_and_variance(x, axes: axes)
@@ -1387,10 +1394,11 @@ defmodule Axon.Layers do
   defn instance_norm(input, gamma, beta, ra_mean, ra_var, opts \\ []) do
     opts = keyword!(opts, epsilon: 1.0e-5, channel_index: 1, momentum: 0.1, mode: :inference)
 
-    training? = transform(opts[:mode], fn
-      :inference -> false
-      :train -> true
-    end)
+    training? =
+      transform(opts[:mode], fn
+        :inference -> false
+        :train -> true
+      end)
 
     axes =
       transform({Nx.axes(input), opts[:channel_index]}, fn {axes, channel} ->
@@ -1420,8 +1428,7 @@ defmodule Axon.Layers do
       )
 
     transform(
-      {input, gamma, beta, ra_mean, ra_var, axes, opts[:epsilon], opts[:momentum],
-       training?},
+      {input, gamma, beta, ra_mean, ra_var, axes, opts[:epsilon], opts[:momentum], training?},
       fn
         {x, g, b, m, v, axes, eps, alpha, true} ->
           {new_mean, new_var} = mean_and_variance(x, axes: axes)
@@ -1969,10 +1976,11 @@ defmodule Axon.Layers do
     transform(cond_expr, fn cond_expr ->
       cond_rank = Nx.rank(cond_expr)
       cond_type = Nx.type(cond_expr)
+
       unless Elixir.Kernel.and(
-          Elixir.Kernel.==(cond_rank, 0),
-          Elixir.Kernel.==(cond_type, {:u, 8})
-        ) do
+               Elixir.Kernel.==(cond_rank, 0),
+               Elixir.Kernel.==(cond_type, {:u, 8})
+             ) do
         raise ArgumentError,
               "cond_fn must return a scalar-boolean tensor" <>
                 " got result with rank #{inspect(cond_rank)} and" <>
@@ -2067,7 +2075,14 @@ defmodule Axon.Layers do
   defn resize(input, opts \\ []) do
     assert_min_rank!("Axon.Layers.resize", "input", input, 3)
 
-    opts = keyword!(opts, [:shape, method: :nearest, channels: :first, align_corners: false, mode: :inference])
+    opts =
+      keyword!(opts, [
+        :shape,
+        method: :nearest,
+        channels: :first,
+        align_corners: false,
+        mode: :inference
+      ])
 
     output_shape = opts[:shape]
 
@@ -2328,9 +2343,9 @@ defmodule Axon.Layers do
   # Private Axon.Layers implementation of activations for the compiler
   # to use when invoking activation layers.
   @activation_layers [:celu, :elu, :exp, :gelu, :hard_sigmoid, :hard_silu, :hard_tanh] ++
-                     [:leaky_relu, :linear, :log_sigmoid, :mish, :relu, :relu6] ++
-                     [:sigmoid, :silu, :selu, :softmax, :softplus, :softsign, :tanh] ++
-                     [:log_softmax]
+                       [:leaky_relu, :linear, :log_sigmoid, :mish, :relu, :relu6] ++
+                       [:sigmoid, :silu, :selu, :softmax, :softplus, :softsign, :tanh] ++
+                       [:log_softmax]
 
   for activation <- @activation_layers do
     @doc false
@@ -2348,6 +2363,7 @@ defmodule Axon.Layers do
     defn unquote(op)(inputs, opts \\ []) do
       transform(inputs, fn inputs ->
         [first | rest] = Tuple.to_list(inputs)
+
         Enum.reduce(rest, first, fn next, acc ->
           apply(Nx, unquote(op), [acc, next])
         end)

--- a/lib/axon/layers.ex
+++ b/lib/axon/layers.ex
@@ -102,20 +102,8 @@ defmodule Axon.Layers do
       >
   """
   @doc type: :linear
-  defn dense(input, kernel, bias \\ 0, _opts \\ []) do
+  defn dense(input, kernel, bias, _opts \\ []) do
     assert_min_rank!("Axon.Layers.dense", "input", input, 2)
-
-    bias =
-      transform(bias, fn
-        [] ->
-          0
-
-        [_ | _] ->
-          0
-
-        bias ->
-          bias
-      end)
 
     input
     |> Nx.dot([Nx.rank(input) - 1], kernel, [0])
@@ -156,23 +144,11 @@ defmodule Axon.Layers do
       >
   """
   @doc type: :linear
-  defn bilinear(input1, input2, kernel, bias \\ 0, _opts \\ []) do
+  defn bilinear(input1, input2, kernel, bias, _opts \\ []) do
     assert_min_rank!("Axon.Layers.bilinear", "input1", input1, 2)
     assert_min_rank!("Axon.Layers.bilinear", "input2", input2, 2)
     assert_equal_rank!("Axon.Layers.bilinear", "input1", input1, "input2", input2)
     assert_rank!("Axon.Layers.bilinear", "kernel", kernel, 3)
-
-    bias =
-      transform(bias, fn
-        [] ->
-          0
-
-        [_ | _] ->
-          0
-
-        bias ->
-          bias
-      end)
 
     inp1_axes = transform(Nx.rank(input1), fn rank -> [rank - 1] end)
     inp2_axes = transform(Nx.rank(input2), fn rank -> [rank - 1] end)
@@ -306,21 +282,9 @@ defmodule Axon.Layers do
       >
   """
   @doc type: :convolutional
-  defn conv(input, kernel, bias \\ 0, opts \\ []) do
+  defn conv(input, kernel, bias, opts \\ []) do
     assert_min_rank!("Axon.Layers.conv", "input", input, 3)
     assert_equal_rank!("Axon.Layers.conv", "input", input, "kernel", kernel)
-
-    {bias, opts} =
-      transform({bias, opts}, fn
-        {%Nx.Tensor{} = bias, opts} ->
-          {bias, opts}
-
-        {[_ | _] = opts, _opts} ->
-          {0, opts}
-
-        {bias, opts} ->
-          {bias, opts}
-      end)
 
     opts =
       keyword!(opts,
@@ -432,7 +396,7 @@ defmodule Axon.Layers do
     * [Deconvolutional Networks](https://www.matthewzeiler.com/mattzeiler/deconvolutionalnetworks.pdf)
   """
   @doc type: :convolutional
-  defn conv_transpose(input, kernel, bias \\ 0, opts \\ []) do
+  defn conv_transpose(input, kernel, bias, opts \\ []) do
     assert_min_rank!("Axon.Layers.conv_transpose", "input", input, 3)
     assert_equal_rank!("Axon.Layers.conv_transpose", "input", input, "kernel", kernel)
 
@@ -518,7 +482,7 @@ defmodule Axon.Layers do
 
   """
   @doc type: :convolutional
-  defn depthwise_conv(input, kernel, bias \\ 0, opts \\ []) do
+  defn depthwise_conv(input, kernel, bias, opts \\ []) do
     assert_min_rank!("Axon.Layers.depthwise_conv", "input", input, 3)
     assert_equal_rank!("Axon.Layers.depthwise_conv", "input", input, "kernel", kernel)
 

--- a/lib/axon/layers.ex
+++ b/lib/axon/layers.ex
@@ -2397,11 +2397,14 @@ defmodule Axon.Layers do
   end
 
   @activation_layers_with_opts [:celu, :elu, :hard_sigmoid, :hard_silu, :leaky_relu] ++
-                                  [:log_softmax, :selu, :softmax]
+                                 [:log_softmax, :selu, :softmax]
   for activation <- @activation_layers_with_opts do
     defn unquote(activation)(input, opts \\ []) do
       transform(input, fn inp ->
-        Elixir.Kernel.apply(Axon.Activations, unquote(activation), [inp, Keyword.delete(opts, :mode)])
+        Elixir.Kernel.apply(Axon.Activations, unquote(activation), [
+          inp,
+          Keyword.delete(opts, :mode)
+        ])
       end)
     end
   end

--- a/lib/axon/layers.ex
+++ b/lib/axon/layers.ex
@@ -102,8 +102,20 @@ defmodule Axon.Layers do
       >
   """
   @doc type: :linear
-  defn dense(input, kernel, bias, _opts \\ []) do
+  defn dense(input, kernel, bias \\ 0, _opts \\ []) do
     assert_min_rank!("Axon.Layers.dense", "input", input, 2)
+
+    bias =
+      transform(bias, fn
+        [] ->
+          0
+
+        [_ | _] ->
+          0
+
+        bias ->
+          bias
+      end)
 
     input
     |> Nx.dot([Nx.rank(input) - 1], kernel, [0])
@@ -144,11 +156,23 @@ defmodule Axon.Layers do
       >
   """
   @doc type: :linear
-  defn bilinear(input1, input2, kernel, bias, _opts \\ []) do
+  defn bilinear(input1, input2, kernel, bias \\ 0, _opts \\ []) do
     assert_min_rank!("Axon.Layers.bilinear", "input1", input1, 2)
     assert_min_rank!("Axon.Layers.bilinear", "input2", input2, 2)
     assert_equal_rank!("Axon.Layers.bilinear", "input1", input1, "input2", input2)
     assert_rank!("Axon.Layers.bilinear", "kernel", kernel, 3)
+
+    bias =
+      transform(bias, fn
+        [] ->
+          0
+
+        [_ | _] ->
+          0
+
+        bias ->
+          bias
+      end)
 
     inp1_axes = transform(Nx.rank(input1), fn rank -> [rank - 1] end)
     inp2_axes = transform(Nx.rank(input2), fn rank -> [rank - 1] end)
@@ -157,11 +181,6 @@ defmodule Axon.Layers do
     |> Nx.dot(inp1_axes, [], kernel, [1], [])
     |> Nx.dot([2], [0], input2, inp2_axes, [0])
     |> Nx.add(bias)
-  end
-
-  @doc false
-  defn bilinear(input1, input2, kernel) do
-    bilinear(input1, input2, kernel, 0)
   end
 
   ## Convolutional
@@ -287,9 +306,21 @@ defmodule Axon.Layers do
       >
   """
   @doc type: :convolutional
-  defn conv(input, kernel, bias, opts \\ []) do
+  defn conv(input, kernel, bias \\ 0, opts \\ []) do
     assert_min_rank!("Axon.Layers.conv", "input", input, 3)
     assert_equal_rank!("Axon.Layers.conv", "input", input, "kernel", kernel)
+
+    {bias, opts} =
+      transform({bias, opts}, fn
+        {%Nx.Tensor{} = bias, opts} ->
+          {bias, opts}
+
+        {[_ | _] = opts, _opts} ->
+          {0, opts}
+
+        {bias, opts} ->
+          {bias, opts}
+      end)
 
     opts =
       keyword!(opts,
@@ -1238,7 +1269,11 @@ defmodule Axon.Layers do
           out = normalize(x, new_mean, new_var, g, b, epsilon: eps)
           ra_mean = update_ema(new_mean, m, alpha)
           ra_var = update_ema(new_var, v, alpha)
-          {out, %{"ra_mean" => ra_mean, "ra_var" => ra_var}}
+
+          %Axon.StatefulOutput{
+            output: out,
+            state: %{"mean" => ra_mean, "var" => ra_var}
+          }
 
         {x, g, b, m, v, _, eps, _, _} ->
           normalize(x, m, v, g, b, epsilon: eps)
@@ -1433,7 +1468,13 @@ defmodule Axon.Layers do
         {x, g, b, m, v, axes, eps, alpha, true} ->
           {new_mean, new_var} = mean_and_variance(x, axes: axes)
           out = normalize(x, new_mean, new_var, g, b, epsilon: eps)
-          {out, update_ema(new_mean, m, alpha), update_ema(new_var, v, alpha)}
+          ra_mean = update_ema(new_mean, m, alpha)
+          ra_var = update_ema(new_var, v, alpha)
+
+          %Axon.StatefulOutput{
+            output: out,
+            state: %{"mean" => ra_mean, "var" => ra_var}
+          }
 
         {x, g, b, m, v, _, eps, _, _} ->
           normalize(x, m, v, g, b, epsilon: eps)
@@ -1885,7 +1926,7 @@ defmodule Axon.Layers do
   """
   defn embedding(input, kernel, _opts \\ []) do
     assert_rank!("Axon.Layers.embedding", "kernel", kernel, 2)
-    Nx.take(kernel, input, axis: 0)
+    Nx.take(kernel, Nx.as_type(input, {:s, 64}), axis: 0)
   end
 
   ## Shape
@@ -1919,9 +1960,9 @@ defmodule Axon.Layers do
   # Internal version of Nx.reshape for constructing reshape layers
   # without worrying about a batch dimension
   defn reshape(x, opts \\ []) do
-    opts = keyword!(opts, [:shape, ignore_batch?: true, mode: :inference])
+    opts = keyword!(opts, [:to, ignore_batch?: true, mode: :inference])
 
-    transform({opts[:shape], opts[:ignore_batch?]}, fn
+    transform({opts[:to], opts[:ignore_batch?]}, fn
       {shape, true} ->
         Nx.reshape(x, put_elem(shape, 0, elem(Nx.shape(x), 0)))
 
@@ -1997,7 +2038,7 @@ defmodule Axon.Layers do
 
   @doc false
   # Internal helper for constructing bias layers without
-  defn bias(input, bias) do
+  defn bias(input, bias, _opts \\ []) do
     input + bias
   end
 
@@ -2005,7 +2046,7 @@ defmodule Axon.Layers do
   Resizes a batch of tensors to the given shape using one of a
   number of sampling methods.
 
-  Requires input option `:shape` which should be a tuple specifying
+  Requires input option `:to` which should be a tuple specifying
   the resized spatial dimensions of the input tensor. Input tensor
   must be at least rank 3, with fixed `batch` and `channel` dimensions.
   Resizing will upsample or downsample using the given resize method.
@@ -2016,7 +2057,7 @@ defmodule Axon.Layers do
   ## Examples
 
       iex> img = Nx.iota({1, 1, 3, 3}, type: {:f, 32})
-      iex> Axon.Layers.resize(img, shape: {4, 4})
+      iex> Axon.Layers.resize(img, to: {4, 4})
       #Nx.Tensor<
         f32[1][1][4][4]
         [
@@ -2032,7 +2073,7 @@ defmodule Axon.Layers do
       >
 
       iex> img = Nx.iota({1, 1, 3}, type: {:f, 32})
-      iex> Axon.Layers.resize(img, shape: {2})
+      iex> Axon.Layers.resize(img, to: {2})
       #Nx.Tensor<
         f32[1][1][2]
         [
@@ -2043,7 +2084,7 @@ defmodule Axon.Layers do
       >
 
       iex> img = Nx.iota({1, 2, 2, 2, 1}, type: {:f, 32})
-      iex> Axon.Layers.resize(img, shape: {1, 3, 2})
+      iex> Axon.Layers.resize(img, to: {1, 3, 2})
       #Nx.Tensor<
         f32[1][2][1][3][2]
         [
@@ -2069,7 +2110,7 @@ defmodule Axon.Layers do
   ### Error cases
 
       iex> img = Nx.iota({1, 1, 3, 3}, type: {:f, 32})
-      iex> Axon.Layers.resize(img, shape: {4, 4}, method: :foo)
+      iex> Axon.Layers.resize(img, to: {4, 4}, method: :foo)
       ** (ArgumentError) invalid resize method :foo, resize method must be one of :nearest
   """
   defn resize(input, opts \\ []) do
@@ -2077,14 +2118,14 @@ defmodule Axon.Layers do
 
     opts =
       keyword!(opts, [
-        :shape,
+        :to,
         method: :nearest,
         channels: :first,
         align_corners: false,
         mode: :inference
       ])
 
-    output_shape = opts[:shape]
+    output_shape = opts[:to]
 
     spatial_dimensions =
       transform({Nx.rank(input), opts[:channels]}, fn
@@ -2342,15 +2383,26 @@ defmodule Axon.Layers do
 
   # Private Axon.Layers implementation of activations for the compiler
   # to use when invoking activation layers.
-  @activation_layers [:celu, :elu, :exp, :gelu, :hard_sigmoid, :hard_silu, :hard_tanh] ++
-                       [:leaky_relu, :linear, :log_sigmoid, :mish, :relu, :relu6] ++
-                       [:sigmoid, :silu, :selu, :softmax, :softplus, :softsign, :tanh] ++
-                       [:log_softmax]
+  @activation_layers [:exp, :gelu, :hard_tanh, :linear, :log_sigmoid] ++
+                       [:mish, :relu, :relu6, :sigmoid, :silu, :softplus] ++
+                       [:softsign, :tanh]
 
   for activation <- @activation_layers do
     @doc false
-    def unquote(activation)(input, _opts \\ []) do
-      apply(Axon.Activations, unquote(activation), [input])
+    defn unquote(activation)(input, _opts \\ []) do
+      transform(input, fn inp ->
+        Elixir.Kernel.apply(Axon.Activations, unquote(activation), [inp])
+      end)
+    end
+  end
+
+  @activation_layers_with_opts [:celu, :elu, :hard_sigmoid, :hard_silu, :leaky_relu] ++
+                                  [:log_softmax, :selu, :softmax]
+  for activation <- @activation_layers_with_opts do
+    defn unquote(activation)(input, opts \\ []) do
+      transform(input, fn inp ->
+        Elixir.Kernel.apply(Axon.Activations, unquote(activation), [inp, Keyword.delete(opts, :mode)])
+      end)
     end
   end
 
@@ -2360,7 +2412,7 @@ defmodule Axon.Layers do
   @element_wise_layers [:add, :subtract, :multiply]
 
   for op <- @element_wise_layers do
-    defn unquote(op)(inputs, opts \\ []) do
+    defn unquote(op)(inputs, _opts \\ []) do
       transform(inputs, fn inputs ->
         [first | rest] = Tuple.to_list(inputs)
 
@@ -2369,5 +2421,98 @@ defmodule Axon.Layers do
         end)
       end)
     end
+  end
+
+  @doc false
+  defn concatenate(inputs, opts \\ []) do
+    opts = keyword!(opts, axis: -1, mode: :inference)
+
+    transform(inputs, fn inputs ->
+      inputs
+      |> Tuple.to_list()
+      |> Nx.concatenate(axis: opts[:axis])
+    end)
+  end
+
+  @recurrent_layers [:lstm, :gru, :conv_lstm]
+
+  for rnn_op <- @recurrent_layers do
+    defn unquote(rnn_op)(input, hidden_state, input_kernel, hidden_kernel, bias \\ 0, opts \\ []) do
+      {bias, opts} =
+        transform({bias, opts}, fn
+          {[_ | _] = opts, _opts} ->
+            {0, opts}
+
+          {[] = opts, _opts} ->
+            {0, opts}
+
+          {bias, opts} ->
+            {bias, opts}
+        end)
+
+      opts = transform(opts, &Keyword.put(&1, :cell, unquote(rnn_op)))
+      rnn(input, hidden_state, input_kernel, hidden_kernel, bias, opts)
+    end
+  end
+
+  defnp rnn(input, hidden_state, input_kernel, hidden_kernel, bias, opts \\ []) do
+    opts =
+      keyword!(opts,
+        mode: :inference,
+        unroll: :static,
+        cell: :lstm,
+        activation: :sigmoid,
+        gate: :tanh,
+        conv_opts: []
+      )
+
+    bias =
+      transform({bias, opts[:cell]}, fn
+        {0, :lstm} -> {0, 0, 0, 0}
+        {0, :gru} -> {0, 0, 0, 0}
+        {0, :conv_lstm} -> {0, 0, 0}
+        {bias, _} -> bias
+      end)
+
+    cell_fn =
+      transform({opts[:cell], opts[:activation], opts[:gate], opts[:conv_opts]}, &get_cell_fn/1)
+
+    transform({input, hidden_state, input_kernel, hidden_kernel, bias, cell_fn, opts[:unroll]}, fn
+      {input, hidden_state, input_kernel, hidden_kernel, bias, cell_fn, :static} ->
+        Axon.Recurrent.static_unroll(
+          cell_fn,
+          input,
+          hidden_state,
+          input_kernel,
+          hidden_kernel,
+          bias
+        )
+
+      {input, hidden_state, input_kernel, hidden_kernel, bias, cell_fn, :dynamic} ->
+        Axon.Recurrent.dynamic_unroll(
+          cell_fn,
+          input,
+          hidden_state,
+          input_kernel,
+          hidden_kernel,
+          bias
+        )
+    end)
+  end
+
+  defp get_cell_fn({:lstm, activation, gate, _}) do
+    gate_fn = &apply(Axon.Activations, gate, [&1])
+    act_fn = &apply(Axon.Activations, activation, [&1])
+    &Axon.Recurrent.lstm_cell(&1, &2, &3, &4, &5, gate_fn, act_fn)
+  end
+
+  defp get_cell_fn({:gru, activation, gate, _}) do
+    gate_fn = &apply(Axon.Activations, gate, [&1])
+    act_fn = &apply(Axon.Activations, activation, [&1])
+    &Axon.Recurrent.gru_cell(&1, &2, &3, &4, &5, gate_fn, act_fn)
+  end
+
+  defp get_cell_fn({:conv_lstm, _, _, conv_opts}) do
+    &Axon.Recurrent.conv_lstm_cell(&1, &2, &3, &4, &5, conv_opts)
   end
 end

--- a/lib/axon/loop.ex
+++ b/lib/axon/loop.ex
@@ -352,13 +352,15 @@ defmodule Axon.Loop do
       {updates, new_optimizer_state} =
         update_optimizer_fn.(gradients, optimizer_state, model_state)
 
+      new_model_state = Axon.Updates.apply_updates(model_state, updates, new_state)
+
       %{
         state
         | i: Nx.add(i, 1),
           y_true: tar,
           y_pred: preds,
           loss: new_loss,
-          model_state: Axon.Updates.apply_updates(model_state, updates, new_state),
+          model_state: new_model_state,
           optimizer_state: new_optimizer_state
       }
     end

--- a/lib/axon/recurrent.ex
+++ b/lib/axon/recurrent.ex
@@ -26,7 +26,6 @@ defmodule Axon.Recurrent do
   """
   import Nx.Defn
   import Axon.Layers
-  import Axon.Activations
 
   @doc """
   GRU Cell.

--- a/lib/axon/shared.ex
+++ b/lib/axon/shared.ex
@@ -203,6 +203,10 @@ defmodule Axon.Shared do
   @doc """
   Deep reduces a map with an accumulator.
   """
+  def deep_reduce(item, acc, fun) when is_integer(item) do
+    fun.(item, acc)
+  end
+
   def deep_reduce(map, acc, fun) do
     Nx.Container.reduce(map, acc, &recur_deep_reduce(&1, &2, fun))
   end

--- a/lib/axon/stateful_output.ex
+++ b/lib/axon/stateful_output.ex
@@ -1,0 +1,31 @@
+defmodule Axon.StatefulOutput do
+  @moduledoc """
+  Container for returning stateful outputs from Axon layers.
+
+  Some layers, such as `Axon.batch_norm/3`, keep a running internal
+  state which is updated continuously at train time and used statically
+  at inference time. In order for the Axon compiler to differentiate
+  ordinary layer outputs from internal state, you must mark output
+  as stateful.
+
+  Stateful Outputs consist of two fields:
+
+      :output - Actual layer output to be forwarded to next layer
+      :state - Internal layer state to be tracked and updated
+
+  `:output` is simply forwarded to the next layer. `:state` is aggregated
+  with other stateful outputs, and then is treated specially by internal
+  Axon training functions such that update state parameters reflect returned
+  values from stateful outputs.
+
+  `:state` must be a map with keys that map directly to layer internal
+  state names. For example, `Axon.Layers.batch_norm` returns StatefulOutput
+  with `:state` keys of `"mean"` and `"var"`.
+  """
+
+  @derive {
+    Nx.Container,
+    keep: [], containers: [:output, :state]
+  }
+  defstruct [:output, :state]
+end

--- a/test/axon/compiler_test.exs
+++ b/test/axon/compiler_test.exs
@@ -2445,7 +2445,7 @@ defmodule CompilerTest do
       input1 = Nx.random_uniform({1, 1, 3, 3})
 
       assert {_, predict_fn} = Axon.compile(model1)
-      assert_equal(predict_fn.(%{}, input1), Axon.Layers.resize(input1, shape: {4, 4}))
+      assert_equal(predict_fn.(%{}, input1), Axon.Layers.resize(input1, to: {4, 4}))
     end
 
     test "computes forward pass with output policy" do

--- a/test/axon/layers_test.exs
+++ b/test/axon/layers_test.exs
@@ -793,7 +793,7 @@ defmodule Axon.LayersTest do
     test "bilinear without aligned corners" do
       input = Nx.iota({1, 1, 3, 4}, type: {:f, 32})
 
-      assert Axon.Layers.resize(input, shape: {5, 2}, method: :bilinear, align_corners: false) ==
+      assert Axon.Layers.resize(input, to: {5, 2}, method: :bilinear, align_corners: false) ==
                Nx.tensor([
                  [
                    [
@@ -810,7 +810,7 @@ defmodule Axon.LayersTest do
     test "bilinear with aligned corners" do
       input = Nx.iota({1, 1, 3, 4}, type: {:f, 32})
 
-      assert Axon.Layers.resize(input, shape: {5, 2}, method: :bilinear, align_corners: true) ==
+      assert Axon.Layers.resize(input, to: {5, 2}, method: :bilinear, align_corners: true) ==
                Nx.tensor([
                  [
                    [

--- a/test/axon/mixed_precision_test.exs
+++ b/test/axon/mixed_precision_test.exs
@@ -25,10 +25,10 @@ defmodule MixedPrecisionTest do
 
       assert %Axon{
                op: :dense,
-               parent: [
+               inputs: [
                  %Axon{
                    op: :batch_norm,
-                   parent: [%Axon{op: :dense, policy: %Policy{compute: {:bf, 16}}}],
+                   inputs: [%Axon{op: :dense, policy: %Policy{compute: {:bf, 16}}}],
                    policy: %Policy{compute: {:f, 32}}
                  }
                ],

--- a/test/axon/mixed_precision_test.exs
+++ b/test/axon/mixed_precision_test.exs
@@ -25,10 +25,10 @@ defmodule MixedPrecisionTest do
 
       assert %Axon{
                op: :dense,
-               inputs: [
+               parent: [
                  %Axon{
                    op: :batch_norm,
-                   inputs: [%Axon{op: :dense, policy: %Policy{compute: {:bf, 16}}}],
+                   parent: [%Axon{op: :dense, policy: %Policy{compute: {:bf, 16}}}],
                    policy: %Policy{compute: {:f, 32}}
                  }
                ],

--- a/test/axon_test.exs
+++ b/test/axon_test.exs
@@ -63,8 +63,7 @@ defmodule AxonTest do
     end
 
     test "works with use_bias false" do
-      assert %Axon{op: :dense, parameters: [_]} =
-               Axon.input({nil, 784}) |> Axon.dense(128, use_bias: false)
+      assert %Axon{parameters: [_]} = Axon.input({nil, 784}) |> Axon.dense(128, use_bias: false)
     end
   end
 
@@ -134,8 +133,7 @@ defmodule AxonTest do
     end
 
     test "works with use_bias false" do
-      assert %Axon{op: :conv, parameters: [_]} =
-               Axon.input({nil, 1, 2}) |> Axon.conv(2, use_bias: false)
+      assert %Axon{parameters: [_]} = Axon.input({nil, 1, 2}) |> Axon.conv(2, use_bias: false)
     end
   end
 
@@ -205,7 +203,7 @@ defmodule AxonTest do
     end
 
     test "works with use_bias false" do
-      assert %Axon{op: :depthwise_conv, parameters: [_]} =
+      assert %Axon{parameters: [_]} =
                Axon.input({nil, 1, 2}) |> Axon.depthwise_conv(1, use_bias: false)
     end
   end

--- a/test/axon_test.exs
+++ b/test/axon_test.exs
@@ -6,7 +6,7 @@ defmodule AxonTest do
 
   describe "input" do
     test "works with defaults" do
-      assert %Axon{op: :input, parent: nil} = Axon.input({32, 1, 28, 28})
+      assert %Axon{op: :input, parent: []} = Axon.input({32, 1, 28, 28})
     end
   end
 
@@ -31,8 +31,7 @@ defmodule AxonTest do
     test "works with defaults" do
       assert %Axon{
                op: :dense,
-               params: %{"kernel" => weight, "bias" => bias},
-               opts: [use_bias: true]
+               parameters: [weight, bias]
              } = Axon.input({nil, 784}) |> Axon.dense(128)
 
       assert %Axon.Parameter{initializer: :glorot_uniform} = weight
@@ -40,7 +39,7 @@ defmodule AxonTest do
     end
 
     test "works with parameter initializer" do
-      assert %Axon{op: :dense, params: %{"kernel" => weight, "bias" => bias}} =
+      assert %Axon{op: :dense, parameters: [weight, bias]} =
                Axon.input({nil, 784})
                |> Axon.dense(128, kernel_initializer: :lecun_normal, bias_initializer: :ones)
 
@@ -64,21 +63,20 @@ defmodule AxonTest do
     end
 
     test "works with use_bias false" do
-      assert %Axon{op: :dense, opts: [use_bias: false]} =
+      assert %Axon{op: :dense, parameters: [_]} =
                Axon.input({nil, 784}) |> Axon.dense(128, use_bias: false)
     end
   end
 
   describe "conv" do
     test "works with defaults" do
-      assert %Axon{op: :conv, params: %{"kernel" => kernel, "bias" => bias}, opts: opts} =
+      assert %Axon{op: :conv, parameters: [kernel, bias], opts: opts} =
                Axon.input({nil, 1, 28, 28}) |> Axon.conv(64)
 
       assert opts[:padding] == :valid
       assert opts[:strides] == [1, 1]
       assert opts[:kernel_dilation] == [1, 1]
       assert opts[:input_dilation] == [1, 1]
-      assert opts[:use_bias] == true
 
       assert %Axon.Parameter{initializer: :glorot_uniform} = kernel
       assert %Axon.Parameter{initializer: :zeros} = bias
@@ -90,7 +88,7 @@ defmodule AxonTest do
     end
 
     test "works with options" do
-      assert %Axon{op: :conv, opts: opts, params: %{"kernel" => kernel, "bias" => bias}} =
+      assert %Axon{op: :conv, opts: opts, parameters: [kernel, bias]} =
                Axon.input({nil, 1, 28, 28})
                |> Axon.conv(64, padding: :same, strides: [2, 1], kernel_size: 2)
 
@@ -136,23 +134,20 @@ defmodule AxonTest do
     end
 
     test "works with use_bias false" do
-      assert %Axon{op: :conv, opts: opts} =
+      assert %Axon{op: :conv, parameters: [_]} =
                Axon.input({nil, 1, 2}) |> Axon.conv(2, use_bias: false)
-
-      assert opts[:use_bias] == false
     end
   end
 
   describe "depthwise_conv" do
     test "works with defaults" do
-      assert %Axon{op: :depthwise_conv, params: %{"kernel" => kernel, "bias" => bias}, opts: opts} =
+      assert %Axon{op: :depthwise_conv, parameters: [kernel, bias], opts: opts} =
                Axon.input({nil, 1, 28, 28}) |> Axon.depthwise_conv(3)
 
       assert opts[:padding] == :valid
       assert opts[:strides] == [1, 1]
       assert opts[:kernel_dilation] == [1, 1]
       assert opts[:input_dilation] == [1, 1]
-      assert opts[:use_bias] == true
 
       assert %Axon.Parameter{initializer: :glorot_uniform} = kernel
       assert %Axon.Parameter{initializer: :zeros} = bias
@@ -164,7 +159,7 @@ defmodule AxonTest do
     end
 
     test "works with options" do
-      assert %Axon{op: :depthwise_conv, opts: opts, params: %{"kernel" => kernel, "bias" => bias}} =
+      assert %Axon{op: :depthwise_conv, opts: opts, parameters: [kernel, bias]} =
                Axon.input({nil, 1, 28, 28})
                |> Axon.depthwise_conv(3, padding: :same, strides: [2, 1], kernel_size: 2)
 
@@ -210,10 +205,8 @@ defmodule AxonTest do
     end
 
     test "works with use_bias false" do
-      assert %Axon{op: :depthwise_conv, opts: opts} =
+      assert %Axon{op: :depthwise_conv, parameters: [_]} =
                Axon.input({nil, 1, 2}) |> Axon.depthwise_conv(1, use_bias: false)
-
-      assert opts[:use_bias] == false
     end
   end
 
@@ -221,7 +214,7 @@ defmodule AxonTest do
     test "works with defaults" do
       assert %Axon{
                op: :separable_conv2d,
-               params: %{"k1" => k1, "b1" => b1, "k2" => k2, "b2" => b2},
+               parameters: [k1, b1, k2, b2],
                opts: opts
              } = Axon.input({nil, 1, 28, 28}) |> Axon.separable_conv2d(3)
 
@@ -229,7 +222,6 @@ defmodule AxonTest do
       assert opts[:strides] == [1, 1]
       assert opts[:kernel_dilation] == [1, 1]
       assert opts[:input_dilation] == [1, 1]
-      assert opts[:use_bias] == true
 
       assert %Axon.Parameter{initializer: :glorot_uniform} = k1
       assert %Axon.Parameter{initializer: :glorot_uniform} = k2
@@ -246,7 +238,7 @@ defmodule AxonTest do
       assert %Axon{
                op: :separable_conv2d,
                opts: opts,
-               params: %{"k1" => k1, "b1" => b1, "k2" => k2, "b2" => b2}
+               parameters: [k1, b1, k2, b2]
              } =
                Axon.input({nil, 1, 28, 28})
                |> Axon.separable_conv2d(3, padding: :same, strides: [2, 1], kernel_size: 2)
@@ -295,10 +287,8 @@ defmodule AxonTest do
     end
 
     test "works with use_bias false" do
-      assert %Axon{op: :separable_conv2d, opts: opts} =
+      assert %Axon{op: :separable_conv2d, parameters: [_, _]} =
                Axon.input({nil, 1, 2, 2}) |> Axon.separable_conv2d(1, use_bias: false)
-
-      assert opts[:use_bias] == false
     end
   end
 
@@ -306,7 +296,7 @@ defmodule AxonTest do
     test "works with defaults" do
       assert %Axon{
                op: :separable_conv3d,
-               params: %{"k1" => k1, "b1" => b1, "k2" => k2, "b2" => b2, "k3" => k3, "b3" => b3},
+               parameters: [k1, b1, k2, b2, k3, b3],
                opts: opts
              } = Axon.input({nil, 1, 28, 28, 3}) |> Axon.separable_conv3d(3)
 
@@ -314,7 +304,6 @@ defmodule AxonTest do
       assert opts[:strides] == [1, 1, 1]
       assert opts[:kernel_dilation] == [1, 1, 1]
       assert opts[:input_dilation] == [1, 1, 1]
-      assert opts[:use_bias] == true
 
       assert %Axon.Parameter{initializer: :glorot_uniform} = k1
       assert %Axon.Parameter{initializer: :glorot_uniform} = k2
@@ -333,7 +322,7 @@ defmodule AxonTest do
       assert %Axon{
                op: :separable_conv3d,
                opts: opts,
-               params: %{"k1" => k1, "b1" => b1, "k2" => k2, "b2" => b2, "k3" => k3, "b3" => b3}
+               parameters: [k1, b1, k2, b2, k3, b3]
              } =
                Axon.input({nil, 1, 28, 28, 3})
                |> Axon.separable_conv3d(3,
@@ -388,10 +377,8 @@ defmodule AxonTest do
     end
 
     test "works with use_bias false" do
-      assert %Axon{op: :separable_conv3d, opts: opts} =
+      assert %Axon{op: :separable_conv3d, parameters: [_, _, _], opts: opts} =
                Axon.input({nil, 1, 2, 2, 2}) |> Axon.separable_conv3d(1, use_bias: false)
-
-      assert opts[:use_bias] == false
     end
   end
 
@@ -486,7 +473,7 @@ defmodule AxonTest do
   describe "normalization" do
     test "works with defaults" do
       for norm <- @normalization_layers do
-        assert %Axon{op: norm1, opts: opts, params: %{"gamma" => gamma, "beta" => beta}} =
+        assert %Axon{op: norm1, opts: opts, parameters: [gamma, beta]} =
                  apply(Axon, norm, [Axon.input({nil, 784})])
 
         assert norm1 == norm
@@ -501,7 +488,7 @@ defmodule AxonTest do
 
     test "works with parameter initializer" do
       for norm <- @normalization_layers do
-        assert %Axon{params: %{"gamma" => gamma, "beta" => beta}} =
+        assert %Axon{parameters: [gamma, beta, mean, var]} =
                  apply(Axon, norm, [
                    Axon.input({nil, 784}),
                    [gamma_initializer: :lecun_normal, beta_initializer: :ones]
@@ -509,6 +496,8 @@ defmodule AxonTest do
 
         assert %Axon.Parameter{initializer: :lecun_normal} = gamma
         assert %Axon.Parameter{initializer: :ones} = beta
+        assert %Axon.Parameter{initializer: :zeros} = mean
+        assert %Axon.Parameter{initializer: :ones} = var
       end
     end
 
@@ -527,7 +516,7 @@ defmodule AxonTest do
 
   describe "group normalization" do
     test "works with defaults" do
-      assert %Axon{op: :group_norm, params: %{"gamma" => gamma, "beta" => beta}, opts: opts} =
+      assert %Axon{op: :group_norm, parameters: [gamma, beta], opts: opts} =
                Axon.input({nil, 3, 28, 28}) |> Axon.group_norm(3)
 
       assert opts[:channel_index] == 1
@@ -539,7 +528,7 @@ defmodule AxonTest do
     end
 
     test "works with parameter initializer" do
-      assert %Axon{params: %{"gamma" => gamma, "beta" => beta}} =
+      assert %Axon{parameters: [gamma, beta]} =
                Axon.input({nil, 3, 28, 28})
                |> Axon.group_norm(3, gamma_initializer: :lecun_normal, beta_initializer: :ones)
 
@@ -711,9 +700,9 @@ defmodule AxonTest do
         |> Axon.dense(128)
         |> Axon.freeze()
 
-      assert %Axon{params: %{"kernel" => %{frozen: true}, "bias" => %{frozen: true}}} = model
+      assert %Axon{parameters: %{"kernel" => %{frozen: true}, "bias" => %{frozen: true}}} = model
 
-      assert %Axon{params: %{"kernel" => %{frozen: false}, "bias" => %{frozen: false}}} =
+      assert %Axon{parameters: %{"kernel" => %{frozen: false}, "bias" => %{frozen: false}}} =
                model |> Axon.dense(10)
     end
   end


### PR DESCRIPTION
This PR aims to greatly simplify the compiler by tweaking a few things and following a few unifying principles. I think the goal is for this to be the final evolution of the layer API into an interface that is flexible, simple, and easy to understand. Overall here's what needs to happen/change:

1) Parameters need to be defined with `Axon.param` and passed as a list to `layer` in the order they are to be passed to their implementation function. The original usage of map I think was for order preservation/forwarding, but it's actually not necessary and creates some ambiguity about what the name of the parameter being referenced is. I think the list is more clear as the order you give parameters in the list is the order they will be used. Another option even is to just pass everything (inputs and params) as inputs, and let `Axon.layer` split parameters in inputs by struct type. This also allows us to unify pretty much every trainable layer clause because we don't hard match on parameters---we just consume the list and forward it to the implementation function.

2) We need to forward `:mode` as an option to every implementation function. This means every implementation function needs to have a trailing `opts`---even if they are not used. I think though this is favorable over being ambiguous. And this means custom layers can have behavior that depends on training and inference mode---just like dropout and batch norm. This was not possible before.

3) We need to come up with an API for "stateful" layers so the compiler knows how to handle those in training mode. This will allow us to eliminate the additional `:batch_norm` clause and will mean that custom layers can also implement layers with state.

4) We need a more graceful way to implement combinators such as `add`, `concatenate`, and `cond` as functions in `Axon.Layers` so that we can unify them under the current monolithic clause.

Once this is complete custom layers will be 100% consistent with Axon's internal layers and everything that's possible to do internally with Axon will be possible externally with custom layers. So the flow of custom layers will be:

1. Define an implementation function as `defn` which can be an arbitrary arity function, as long as it ends in `opts`.
2. Define an interface for the layer which declares trainable parameters and state and attaches to the implementation function.

I also think it will be really cool to just say the Axon compiler is basically 1 function