### PR TITLE
Introduce metadata to Axon

### DIFF
--- a/lib/axon.ex
+++ b/lib/axon.ex
@@ -160,7 +160,7 @@ defmodule Axon do
     {shape, opts} = Keyword.pop(opts, :shape)
     {op_name, opts} = Keyword.pop(opts, :op_name, :custom)
 
-    {id, name} = unique_identifiers(type, name)
+    {id, name} = unique_identifiers(op_name, name)
 
     output_shape =
       if shape do
@@ -2814,7 +2814,7 @@ defmodule Axon do
       |> string()
     end
 
-    defp axon_to_rows(%{id: id, op_name: op_name} = graph, cache, op_counts) do
+    defp axon_to_rows(%{id: id, op_name: op_name} = graph, cache, op_counts, model_info) do
       case cache do
         %{^id => {row, name}} ->
           {row, name, cache, op_counts, model_info}
@@ -2825,7 +2825,7 @@ defmodule Axon do
 
           cache = Map.put(cache, id, {row, name})
           op_counts = Map.update(op_counts, op_name, 1, fn x -> x + 1 end)
-          {row, name, cache, op_counts}
+          {row, name, cache, op_counts, model_info}
       end
     end
 

--- a/lib/axon.ex
+++ b/lib/axon.ex
@@ -160,8 +160,6 @@ defmodule Axon do
     {shape, opts} = Keyword.pop(opts, :shape)
     {op_name, opts} = Keyword.pop(opts, :op_name, :custom)
 
-    type = if op_name, do: op_name, else: :custom
-
     {id, name} = unique_identifiers(type, name)
 
     output_shape =
@@ -2826,7 +2824,6 @@ defmodule Axon do
             do_axon_to_rows(graph, cache, op_counts, model_info)
 
           cache = Map.put(cache, id, {row, name})
-          op_name = if op_name, do: op_name, else: :custom
           op_counts = Map.update(op_counts, op_name, 1, fn x -> x + 1 end)
           {row, name, cache, op_counts}
       end
@@ -2901,12 +2898,7 @@ defmodule Axon do
 
       param_byte_size = num_params * div(bitsize, 8)
 
-      op_inspect =
-        if op_name do
-          Atom.to_string(op_name)
-        else
-          "custom"
-        end
+      op_inspect = Atom.to_string(op_name)
 
       inputs =
         case input_names do

--- a/lib/axon.ex
+++ b/lib/axon.ex
@@ -90,9 +90,33 @@ defmodule Axon do
   @derive {
     Nx.Container,
     containers: [],
-    keep: [:id, :name, :output_shape, :parent, :parameters, :args, :op, :policy, :hooks, :opts, :meta]
+    keep: [
+      :id,
+      :name,
+      :output_shape,
+      :parent,
+      :parameters,
+      :args,
+      :op,
+      :policy,
+      :hooks,
+      :opts,
+      :meta
+    ]
   }
-  defstruct [:id, :name, :output_shape, :parent, :parameters, :args, :op, :policy, :hooks, :opts, :meta]
+  defstruct [
+    :id,
+    :name,
+    :output_shape,
+    :parent,
+    :parameters,
+    :args,
+    :op,
+    :policy,
+    :hooks,
+    :opts,
+    :meta
+  ]
 
   @doc """
   Custom Axon layer with given inputs.

--- a/lib/axon.ex
+++ b/lib/axon.ex
@@ -158,7 +158,7 @@ defmodule Axon do
 
     {name, opts} = Keyword.pop(opts, :name)
     {shape, opts} = Keyword.pop(opts, :shape)
-    {op_name, opts} = Keyword.pop(opts, :op_name)
+    {op_name, opts} = Keyword.pop(opts, :op_name, :custom)
 
     type = if op_name, do: op_name, else: :custom
 

--- a/lib/axon/compiler.ex
+++ b/lib/axon/compiler.ex
@@ -81,7 +81,6 @@ defmodule Axon.Compiler do
           Enum.map_reduce(parents, cache_and_counts, &to_init_fun/2)
       end
 
-    op_name = if op_name, do: op_name, else: :custom
     name = name_fn.(op_name, op_counts)
     op_counts = Map.update(op_counts, op_name, 1, fn x -> x + 1 end)
 
@@ -316,7 +315,6 @@ defmodule Axon.Compiler do
 
     # Names are computed lazily, so compute name from current
     # op and aggregate op_counts.
-    op_name = if op_name, do: op_name, else: :custom
     name = name_fn.(op_name, op_counts)
     op_counts = Map.update(op_counts, op, 1, fn x -> x + 1 end)
 

--- a/lib/axon/compiler.ex
+++ b/lib/axon/compiler.ex
@@ -67,7 +67,8 @@ defmodule Axon.Compiler do
            op: op,
            name: name_fn,
            policy: %{params: dtype},
-           hooks: hooks
+           hooks: hooks,
+           op_name: op_name
          },
          cache_and_counts
        ) do
@@ -80,8 +81,9 @@ defmodule Axon.Compiler do
           Enum.map_reduce(parents, cache_and_counts, &to_init_fun/2)
       end
 
-    name = name_fn.(op, op_counts)
-    op_counts = Map.update(op_counts, op, 1, fn x -> x + 1 end)
+    op_name = if op_name, do: op_name, else: :custom
+    name = name_fn.(op_name, op_counts)
+    op_counts = Map.update(op_counts, op_name, 1, fn x -> x + 1 end)
 
     init_fn = fn cache, result_cache ->
       result_cache =
@@ -294,7 +296,8 @@ defmodule Axon.Compiler do
            args: args,
            opts: opts,
            policy: %{compute: compute, output: output},
-           hooks: hooks
+           hooks: hooks,
+           op_name: op_name
          },
          cache_and_counts,
          mode
@@ -313,7 +316,8 @@ defmodule Axon.Compiler do
 
     # Names are computed lazily, so compute name from current
     # op and aggregate op_counts.
-    name = name_fn.(op, op_counts)
+    op_name = if op_name, do: op_name, else: :custom
+    name = name_fn.(op_name, op_counts)
     op_counts = Map.update(op_counts, op, 1, fn x -> x + 1 end)
 
     # Sub-inference functions contain `params` - trainable parameters

--- a/lib/axon/compiler.ex
+++ b/lib/axon/compiler.ex
@@ -311,10 +311,6 @@ defmodule Axon.Compiler do
         &to_predict_fun(&1, &2, mode)
       )
 
-    # TODO: This should be changed/moved when we add a metadata field
-    # to the Axon struct
-    {_, opts} = Keyword.pop(opts, :layer_op)
-
     # Names are computed lazily, so compute name from current
     # op and aggregate op_counts.
     name = name_fn.(op, op_counts)

--- a/test/axon/compiler_test.exs
+++ b/test/axon/compiler_test.exs
@@ -3978,6 +3978,19 @@ defmodule CompilerTest do
       assert Nx.shape(kernel) == {1, 1}
     end
 
+    test "initializes with two custom layers and no op_name" do
+      k1 = Axon.param("kernel", {1, 1})
+      k2 = Axon.param("kernel", {1, 1})
+
+      layer = fn x, k -> Axon.layer(fn y, _kernel, _opts -> y end, [x, k]) end
+
+      input = Axon.input({nil, 1})
+
+      model = input |> layer.(k1) |> layer.(k2)
+
+      assert %{"custom_0" => %{"kernel" => _}, "custom_1" => %{"kernel" => _}} = Axon.init(model)
+    end
+
     test "computes forward pass with parameters" do
       input = Axon.input({nil, 1})
       kernel_param = Axon.param("kernel", {1, 1})

--- a/test/axon_test.exs
+++ b/test/axon_test.exs
@@ -813,7 +813,7 @@ defmodule AxonTest do
               lstm_h_hidden_state ( recurrent_state["input_0"] )                               {nil, 1, 64}                                    p=f32 c=f32 o=f32   0            0 bytes
               lstm_hidden_state ( container {"lstm_c_hidden_state", "lstm_h_hidden_state"} )   {{nil, 1, 64}, {nil, 1, 64}}                    p=f32 c=f32 o=f32   0            0 bytes
               lstm ( lstm["input_0", "lstm_hidden_state"] )                                    {{{nil, 1, 64}, {nil, 1, 64}}, {nil, 32, 64}}   p=f32 c=f32 o=f32   19200        76800 bytes
-              lstm_output_sequence ( custom["lstm"] )                                          {nil, 32, 64}                                   p=f32 c=f32 o=f32   0            0 bytes
+              lstm_output_sequence ( elem["lstm"] )                                            {nil, 32, 64}                                   p=f32 c=f32 o=f32   0            0 bytes
              -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
              Total Parameters: 19200
              Total Parameters Memory: 76800 bytes


### PR DESCRIPTION
For now the only metadata that is used internally is `op` for custom layers, but this could be useful to external libraries as well 