### PR TITLE
Remove ignore_batch in shape layers

### DIFF
--- a/lib/axon.ex
+++ b/lib/axon.ex
@@ -1791,18 +1791,13 @@ defmodule Axon do
 
     * `:name` - layer name.
 
-    * `:ignore_batch?` - whether to ignore batch dimension in
-      transpose operation. Defaults to `true`.
-
   """
   @doc type: :shape
-  def flatten(%Axon{op: op} = x, opts \\ []) do
-    opts = Keyword.validate!(opts, [:name, ignore_batch?: op != :constant])
-    ignore_batch? = opts[:ignore_batch?]
+  def flatten(%Axon{} = x, opts \\ []) do
+    opts = Keyword.validate!(opts, [:name])
 
     layer(:flatten, [x],
       name: opts[:name],
-      ignore_batch?: ignore_batch?,
       op_name: :flatten
     )
   end
@@ -1811,30 +1806,24 @@ defmodule Axon do
   Adds a reshape layer to the network.
 
   This layer implements a special case of `Nx.reshape` which accounts
-  for possible batch dimensions in the input tensor. If the input contains
-  batch dimensions, the reshape operation is performed on all non-batch
-  dimensions of the input - preserving the original batch size.
+  for possible batch dimensions in the input tensor. You may pass the
+  magic dimension `:batch` as a placeholder for dynamic batch sizes.
+  You can use `:batch` seamlessly with `:auto` dimension sizes.
 
   If the input is an Axon constant, the reshape behavior matches that of
-  `Nx.reshape`.
+  `Nx.reshape/2`.
 
   ## Options
 
     * `:name` - layer name.
-
-    * `:ignore_batch?` - whether to ignore batch dimension in transpose
-      operation. Defaults to `true`.
-
   """
   @doc type: :shape
-  def reshape(%Axon{op: op} = x, new_shape, opts \\ []) do
-    opts = Keyword.validate!(opts, [:name, ignore_batch?: op != :constant])
-    ignore_batch? = opts[:ignore_batch?]
+  def reshape(%Axon{} = x, new_shape, opts \\ []) do
+    opts = Keyword.validate!(opts, [:name])
 
     layer(:reshape, [x],
       name: opts[:name],
       shape: new_shape,
-      ignore_batch?: ignore_batch?,
       op_name: :reshape
     )
   end
@@ -1846,19 +1835,14 @@ defmodule Axon do
 
     * `:name` - layer name.
 
-    * `:ignore_batch?` - whether to ignore batch dimension in transpose
-      operation. Defaults to true.
-
   """
   @doc type: :shape
-  def transpose(%Axon{op: op} = x, permutation \\ nil, opts \\ []) do
-    opts = Keyword.validate!(opts, [:name, ignore_batch?: op != :constant])
-    ignore_batch? = opts[:ignore_batch?]
+  def transpose(%Axon{} = x, permutation \\ nil, opts \\ []) do
+    opts = Keyword.validate!(opts, [:name])
 
     layer(:transpose, [x],
       name: opts[:name],
       axes: permutation,
-      ignore_batch?: ignore_batch?,
       op_name: :transpose
     )
   end

--- a/lib/axon/shape.ex
+++ b/lib/axon/shape.ex
@@ -815,28 +815,19 @@ defmodule Axon.Shape do
 
   ## Examples
 
-      iex> Axon.Shape.flatten({nil, 1, 28, 28}, true)
+      iex> Axon.Shape.flatten({nil, 1, 28, 28})
       {nil, 784}
 
-      iex> Axon.Shape.flatten({32, 128}, true)
+      iex> Axon.Shape.flatten({32, 128})
       {32, 128}
 
-      iex> Axon.Shape.flatten({nil, 10, 10}, true)
+      iex> Axon.Shape.flatten({nil, 10, 10})
       {nil, 100}
   """
-  def flatten(shape, ignore_batch?) do
-    out_units =
-      if ignore_batch? do
-        Nx.size(Tuple.delete_at(shape, 0))
-      else
-        Nx.size(shape)
-      end
+  def flatten(shape) do
+    out_units = Nx.size(Tuple.delete_at(shape, 0))
 
-    if ignore_batch? do
-      {elem(shape, 0), out_units}
-    else
-      {out_units}
-    end
+    {elem(shape, 0), out_units}
   end
 
   @doc """

--- a/test/axon_test.exs
+++ b/test/axon_test.exs
@@ -582,13 +582,13 @@ defmodule AxonTest do
 
   describe "transpose" do
     test "works with batch input" do
-      assert %Axon{} = Axon.input("input", shape: {nil, 2, 1}) |> Axon.transpose([1, 0])
+      assert %Axon{} = Axon.input("input", shape: {nil, 2, 1}) |> Axon.transpose([0, 2, 1])
     end
 
     test "works with constant input" do
       assert %Axon{} =
                Axon.constant(Nx.iota({3, 2, 1}))
-               |> Axon.transpose([2, 1, 0], ignore_batch?: false)
+               |> Axon.transpose([2, 1, 0])
     end
   end
 


### PR DESCRIPTION
Resolves #286 

In all cases except reshape it doesn't make sense to ignore the batch size since it's irrelevant or strange behavior. This compromise is to remove the logic altogether, and expose a documented `:batch` atom in `Axon.reshape` which can be used to fill in the batch size and works well with `:auto`

Before this is merged I need to test with both AxonOnnx and the other lib