### PR TITLE
Per-optimizer default learning_rate in `Axon.Loop`

### DIFF
--- a/lib/axon/loop.ex
+++ b/lib/axon/loop.ex
@@ -1518,9 +1518,7 @@ defmodule Axon.Loop do
   # Axon.Optimizers.
   defp build_optimizer_fns(optimizer)
        when is_atom(optimizer) and optimizer in @valid_axon_optimizers do
-    # TODO(seanmor5): Fall back to optimizer defaults rather
-    # than this global default.
-    apply(Axon.Optimizers, optimizer, [1.0e-2])
+    apply(Axon.Optimizers, optimizer, [])
   end
 
   defp build_optimizer_fns({init_optimizer_fn, update_optimizer_fn})

--- a/lib/axon/optimizers.ex
+++ b/lib/axon/optimizers.ex
@@ -69,7 +69,7 @@ defmodule Axon.Optimizers do
 
     * [AdaBelief Optimizer: Adapting Stepsizes by the Belief in Observed Gradients](https://arxiv.org/abs/2010.07468)
   """
-  def adabelief(learning_rate, opts \\ []) do
+  def adabelief(learning_rate \\ 1.0e-3, opts \\ []) do
     Updates.scale_by_belief(opts)
     |> scale_by_learning_rate(learning_rate)
   end
@@ -85,7 +85,7 @@ defmodule Axon.Optimizers do
 
     * [Adaptive Subgradient Methods for Online Learning and Stochastic Optimization](https://www.jmlr.org/papers/volume12/duchi11a/duchi11a.pdf)
   """
-  def adagrad(learning_rate, opts \\ []) do
+  def adagrad(learning_rate \\ 1.0e-3, opts \\ []) do
     Updates.scale_by_rss(opts)
     |> scale_by_learning_rate(learning_rate)
   end
@@ -104,7 +104,7 @@ defmodule Axon.Optimizers do
 
     * [Adam: A Method for Stochastic Optimization](https://arxiv.org/abs/1412.6980)
   """
-  def adam(learning_rate, opts \\ []) do
+  def adam(learning_rate \\ 1.0e-3, opts \\ []) do
     Updates.scale_by_adam(opts)
     |> scale_by_learning_rate(learning_rate)
   end
@@ -120,7 +120,7 @@ defmodule Axon.Optimizers do
     * `:eps_root` - numerical stability term. Defaults to `0.0`
     * `:decay` - weight decay. Defaults to `0.0`
   """
-  def adamw(learning_rate, opts \\ []) do
+  def adamw(learning_rate \\ 1.0e-3, opts \\ []) do
     {decay, opts} = Keyword.pop(opts, :decay, 0.0)
 
     Updates.scale_by_adam(opts)
@@ -139,7 +139,7 @@ defmodule Axon.Optimizers do
 
     * [On the distance between two neural networks and the stability of learning](https://proceedings.neurips.cc/paper/2020/file/f4b31bee138ff5f7b84ce1575a738f95-Paper.pdf)
   """
-  def fromage(learning_rate, opts \\ []) do
+  def fromage(learning_rate \\ 1.0e-2, opts \\ []) do
     if is_function(learning_rate) do
       raise ArgumentError,
             "fromage optimizer does not support learning rate schedule," <>
@@ -169,7 +169,7 @@ defmodule Axon.Optimizers do
 
     * [Large Batch Optimization for Deep Learning: Training BERT in 76 minutes](https://arxiv.org/abs/1904.00962)
   """
-  def lamb(learning_rate, opts \\ []) do
+  def lamb(learning_rate \\ 1.0e-2, opts \\ []) do
     {decay, opts} = Keyword.pop(opts, :decay, 0.0)
     {min_norm, opts} = Keyword.pop(opts, :min_norm, 0.0)
 
@@ -187,7 +187,7 @@ defmodule Axon.Optimizers do
     * `:eta` - used to compute variance of noise distribution. Defaults to `0.1`
     * `:gamma` - used to compute variance of noise distribution. Defaults to `0.55`
   """
-  def noisy_sgd(learning_rate, opts \\ []) do
+  def noisy_sgd(learning_rate \\ 1.0e-2, opts \\ []) do
     scale_by_learning_rate(learning_rate)
     |> Updates.add_noise(opts)
   end
@@ -207,7 +207,7 @@ defmodule Axon.Optimizers do
 
     * [On the Variance of Adaptive Learning Rate and Beyond](https://arxiv.org/pdf/1908.03265.pdf)
   """
-  def radam(learning_rate, opts \\ []) do
+  def radam(learning_rate \\ 1.0e-3, opts \\ []) do
     Updates.scale_by_radam(opts)
     |> scale_by_learning_rate(learning_rate)
   end
@@ -225,7 +225,7 @@ defmodule Axon.Optimizers do
     * `:decay` - EMA decay rate. Defaults to `0.9`
     * `:eps` - numerical stability term. Defaults to `1.0e-8`
   """
-  def rmsprop(learning_rate, opts \\ []) do
+  def rmsprop(learning_rate \\ 1.0e-2, opts \\ []) do
     {centered, opts} = Keyword.pop(opts, :centered, false)
     {nesterov?, opts} = Keyword.pop(opts, :nesterov, false)
     {momentum, opts} = Keyword.pop(opts, :momentum, nil)
@@ -252,7 +252,7 @@ defmodule Axon.Optimizers do
       to value of this term.
     * `:nesterov` - whether or not to use nesterov momentum. Defaults to `false`
   """
-  def sgd(learning_rate, opts \\ []) do
+  def sgd(learning_rate \\ 1.0e-2, opts \\ []) do
     momentum = opts[:momentum]
     nesterov? = opts[:nesterov] || false
 
@@ -279,7 +279,7 @@ defmodule Axon.Optimizers do
 
     * [Adaptive Methods for Nonconvex Optimization](https://papers.nips.cc/paper/2018/file/90365351ccc7437a1309dc64e4db32a3-Paper.pdf)
   """
-  def yogi(learning_rate, opts \\ []) do
+  def yogi(learning_rate \\ 1.0e-2, opts \\ []) do
     Updates.scale_by_yogi(opts)
     |> scale_by_learning_rate(learning_rate)
   end


### PR DESCRIPTION
Default learning rates for each optimizer.

### Default: 0.001
 - `adabelief`
 - `adagrad`
 - `adam`
 - `adamw`
 - `radam`

### Default: 0.01
 - `fromage`
 - `lamb`
 - `noisy_sgd`
 - `rmsprop`
 - `sgd`
 - `yogi`