### PR TITLE
Explicit backend transfer of constants

### DIFF
--- a/lib/axon/compiler.ex
+++ b/lib/axon/compiler.ex
@@ -202,6 +202,8 @@ defmodule Axon.Compiler do
          {cache, op_counts},
          _
        ) do
+    tensor = Nx.backend_transfer(tensor, Nx.Defn.Expr)
+
     fun = fn _params, _inputs, state, _cache, result_cache ->
       out = safe_as_type(tensor, output)
       {out, {state, result_cache}}

--- a/lib/axon/compiler.ex
+++ b/lib/axon/compiler.ex
@@ -202,7 +202,7 @@ defmodule Axon.Compiler do
          {cache, op_counts},
          _
        ) do
-    tensor = Nx.backend_transfer(tensor, Nx.Defn.Expr)
+    tensor = Nx.backend_transfer(tensor, Nx.BinaryBackend)
 
     fun = fn _params, _inputs, state, _cache, result_cache ->
       out = safe_as_type(tensor, output)


### PR DESCRIPTION
This seems to be the tweak that allows EXLA Backend and Compiler to coexist within Axon. I'm still troubleshooting an issue that EXLA raises though about casting types (at least when performing inference on various transformer models)