### PR TITLE
Fix accuracy calculation logic

### DIFF
--- a/lib/axon/metrics.ex
+++ b/lib/axon/metrics.ex
@@ -40,27 +40,37 @@ defmodule Axon.Metrics do
 
   ## Examples
 
+      iex> Axon.Metrics.accuracy(Nx.tensor([[1], [0], [0]]), Nx.tensor([[1], [1], [1]]))
+      #Nx.Tensor<
+        f32
+        0.3333333432674408
+      >
+
       iex> Axon.Metrics.accuracy(Nx.tensor([[0, 1], [1, 0], [1, 0]]), Nx.tensor([[0, 1], [1, 0], [0, 1]]))
       #Nx.Tensor<
         f32
         0.6666666865348816
       >
 
+      iex> Axon.Metrics.accuracy(Nx.tensor([[0, 1, 0], [1, 0, 0]]), Nx.tensor([[0, 1, 0], [0, 1, 0]]))
+      #Nx.Tensor<
+        f32
+        0.5
+      >
+
   """
   defn accuracy(y_true, y_pred) do
-    transform({y_true, y_pred}, fn {y_true, y_pred} ->
-      if elem(Nx.shape(y_pred), Nx.rank(y_pred) - 1) == 1 do
-        y_pred
-        |> Nx.greater(0.5)
-        |> Nx.equal(y_true)
-        |> Nx.mean()
-      else
-        y_true
-        |> Nx.argmax(axis: -1)
-        |> Nx.equal(Nx.argmax(y_pred, axis: -1))
-        |> Nx.mean()
-      end
-    end)
+    if elem(Nx.shape(y_pred), Nx.rank(y_pred) - 1) == 1 do
+      y_pred
+      |> Nx.greater(0.5)
+      |> Nx.equal(y_true)
+      |> Nx.mean()
+    else
+      y_true
+      |> Nx.argmax(axis: -1)
+      |> Nx.equal(Nx.argmax(y_pred, axis: -1))
+      |> Nx.mean()
+    end
   end
 
   @doc ~S"""


### PR DESCRIPTION
Using compare operators inside `defn` even with `transform` will not work as expected. 
To do that it needs to be inside a separate function.