### PR TITLE
Add Axon Serving API

### DIFF
--- a/lib/axon.ex
+++ b/lib/axon.ex
@@ -369,11 +369,11 @@ defmodule Axon do
   def input(name, opts \\ [])
 
   def input(name, opts) when is_binary(name) and is_list(opts) do
-    opts = Keyword.validate!(opts, [:shape, optional: false, type: :f32])
+    opts = Keyword.validate!(opts, [:shape, :type, optional: false])
     optional = opts[:optional]
 
     input_shape = opts[:shape]
-    input_type = opts[:type] || :f32
+    input_type = opts[:type]
 
     output_shape = input_shape && Axon.Shape.input(input_shape)
 

--- a/lib/axon.ex
+++ b/lib/axon.ex
@@ -3204,7 +3204,7 @@ defmodule Axon do
   """
   @doc type: :model
   def compile(model, template, init_params \\ %{}, opts \\ []) when is_list(opts) do
-    {init_fn, predict_fn} = build(model)
+    {init_fn, predict_fn} = build(model, opts)
 
     init_compiled_fn = Nx.Defn.compile(init_fn, [template, init_params], opts)
 

--- a/lib/axon.ex
+++ b/lib/axon.ex
@@ -369,13 +369,21 @@ defmodule Axon do
   def input(name, opts \\ [])
 
   def input(name, opts) when is_binary(name) and is_list(opts) do
-    opts = Keyword.validate!(opts, [:shape, optional: false])
+    opts = Keyword.validate!(opts, [:shape, optional: false, type: :f32])
     optional = opts[:optional]
 
     input_shape = opts[:shape]
+    input_type = opts[:type] || :f32
 
     output_shape = input_shape && Axon.Shape.input(input_shape)
-    layer(:input, [], name: name, shape: output_shape, op_name: :input, optional: optional)
+
+    layer(:input, [],
+      name: name,
+      shape: output_shape,
+      op_name: :input,
+      optional: optional,
+      type: input_type
+    )
   end
 
   # TODO: remove on Axon v0.3
@@ -2986,7 +2994,8 @@ defmodule Axon do
     reduce_nodes(axon, %{}, fn
       %Axon.Node{op: :input, name: name, opts: opts}, inputs ->
         name = name.(:input, %{})
-        Map.put(inputs, name, %{shape: opts[:shape], optional: opts[:optional]})
+
+        Map.put(inputs, name, %{shape: opts[:shape], optional: opts[:optional], type: opts[:type]})
 
       _, inputs ->
         inputs

--- a/lib/axon.ex
+++ b/lib/axon.ex
@@ -3204,11 +3204,12 @@ defmodule Axon do
   """
   @doc type: :model
   def compile(model, template, init_params \\ %{}, opts \\ []) when is_list(opts) do
-    {init_fn, predict_fn} = build(model, opts)
-    init_compiled_fn = Nx.Defn.compile(init_fn, [template, init_params])
+    {init_fn, predict_fn} = build(model)
+
+    init_compiled_fn = Nx.Defn.compile(init_fn, [template, init_params], opts)
 
     predict_compiled_fn =
-      Nx.Defn.compile(predict_fn, [init_compiled_fn.(template, init_params), template])
+      Nx.Defn.compile(predict_fn, [init_compiled_fn.(template, init_params), template], opts)
 
     {init_compiled_fn, predict_compiled_fn}
   end

--- a/lib/axon.ex
+++ b/lib/axon.ex
@@ -2986,7 +2986,7 @@ defmodule Axon do
     reduce_nodes(axon, %{}, fn
       %Axon.Node{op: :input, name: name, opts: opts}, inputs ->
         name = name.(:input, %{})
-        Map.put(inputs, name, opts[:shape])
+        Map.put(inputs, name, %{shape: opts[:shape], optional: opts[:optional]})
 
       _, inputs ->
         inputs

--- a/lib/axon/compiler.ex
+++ b/lib/axon/compiler.ex
@@ -200,7 +200,7 @@ defmodule Axon.Compiler do
            op: :input,
            hooks: hooks,
            name: name_fn,
-           opts: [shape: _input_shape, optional: optional?]
+           opts: [shape: _input_shape, optional: optional?, type: _input_type]
          },
          _nodes,
          {cache, op_counts},
@@ -214,6 +214,7 @@ defmodule Axon.Compiler do
 
       # TODO: Add this back in
       # validate_input_shape!(value, shape)
+      # validate_input_type!(value, type)
 
       res =
         value
@@ -794,10 +795,19 @@ defmodule Axon.Compiler do
         none
 
       %Nx.Tensor{} = tensor ->
-        Nx.as_type(tensor, type)
+        maybe_as_type(tensor, type)
 
       container ->
-        deep_new(container, &Nx.as_type(&1, type))
+        deep_new(container, &maybe_as_type(&1, type))
+    end
+  end
+
+  defp maybe_as_type(tensor, type) do
+    # do not convert integer types
+    if Nx.Type.integer?(Nx.type(tensor)) do
+      tensor
+    else
+      Nx.as_type(tensor, type)
     end
   end
 

--- a/lib/axon/compiler.ex
+++ b/lib/axon/compiler.ex
@@ -802,6 +802,8 @@ defmodule Axon.Compiler do
     end
   end
 
+  defp maybe_as_type(%Axon.None{} = none, _), do: none
+
   defp maybe_as_type(tensor, type) do
     # do not convert integer types
     if Nx.Type.integer?(Nx.type(tensor)) do

--- a/lib/axon/serving.ex
+++ b/lib/axon/serving.ex
@@ -81,6 +81,8 @@ defmodule Axon.Serving do
 
     * `:shape` - input shapes for each input in the model
 
+    * `:type` - input types for each input in the model
+
     * `:batch_size` - maximum batch size to forward to model
 
     * `:batch_timeout` - auto-batching queue timeout limit

--- a/lib/axon/serving.ex
+++ b/lib/axon/serving.ex
@@ -12,23 +12,51 @@ defmodule Axon.Serving do
 
     %{
       id: id,
-      start: {Axon.Serving, :start_link, [opts]},
+      start: {Axon.Serving, :start_link, [opts]}
     }
   end
 
   ## API
 
   @doc """
+  Starts the Axon.Serving process.
+
+  At a minimum you must provide `:model` which is a tuple of
+  `{model, params}` and `:name` which is an atom used to
+  uniquely identify the model serving process.
+
   ## Options
+
+    * `:model` - tuple of `{model, params}` to compile and use
+
+    * `:shape` - input shapes for each input in the model
+
+    * `:batch_size` - maximum batch size to forward to model
+
+    * `:batch_timeout` - auto-batching queue timeout limit
+
+    All other options are treated as compilation options and
+    forwarded to the defn compiler.
   """
   def start_link(opts) do
+    {{model, params}, opts} = Keyword.pop!(opts, :model)
+    {name, opts} = Keyword.pop!(opts, :name)
+    {shape, opts} = Keyword.pop(opts, :shape)
+    {batch_size, opts} = Keyword.pop(opts, :batch_size, 1)
+    {batch_timeout, compiler_opts} = Keyword.pop(opts, :batch_timeout, 100)
+
+    template = template!(model, shape, batch_size)
+
+    {_init_fun, predict_fun} = Axon.compile(model, template, %{}, compiler_opts)
+
     config = %{
-      batch_size: Keyword.fetch!(opts, :batch_size, 1),
-      batch_timeout: Keyword.fetch!(opts, :batch_timeout, 100),
-      # model: Keyword.fetch!(opts, :model)
+      model: predict_fun,
+      params: params,
+      batch_size: batch_size,
+      batch_timeout: batch_timeout
     }
 
-    GenServer.start_link(__MODULE__, config, opts)
+    GenServer.start_link(__MODULE__, config, name: name)
   end
 
   def predict(server, input) do
@@ -49,23 +77,70 @@ defmodule Axon.Serving do
     {:ok, state}
   end
 
+  @impl true
   def handle_call({:predict, input}, from, state) do
     %{queue: queue, count: count} = state
     queue = :queue.in({input, from}, queue)
 
     # TODO: if Nx.axis_size(input, 0) is more than batch_size,
     # we should return error.
+    # TODO: correctly handle counts/batch for all inputs
+
+    [input] = Map.values(input)
 
     state =
-      %{state | acc: queue, count: count + Nx.axis_size(input, 0)}
+      %{state | queue: queue, count: count + Nx.axis_size(input, 0)}
       |> maybe_start_timer()
       |> maybe_dispatch()
 
     {:noreply, state}
   end
 
+  @impl true
   def handle_info(:timeout, state) do
-    dispatch(state)
+    {:noreply, dispatch(state)}
+  end
+
+  defp template!(%Axon{} = model, config_shapes, batch_size) do
+    model
+    |> Axon.get_inputs()
+    |> Map.new(fn {name, axon_shape} ->
+      config_shape = config_shapes[name]
+
+      shape =
+        cond do
+          config_shape != nil and same_shape?(axon_shape, config_shape) and
+              valid_shape?(config_shape, batch_size) ->
+            put_elem(config_shape, 0, batch_size)
+
+          valid_shape?(axon_shape, batch_size) ->
+            put_elem(axon_shape, 0, batch_size)
+
+          true ->
+            raise ArgumentError, "invalid shape for input #{name}"
+        end
+
+      # TODO: preserve input type
+      {name, Nx.template(shape, :f32)}
+    end)
+  end
+
+  defp same_shape?(shape1, shape2) do
+    shape1
+    |> Tuple.to_list()
+    |> Enum.zip_with(Tuple.to_list(shape2), fn s1, s2 ->
+      s1 == nil or s2 == nil or s1 == s2
+    end)
+    |> Enum.all?()
+  end
+
+  defp valid_shape?(shape, batch_size) do
+    shape != nil and num_nil_dims(shape) <= 1 and
+      (elem(shape, 0) == nil or elem(shape, 0) == batch_size)
+  end
+
+  defp num_nil_dims(shape) do
+    shape |> Tuple.to_list() |> Enum.count(&(&1 == nil))
   end
 
   defp maybe_start_timer(%{timeout_ref: nil, count: count} = state) when count > 0 do
@@ -73,11 +148,15 @@ defmodule Axon.Serving do
     %{state | timeout_ref: ref}
   end
 
+  defp maybe_start_timer(%{timeout_ref: nil} = state) do
+    state
+  end
+
   defp maybe_start_timer(%{timeout_ref: ref} = state) when is_reference(ref) do
     state
   end
 
-  defp maybe_dispatch(%{count: count, config: %{batch_size: batch_size} = state)
+  defp maybe_dispatch(%{count: count, config: %{batch_size: batch_size}} = state)
        when count >= batch_size do
     dispatch(state)
   end
@@ -88,13 +167,17 @@ defmodule Axon.Serving do
 
   # TODO: Make this work with batches != 1
   defp dispatch(state) do
-    %{batch_size: batch_size, queue: queue, count: count, timeout_ref: timeout_ref} = state
+    %{queue: queue, count: count, timeout_ref: timeout_ref} = state
     cancel_timer(timeout_ref)
 
+    batch_size = min(count, state.config.batch_size)
+
     {now, queue} =
-      Enum.map_reduce(1..batch_size, state.queue, fn _, queue ->
-        {{:value, {input, from}}, queue} = :queue.out(queue)
-        1 = Nx.axis_size(input)
+      Enum.map_reduce(1..batch_size, queue, fn _, queue ->
+        {{:value, {input, _} = pair}, queue} = :queue.out(queue)
+        # TODO: handle with counts per input
+        [input] = Map.values(input)
+        1 = Nx.axis_size(input, 0)
         {pair, queue}
       end)
 
@@ -102,14 +185,16 @@ defmodule Axon.Serving do
 
     # TODO: Do we want to start a process or not?
     inputs
-    |> Nx.concatenate()
-    |> state.config.model.()
-    |> Nx.to_batched(batch, 1)
+    |> concat_inputs()
+    |> maybe_pad(batch_size, state.config.batch_size)
+    |> then(&state.config.model.(state.config.params, &1))
+    |> maybe_pad(state.config.batch_size, batch_size)
+    |> Nx.to_batched(1)
     |> Enum.zip_with(froms, fn tensor, from ->
       GenServer.reply(from, tensor)
     end)
 
-    %{state | count: count - min(count, batch_size), queue: queue, timeout_ref: nil}
+    %{state | count: count - batch_size, queue: queue, timeout_ref: nil}
     |> maybe_start_timer()
     |> maybe_dispatch()
   end
@@ -122,5 +207,37 @@ defmodule Axon.Serving do
     after
       0 -> :ok
     end
+  end
+
+  defp concat_inputs(input_map) do
+    input_map
+    |> Enum.reduce(%{}, fn batch, inputs ->
+      batch
+      |> Enum.reduce(inputs, fn {name, tensor}, acc ->
+        Map.update(acc, name, [tensor], fn tensors -> [tensor | tensors] end)
+      end)
+    end)
+    |> Map.new(fn {key, tensors} -> {key, Nx.concatenate(tensors, axis: 0)} end)
+  end
+
+  defp maybe_pad(input, current_batch_size, desired_batch_size)
+       when current_batch_size == desired_batch_size do
+    input
+  end
+
+  defp maybe_pad(%Nx.Tensor{} = tensor, current_batch_size, desired_batch_size) do
+    pad_size = desired_batch_size - current_batch_size
+    do_pad(tensor, pad_size)
+  end
+
+  defp maybe_pad(inputs, current_batch_size, desired_batch_size) when is_map(inputs) do
+    pad_size = desired_batch_size - current_batch_size
+    Map.new(inputs, fn {name, tensor} -> {name, do_pad(tensor, pad_size)} end)
+  end
+
+  defp do_pad(tensor, pad_size) do
+    first_axis_pad = {0, pad_size, 0}
+    rest_axes_pad = List.duplicate({0, 0, 0}, Nx.rank(tensor) - 1)
+    Nx.pad(tensor, 0.0, [first_axis_pad | rest_axes_pad])
   end
 end

--- a/lib/axon/serving.ex
+++ b/lib/axon/serving.ex
@@ -10,7 +10,7 @@ defmodule Axon.Serving do
       children = [
         {Axon.Serving,
           name: :my_model,
-          model: &MyApp.Model.load_model/0,
+          model: MyApp.Model.load_model(),
           shape: MyApp.Model.input(),
           batch_size: 32,
           batch_timeout: 50,

--- a/lib/axon/serving.ex
+++ b/lib/axon/serving.ex
@@ -1,0 +1,126 @@
+defmodule Axon.Serving do
+  use GenServer
+
+  @doc false
+  def child_spec(opts) when is_list(opts) do
+    id =
+      case Keyword.get(opts, :name, Axon.Serving) do
+        name when is_atom(name) -> name
+        {:global, name} -> name
+        {:via, _module, name} -> name
+      end
+
+    %{
+      id: id,
+      start: {Axon.Serving, :start_link, [opts]},
+    }
+  end
+
+  ## API
+
+  @doc """
+  ## Options
+  """
+  def start_link(opts) do
+    config = %{
+      batch_size: Keyword.fetch!(opts, :batch_size, 1),
+      batch_timeout: Keyword.fetch!(opts, :batch_timeout, 100),
+      # model: Keyword.fetch!(opts, :model)
+    }
+
+    GenServer.start_link(__MODULE__, config, opts)
+  end
+
+  def predict(server, input) do
+    GenServer.call(server, {:predict, input}, :infinity)
+  end
+
+  ## Callbacks
+
+  @impl true
+  def init(config) do
+    state = %{
+      queue: :queue.new(),
+      count: 0,
+      timeout_ref: nil,
+      config: config
+    }
+
+    {:ok, state}
+  end
+
+  def handle_call({:predict, input}, from, state) do
+    %{queue: queue, count: count} = state
+    queue = :queue.in({input, from}, queue)
+
+    # TODO: if Nx.axis_size(input, 0) is more than batch_size,
+    # we should return error.
+
+    state =
+      %{state | acc: queue, count: count + Nx.axis_size(input, 0)}
+      |> maybe_start_timer()
+      |> maybe_dispatch()
+
+    {:noreply, state}
+  end
+
+  def handle_info(:timeout, state) do
+    dispatch(state)
+  end
+
+  defp maybe_start_timer(%{timeout_ref: nil, count: count} = state) when count > 0 do
+    ref = Process.send_after(self(), :timeout, state.config.batch_timeout)
+    %{state | timeout_ref: ref}
+  end
+
+  defp maybe_start_timer(%{timeout_ref: ref} = state) when is_reference(ref) do
+    state
+  end
+
+  defp maybe_dispatch(%{count: count, config: %{batch_size: batch_size} = state)
+       when count >= batch_size do
+    dispatch(state)
+  end
+
+  defp maybe_dispatch(state) do
+    state
+  end
+
+  # TODO: Make this work with batches != 1
+  defp dispatch(state) do
+    %{batch_size: batch_size, queue: queue, count: count, timeout_ref: timeout_ref} = state
+    cancel_timer(timeout_ref)
+
+    {now, queue} =
+      Enum.map_reduce(1..batch_size, state.queue, fn _, queue ->
+        {{:value, {input, from}}, queue} = :queue.out(queue)
+        1 = Nx.axis_size(input)
+        {pair, queue}
+      end)
+
+    {inputs, froms} = Enum.unzip(now)
+
+    # TODO: Do we want to start a process or not?
+    inputs
+    |> Nx.concatenate()
+    |> state.config.model.()
+    |> Nx.to_batched(batch, 1)
+    |> Enum.zip_with(froms, fn tensor, from ->
+      GenServer.reply(from, tensor)
+    end)
+
+    %{state | count: count - min(count, batch_size), queue: queue, timeout_ref: nil}
+    |> maybe_start_timer()
+    |> maybe_dispatch()
+  end
+
+  defp cancel_timer(timeout_ref) do
+    Process.cancel_timer(timeout_ref)
+
+    receive do
+      :timeout -> :ok
+    after
+      0 -> :ok
+    end
+  end
+end

--- a/lib/axon/serving.ex
+++ b/lib/axon/serving.ex
@@ -342,7 +342,7 @@ defmodule Axon.Serving do
     for idx <- 0..(batch_size - 1) do
       deep_new(result, fn
         %Axon.None{} = out -> out
-        out -> out[[idx]]
+        out -> Nx.new_axis(out[[idx]], 0)
       end)
     end
   end

--- a/lib/axon/serving.ex
+++ b/lib/axon/serving.ex
@@ -270,6 +270,7 @@ defmodule Axon.Serving do
 
   defp maybe_pad(inputs, current_batch_size, desired_batch_size) when is_map(inputs) do
     pad_size = desired_batch_size - current_batch_size
+    # TODO: Do not pad batched outputs
     Map.new(inputs, fn {name, tensor} -> {name, do_pad(tensor, pad_size)} end)
   end
 

--- a/lib/axon/serving.ex
+++ b/lib/axon/serving.ex
@@ -65,6 +65,7 @@ defmodule Axon.Serving do
 
   # TODO: With pre-processing how can we determine batch size
   # TODO: Add debug to trace wait time, execution time, etc.
+  # TODO: Support multiple batch sizes
 
   ## API
 

--- a/lib/axon/serving.ex
+++ b/lib/axon/serving.ex
@@ -65,7 +65,6 @@ defmodule Axon.Serving do
 
   # TODO: With pre-processing how can we determine batch size
   # TODO: Add debug to trace wait time, execution time, etc.
-  # TODO: Support multiple batch sizes
 
   ## API
 
@@ -146,8 +145,6 @@ defmodule Axon.Serving do
     %{config: %{batch_size: max_batch_size}, queue: queue, count: count} = state
     queue = :queue.in({input, from}, queue)
 
-    # TODO: if Nx.axis_size(input, 0) is more than batch_size,
-    # we should return error.
     # TODO: correctly handle counts/batch for all inputs
     # TODO: correctly handle container inputs
 
@@ -269,7 +266,7 @@ defmodule Axon.Serving do
 
     {inputs, froms} = Enum.unzip(now)
 
-    # TODO: do we really want to start a process here?
+    # TODO: Do we want to start a process here
     inputs
     |> concat_inputs()
     |> maybe_pad(actual_batch_size, state.config.batch_size)

--- a/lib/axon/shared.ex
+++ b/lib/axon/shared.ex
@@ -189,11 +189,15 @@ defmodule Axon.Shared do
   Creates a new map-like structure from a possible nested map, applying `fun`
   to each leaf.
   """
-  deftransform deep_new(item, fun) when is_integer(item) do
+  deftransform deep_new(item, fun) when is_number(item) do
     fun.(item)
   end
 
   deftransform deep_new(%Nx.Tensor{} = item, fun) do
+    fun.(item)
+  end
+
+  deftransform deep_new(%Axon.None{} = item, fun) do
     fun.(item)
   end
 
@@ -205,6 +209,9 @@ defmodule Axon.Shared do
   defp recur_traverse(item, :ok, fun) do
     case item do
       %Nx.Tensor{} = t ->
+        {fun.(t), :ok}
+
+      %Axon.None{} = t ->
         {fun.(t), :ok}
 
       container ->

--- a/test/axon/serving_test.exs
+++ b/test/axon/serving_test.exs
@@ -1,0 +1,424 @@
+defmodule Axon.ServingTest do
+  use Axon.Case
+
+  defp single_in_single_out() do
+    Axon.input("input") |> Axon.dense(32)
+  end
+
+  defp multi_in_single_out() do
+    inp1 = Axon.input("input1")
+    inp2 = Axon.input("input2")
+    Axon.add(Axon.dense(inp1, 32), Axon.dense(inp2, 32))
+  end
+
+  defp optional() do
+    inp1 = Axon.input("input1")
+    inp2 = Axon.input("input2", optional: true)
+    Axon.container(%{foo: Axon.dense(inp1, 32), bar: Axon.optional(inp2)})
+  end
+
+  defp deeply_nested() do
+    inp1 = Axon.input("input1")
+    inp2 = Axon.input("input2")
+
+    out = %{
+      foo: {inp1, %{bar: Axon.dense(inp1, 32)}},
+      baz: %{bang: {inp2, Axon.dense(inp2, 32)}, buzz: {}}
+    }
+
+    Axon.container(out)
+  end
+
+  defp model(model, shapes) do
+    templates = Map.new(shapes, fn {k, v} -> {k, Nx.template(v, :f32)} end)
+    {init_fn, _} = Axon.build(model)
+    {model, init_fn.(templates, %{})}
+  end
+
+  defp setup_predict(_context) do
+    single_in_shape = %{"input" => {8, 16}}
+    single_in_model = model(single_in_single_out(), single_in_shape)
+
+    Axon.Serving.start_link(
+      name: :single_in,
+      model: single_in_model,
+      shape: single_in_shape,
+      batch_size: 8,
+      batch_timeout: 50,
+      compiler: test_compiler()
+    )
+
+    multi_in_single_out_shape = %{"input1" => {8, 8}, "input2" => {8, 16}}
+    multi_in_single_out_model = model(multi_in_single_out(), multi_in_single_out_shape)
+
+    Axon.Serving.start_link(
+      name: :multi_in_single_out,
+      model: multi_in_single_out_model,
+      shape: multi_in_single_out_shape,
+      batch_size: 8,
+      batch_timeout: 50,
+      compiler: test_compiler()
+    )
+
+    optional_shape = %{"input1" => {8, 8}}
+    optional_model = model(optional(), optional_shape)
+
+    Axon.Serving.start_link(
+      name: :optional,
+      model: optional_model,
+      shape: optional_shape,
+      batch_size: 8,
+      batch_timeout: 50,
+      compiler: test_compiler()
+    )
+
+    deeply_nested_shape = %{"input1" => {8, 8}, "input2" => {8, 16}}
+    deeply_nested_model = model(deeply_nested(), deeply_nested_shape)
+
+    Axon.Serving.start_link(
+      name: :deeply_nested,
+      model: deeply_nested_model,
+      shape: deeply_nested_shape,
+      batch_size: 8,
+      batch_timeout: 50,
+      compiler: test_compiler()
+    )
+
+    {:ok,
+     %{
+       single_in: single_in_model,
+       multi_in_single_out: multi_in_single_out_model,
+       optional: optional_model,
+       deeply_nested: deeply_nested_model
+     }}
+  end
+
+  describe "initialization" do
+    test "initializes correctly with single-in, single-out model" do
+      single_in_shape = %{"input" => {8, 16}}
+      single_in_model = model(single_in_single_out(), single_in_shape)
+
+      assert {:ok, pid} =
+               Axon.Serving.start_link(
+                 name: :single_in,
+                 model: single_in_model,
+                 shape: single_in_shape,
+                 batch_size: 8,
+                 batch_timeout: 50,
+                 compiler: test_compiler()
+               )
+
+      GenServer.stop(pid)
+    end
+
+    test "initializes correctly with single-in, single-out model, nil batch" do
+      single_in_shape = %{"input" => {nil, 16}}
+      single_in_model = model(single_in_single_out(), %{"input" => {8, 16}})
+
+      assert {:ok, pid} =
+               Axon.Serving.start_link(
+                 name: :single_in,
+                 model: single_in_model,
+                 shape: single_in_shape,
+                 batch_size: 8,
+                 batch_timeout: 50,
+                 compiler: test_compiler()
+               )
+
+      GenServer.stop(pid)
+    end
+
+    test "initializes correctly with nil shape specified in model" do
+      model = Axon.input("foo", shape: {nil, 16}) |> Axon.dense(32)
+      {init_fn, _} = Axon.build(model)
+      params = init_fn.(Nx.template({1, 16}, :f32), %{})
+
+      assert {:ok, pid} =
+               Axon.Serving.start_link(
+                 name: :model,
+                 model: {model, params},
+                 shape: %{"foo" => nil},
+                 batch_size: 8,
+                 batch_timeout: 50
+               )
+
+      GenServer.stop(pid)
+    end
+
+    test "initializes correctly without optional input" do
+      inp1 = Axon.input("foo")
+      inp2 = Axon.input("bar", optional: true)
+      model = Axon.container(%{foo: inp1, bar: Axon.optional(inp2)})
+      params = %{}
+
+      assert {:ok, pid} =
+               Axon.Serving.start_link(
+                 name: :model,
+                 model: {model, params},
+                 shape: %{"foo" => {8, 16}},
+                 batch_size: 8,
+                 batch_timeout: 50
+               )
+
+      GenServer.stop(pid)
+    end
+
+    test "raises when shape is nil in both graph and config" do
+      model = Axon.input("foo") |> Axon.dense(32)
+      {init_fn, _} = Axon.build(model)
+      params = init_fn.(Nx.template({1, 16}, :f32), %{})
+
+      assert_raise ArgumentError, ~r/invalid shape/, fn ->
+        Axon.Serving.start_link(
+          name: :bad,
+          model: {model, params},
+          shape: %{"foo" => nil},
+          batch_size: 8,
+          compiler: test_compiler()
+        )
+      end
+    end
+
+    test "raises when required shape is not present in config" do
+      model = Axon.input("foo") |> Axon.dense(32)
+      {init_fn, _} = Axon.build(model)
+      params = init_fn.(Nx.template({1, 16}, :f32), %{})
+
+      assert_raise ArgumentError, ~r/must provide shape/, fn ->
+        Axon.Serving.start_link(
+          name: :bad,
+          model: {model, params},
+          shape: %{"bar" => {nil, 16}},
+          batch_size: 8,
+          compiler: test_compiler()
+        )
+      end
+    end
+
+    test "raises on mismatched shapes" do
+      model = Axon.input("foo", shape: {nil, 8}) |> Axon.dense(32)
+      {init_fn, _} = Axon.build(model)
+      params = init_fn.(Nx.template({1, 8}, :f32), %{})
+
+      assert_raise ArgumentError, ~r/invalid shape/, fn ->
+        Axon.Serving.start_link(
+          name: :bad,
+          model: {model, params},
+          shape: %{"foo" => {nil, 16}},
+          batch_size: 8,
+          compiler: test_compiler()
+        )
+      end
+    end
+
+    test "raises on mismatched batch sizes in config" do
+      model = Axon.input("foo") |> Axon.dense(32)
+      {init_fn, _} = Axon.build(model)
+      params = init_fn.(Nx.template({1, 16}, :f32), %{})
+
+      assert_raise ArgumentError, ~r/invalid shape/, fn ->
+        Axon.Serving.start_link(
+          name: :bad,
+          model: {model, params},
+          shape: %{"foo" => {8, 16}},
+          batch_size: 16,
+          compiler: test_compiler()
+        )
+      end
+    end
+
+    test "raises on mismatched batch sizes in graph" do
+      model = Axon.input("foo", shape: {8, 16}) |> Axon.dense(32)
+      {init_fn, _} = Axon.build(model)
+      params = init_fn.(Nx.template({8, 16}, :f32), %{})
+
+      assert_raise ArgumentError, ~r/invalid shape/, fn ->
+        Axon.Serving.start_link(
+          name: :bad,
+          model: {model, params},
+          shape: %{"foo" => nil},
+          batch_size: 16,
+          compiler: test_compiler()
+        )
+      end
+    end
+  end
+
+  describe "predict" do
+    setup [:setup_predict]
+
+    test "returns correctly with single unbatched predict and single in, single out model", %{
+      single_in: {model, params}
+    } do
+      input = %{"input" => Nx.random_uniform({1, 16})}
+      expected = Axon.predict(model, params, input)
+      actual = Axon.Serving.predict(:single_in, input)
+
+      assert_equal(expected, actual)
+    end
+
+    test "returns correctly with single predict multi-in, single out model", %{
+      multi_in_single_out: {model, params}
+    } do
+      input = %{"input1" => Nx.random_uniform({1, 8}), "input2" => Nx.random_uniform({1, 16})}
+      expected = Axon.predict(model, params, input)
+      actual = Axon.Serving.predict(:multi_in_single_out, input)
+
+      assert_equal(expected, actual)
+    end
+
+    test "returns correctly with single predict optional input model", %{
+      optional: {model, params}
+    } do
+      input = %{"input1" => Nx.random_uniform({1, 8})}
+      expected = Axon.predict(model, params, input)
+      actual = Axon.Serving.predict(:optional, input)
+
+      assert_equal(expected, actual)
+    end
+
+    test "returns correctly with single predict deeply nested model", %{
+      deeply_nested: {model, params}
+    } do
+      input = %{"input1" => Nx.random_uniform({1, 8}), "input2" => Nx.random_uniform({1, 16})}
+      expected = Axon.predict(model, params, input)
+      actual = Axon.Serving.predict(:deeply_nested, input)
+
+      assert_equal(expected, actual)
+    end
+
+    test "returns correctly with full-batch predict and single in, single out model", %{
+      single_in: {model, params}
+    } do
+      0..7
+      |> Enum.map(fn _idx ->
+        inp = %{"input" => Nx.random_uniform({1, 16})}
+        {inp, Axon.predict(model, params, inp)}
+      end)
+      |> Enum.map(fn {inp, expected} ->
+        {Task.async(fn -> Axon.Serving.predict(:single_in, inp) end), expected}
+      end)
+      |> Enum.each(fn {actual_pid, expected} ->
+        actual = Task.await(actual_pid)
+        assert_equal(expected, actual)
+      end)
+    end
+
+    test "returns correctly with full-batch predict and multi-in, single out model", %{
+      multi_in_single_out: {model, params}
+    } do
+      0..7
+      |> Enum.map(fn _idx ->
+        inp = %{"input1" => Nx.random_uniform({1, 8}), "input2" => Nx.random_uniform({1, 16})}
+        {inp, Axon.predict(model, params, inp)}
+      end)
+      |> Enum.map(fn {inp, expected} ->
+        {Task.async(fn -> Axon.Serving.predict(:multi_in_single_out, inp) end), expected}
+      end)
+      |> Enum.each(fn {actual_pid, expected} ->
+        actual = Task.await(actual_pid)
+        assert_equal(expected, actual)
+      end)
+    end
+
+    test "returns correctly with full-batch predict and optional model", %{
+      optional: {model, params}
+    } do
+      0..7
+      |> Enum.map(fn _idx ->
+        inp = %{"input1" => Nx.random_uniform({1, 8})}
+        {inp, Axon.predict(model, params, inp)}
+      end)
+      |> Enum.map(fn {inp, expected} ->
+        {Task.async(fn -> Axon.Serving.predict(:optional, inp) end), expected}
+      end)
+      |> Enum.each(fn {actual_pid, expected} ->
+        actual = Task.await(actual_pid)
+        assert_equal(expected, actual)
+      end)
+    end
+
+    test "returns correctly with full-batch predict and deeply nested model", %{
+      deeply_nested: {model, params}
+    } do
+      0..7
+      |> Enum.map(fn _idx ->
+        inp = %{"input1" => Nx.random_uniform({1, 8}), "input2" => Nx.random_uniform({1, 16})}
+        {inp, Axon.predict(model, params, inp)}
+      end)
+      |> Enum.map(fn {inp, expected} ->
+        {Task.async(fn -> Axon.Serving.predict(:deeply_nested, inp) end), expected}
+      end)
+      |> Enum.each(fn {actual_pid, expected} ->
+        actual = Task.await(actual_pid)
+        assert_equal(expected, actual)
+      end)
+    end
+
+    test "returns correctly with partial-batch predict timeout and single in, single out model",
+         %{single_in: {model, params}} do
+      0..4
+      |> Enum.map(fn _idx ->
+        inp = %{"input" => Nx.random_uniform({1, 16})}
+        {inp, Axon.predict(model, params, inp)}
+      end)
+      |> Enum.map(fn {inp, expected} ->
+        {Task.async(fn -> Axon.Serving.predict(:single_in, inp) end), expected}
+      end)
+      |> Enum.each(fn {actual_pid, expected} ->
+        actual = Task.await(actual_pid)
+        assert_equal(expected, actual)
+      end)
+    end
+
+    test "returns correctly with partial-batch predict timeout and multi-in, single out model", %{
+      multi_in_single_out: {model, params}
+    } do
+      0..4
+      |> Enum.map(fn _idx ->
+        inp = %{"input1" => Nx.random_uniform({1, 8}), "input2" => Nx.random_uniform({1, 16})}
+        {inp, Axon.predict(model, params, inp)}
+      end)
+      |> Enum.map(fn {inp, expected} ->
+        {Task.async(fn -> Axon.Serving.predict(:multi_in_single_out, inp) end), expected}
+      end)
+      |> Enum.each(fn {actual_pid, expected} ->
+        actual = Task.await(actual_pid)
+        assert_equal(expected, actual)
+      end)
+    end
+
+    test "returns correctly with partial-batch predict timeout and optional model",
+         %{optional: {model, params}} do
+      0..4
+      |> Enum.map(fn _idx ->
+        inp = %{"input1" => Nx.random_uniform({1, 8})}
+        {inp, Axon.predict(model, params, inp)}
+      end)
+      |> Enum.map(fn {inp, expected} ->
+        {Task.async(fn -> Axon.Serving.predict(:optional, inp) end), expected}
+      end)
+      |> Enum.each(fn {actual_pid, expected} ->
+        actual = Task.await(actual_pid)
+        assert_equal(expected, actual)
+      end)
+    end
+
+    test "returns correctly with partial-batch predict timeout and deeply nested model", %{
+      deeply_nested: {model, params}
+    } do
+      0..4
+      |> Enum.map(fn _idx ->
+        inp = %{"input1" => Nx.random_uniform({1, 8}), "input2" => Nx.random_uniform({1, 16})}
+        {inp, Axon.predict(model, params, inp)}
+      end)
+      |> Enum.map(fn {inp, expected} ->
+        {Task.async(fn -> Axon.Serving.predict(:deeply_nested, inp) end), expected}
+      end)
+      |> Enum.each(fn {actual_pid, expected} ->
+        actual = Task.await(actual_pid)
+        assert_equal(expected, actual)
+      end)
+    end
+  end
+end

--- a/test/axon/serving_test.exs
+++ b/test/axon/serving_test.exs
@@ -254,7 +254,7 @@ defmodule Axon.ServingTest do
       expected = Axon.predict(model, params, input)
       actual = Axon.Serving.predict(:single_in, input)
 
-      assert_all_close(expected, actual)
+      assert_all_close(expected, actual, atol: 1.0e-4)
     end
 
     test "returns correctly with single predict multi-in, single out model", %{
@@ -264,7 +264,7 @@ defmodule Axon.ServingTest do
       expected = Axon.predict(model, params, input)
       actual = Axon.Serving.predict(:multi_in_single_out, input)
 
-      assert_all_close(expected, actual)
+      assert_all_close(expected, actual, atol: 1.0e-4)
     end
 
     test "returns correctly with single predict optional input model", %{
@@ -274,7 +274,7 @@ defmodule Axon.ServingTest do
       expected = Axon.predict(model, params, input)
       actual = Axon.Serving.predict(:optional, input)
 
-      assert_all_close(expected, actual)
+      assert_all_close(expected, actual, atol: 1.0e-4)
     end
 
     test "returns correctly with single predict deeply nested model", %{
@@ -284,7 +284,7 @@ defmodule Axon.ServingTest do
       expected = Axon.predict(model, params, input)
       actual = Axon.Serving.predict(:deeply_nested, input)
 
-      assert_all_close(expected, actual)
+      assert_all_close(expected, actual, atol: 1.0e-4)
     end
 
     test "returns correctly with full-batch predict and single in, single out model", %{
@@ -300,7 +300,7 @@ defmodule Axon.ServingTest do
       end)
       |> Enum.each(fn {actual_pid, expected} ->
         actual = Task.await(actual_pid)
-        assert_all_close(expected, actual)
+        assert_all_close(expected, actual, atol: 1.0e-4)
       end)
     end
 
@@ -317,7 +317,7 @@ defmodule Axon.ServingTest do
       end)
       |> Enum.each(fn {actual_pid, expected} ->
         actual = Task.await(actual_pid)
-        assert_all_close(expected, actual)
+        assert_all_close(expected, actual, atol: 1.0e-4)
       end)
     end
 
@@ -334,7 +334,7 @@ defmodule Axon.ServingTest do
       end)
       |> Enum.each(fn {actual_pid, expected} ->
         actual = Task.await(actual_pid)
-        assert_all_close(expected, actual)
+        assert_all_close(expected, actual, atol: 1.0e-4)
       end)
     end
 
@@ -351,7 +351,7 @@ defmodule Axon.ServingTest do
       end)
       |> Enum.each(fn {actual_pid, expected} ->
         actual = Task.await(actual_pid)
-        assert_all_close(expected, actual)
+        assert_all_close(expected, actual, atol: 1.0e-4)
       end)
     end
 
@@ -367,7 +367,7 @@ defmodule Axon.ServingTest do
       end)
       |> Enum.each(fn {actual_pid, expected} ->
         actual = Task.await(actual_pid)
-        assert_all_close(expected, actual)
+        assert_all_close(expected, actual, atol: 1.0e-4)
       end)
     end
 
@@ -384,7 +384,7 @@ defmodule Axon.ServingTest do
       end)
       |> Enum.each(fn {actual_pid, expected} ->
         actual = Task.await(actual_pid)
-        assert_all_close(expected, actual)
+        assert_all_close(expected, actual, atol: 1.0e-4)
       end)
     end
 
@@ -400,7 +400,7 @@ defmodule Axon.ServingTest do
       end)
       |> Enum.each(fn {actual_pid, expected} ->
         actual = Task.await(actual_pid)
-        assert_all_close(expected, actual)
+        assert_all_close(expected, actual, atol: 1.0e-4)
       end)
     end
 
@@ -417,7 +417,7 @@ defmodule Axon.ServingTest do
       end)
       |> Enum.each(fn {actual_pid, expected} ->
         actual = Task.await(actual_pid)
-        assert_all_close(expected, actual)
+        assert_all_close(expected, actual, atol: 1.0e-4)
       end)
     end
   end

--- a/test/axon/serving_test.exs
+++ b/test/axon/serving_test.exs
@@ -254,7 +254,7 @@ defmodule Axon.ServingTest do
       expected = Axon.predict(model, params, input)
       actual = Axon.Serving.predict(:single_in, input)
 
-      assert_equal(expected, actual)
+      assert_all_close(expected, actual)
     end
 
     test "returns correctly with single predict multi-in, single out model", %{
@@ -264,7 +264,7 @@ defmodule Axon.ServingTest do
       expected = Axon.predict(model, params, input)
       actual = Axon.Serving.predict(:multi_in_single_out, input)
 
-      assert_equal(expected, actual)
+      assert_all_close(expected, actual)
     end
 
     test "returns correctly with single predict optional input model", %{
@@ -274,7 +274,7 @@ defmodule Axon.ServingTest do
       expected = Axon.predict(model, params, input)
       actual = Axon.Serving.predict(:optional, input)
 
-      assert_equal(expected, actual)
+      assert_all_close(expected, actual)
     end
 
     test "returns correctly with single predict deeply nested model", %{
@@ -284,7 +284,7 @@ defmodule Axon.ServingTest do
       expected = Axon.predict(model, params, input)
       actual = Axon.Serving.predict(:deeply_nested, input)
 
-      assert_equal(expected, actual)
+      assert_all_close(expected, actual)
     end
 
     test "returns correctly with full-batch predict and single in, single out model", %{
@@ -300,7 +300,7 @@ defmodule Axon.ServingTest do
       end)
       |> Enum.each(fn {actual_pid, expected} ->
         actual = Task.await(actual_pid)
-        assert_equal(expected, actual)
+        assert_all_close(expected, actual)
       end)
     end
 
@@ -317,7 +317,7 @@ defmodule Axon.ServingTest do
       end)
       |> Enum.each(fn {actual_pid, expected} ->
         actual = Task.await(actual_pid)
-        assert_equal(expected, actual)
+        assert_all_close(expected, actual)
       end)
     end
 
@@ -334,7 +334,7 @@ defmodule Axon.ServingTest do
       end)
       |> Enum.each(fn {actual_pid, expected} ->
         actual = Task.await(actual_pid)
-        assert_equal(expected, actual)
+        assert_all_close(expected, actual)
       end)
     end
 
@@ -351,7 +351,7 @@ defmodule Axon.ServingTest do
       end)
       |> Enum.each(fn {actual_pid, expected} ->
         actual = Task.await(actual_pid)
-        assert_equal(expected, actual)
+        assert_all_close(expected, actual)
       end)
     end
 
@@ -367,7 +367,7 @@ defmodule Axon.ServingTest do
       end)
       |> Enum.each(fn {actual_pid, expected} ->
         actual = Task.await(actual_pid)
-        assert_equal(expected, actual)
+        assert_all_close(expected, actual)
       end)
     end
 
@@ -384,7 +384,7 @@ defmodule Axon.ServingTest do
       end)
       |> Enum.each(fn {actual_pid, expected} ->
         actual = Task.await(actual_pid)
-        assert_equal(expected, actual)
+        assert_all_close(expected, actual)
       end)
     end
 
@@ -400,7 +400,7 @@ defmodule Axon.ServingTest do
       end)
       |> Enum.each(fn {actual_pid, expected} ->
         actual = Task.await(actual_pid)
-        assert_equal(expected, actual)
+        assert_all_close(expected, actual)
       end)
     end
 
@@ -417,7 +417,7 @@ defmodule Axon.ServingTest do
       end)
       |> Enum.each(fn {actual_pid, expected} ->
         actual = Task.await(actual_pid)
-        assert_equal(expected, actual)
+        assert_all_close(expected, actual)
       end)
     end
   end

--- a/test/axon_test.exs
+++ b/test/axon_test.exs
@@ -765,7 +765,7 @@ defmodule AxonTest do
 
       assert inspect(model) == """
              #Axon<
-               inputs: %{"input" => %{optional: false, shape: {nil, 784}}}
+               inputs: %{"input" => %{optional: false, shape: {nil, 784}, type: nil}}
                outputs: "softmax"
                nodes: 4
              >\
@@ -788,7 +788,7 @@ defmodule AxonTest do
 
       assert inspect(model) == """
              #Axon<
-               inputs: %{"input" => %{optional: false, shape: {nil, 784}}}
+               inputs: %{"input" => %{optional: false, shape: {nil, 784}, type: nil}}
                outputs: "softmax"
                nodes: 7
              >\
@@ -801,7 +801,7 @@ defmodule AxonTest do
 
       assert inspect(out_sequence) == """
              #Axon<
-               inputs: %{"input_0" => %{optional: false, shape: {nil, 32, 10}}}
+               inputs: %{"input_0" => %{optional: false, shape: {nil, 32, 10}, type: nil}}
                outputs: "lstm_output_sequence"
                nodes: 6
              >\
@@ -813,7 +813,7 @@ defmodule AxonTest do
 
       assert inspect(model) == """
              #Axon<
-               inputs: %{"input_0" => %{optional: false, shape: {nil, 1}}}
+               inputs: %{"input_0" => %{optional: false, shape: {nil, 1}, type: nil}}
                outputs: "x"
                nodes: 3
              >\
@@ -829,7 +829,7 @@ defmodule AxonTest do
 
       assert inspect(model) == """
              #Axon<
-               inputs: %{"input_0" => %{optional: false, shape: {nil, 1}}}
+               inputs: %{"input_0" => %{optional: false, shape: {nil, 1}, type: nil}}
                outputs: "y"
                nodes: 4
              >\
@@ -844,7 +844,7 @@ defmodule AxonTest do
 
       assert inspect(model) == """
              #Axon<
-               inputs: %{"input_0" => %{optional: false, shape: {nil, 1}}, "input_1" => %{optional: false, shape: {nil, 1}}}
+               inputs: %{"input_0" => %{optional: false, shape: {nil, 1}, type: nil}, "input_1" => %{optional: false, shape: {nil, 1}, type: nil}}
                outputs: "add_0"
                nodes: 8
              >\
@@ -859,7 +859,7 @@ defmodule AxonTest do
 
       assert inspect(model) == """
              #Axon<
-               inputs: %{"input_0" => %{optional: false, shape: {nil, 1}}, "input_1" => %{optional: false, shape: {nil, 1}}}
+               inputs: %{"input_0" => %{optional: false, shape: {nil, 1}, type: nil}, "input_1" => %{optional: false, shape: {nil, 1}, type: nil}}
                outputs: "add_0"
                nodes: 7
              >\

--- a/test/axon_test.exs
+++ b/test/axon_test.exs
@@ -765,7 +765,7 @@ defmodule AxonTest do
 
       assert inspect(model) == """
              #Axon<
-               inputs: %{"input" => {nil, 784}}
+               inputs: %{"input" => %{optional: false, shape: {nil, 784}}}
                outputs: "softmax"
                nodes: 4
              >\
@@ -788,7 +788,7 @@ defmodule AxonTest do
 
       assert inspect(model) == """
              #Axon<
-               inputs: %{"input" => {nil, 784}}
+               inputs: %{"input" => %{optional: false, shape: {nil, 784}}}
                outputs: "softmax"
                nodes: 7
              >\
@@ -801,7 +801,7 @@ defmodule AxonTest do
 
       assert inspect(out_sequence) == """
              #Axon<
-               inputs: %{"input_0" => {nil, 32, 10}}
+               inputs: %{"input_0" => %{optional: false, shape: {nil, 32, 10}}}
                outputs: "lstm_output_sequence"
                nodes: 6
              >\
@@ -813,7 +813,7 @@ defmodule AxonTest do
 
       assert inspect(model) == """
              #Axon<
-               inputs: %{"input_0" => {nil, 1}}
+               inputs: %{"input_0" => %{optional: false, shape: {nil, 1}}}
                outputs: "x"
                nodes: 3
              >\
@@ -829,7 +829,7 @@ defmodule AxonTest do
 
       assert inspect(model) == """
              #Axon<
-               inputs: %{"input_0" => {nil, 1}}
+               inputs: %{"input_0" => %{optional: false, shape: {nil, 1}}}
                outputs: "y"
                nodes: 4
              >\
@@ -844,7 +844,7 @@ defmodule AxonTest do
 
       assert inspect(model) == """
              #Axon<
-               inputs: %{"input_0" => {nil, 1}, "input_1" => {nil, 1}}
+               inputs: %{"input_0" => %{optional: false, shape: {nil, 1}}, "input_1" => %{optional: false, shape: {nil, 1}}}
                outputs: "add_0"
                nodes: 8
              >\
@@ -859,7 +859,7 @@ defmodule AxonTest do
 
       assert inspect(model) == """
              #Axon<
-               inputs: %{"input_0" => {nil, 1}, "input_1" => {nil, 1}}
+               inputs: %{"input_0" => %{optional: false, shape: {nil, 1}}, "input_1" => %{optional: false, shape: {nil, 1}}}
                outputs: "add_0"
                nodes: 7
              >\


### PR DESCRIPTION
WIP: Need to add tests

From our original implementation I added a few features, and there's still more I think we need to determine before merging:

1. `preprocess`/`postprocess` - I found when trying to deploy a pipeline, it makes sense to have something like this. For example, imagine an image classification task, you probably want the logic of featurizing and processing config to be batched/handled in batches rather than worry about doing it yourself. Both `preprocess` and `postprocess` take an input and `state` (discussed later) and return tensors. The issue right now with is that if we focus on pre-processing raw inputs, it's not possible to determine batch size unless we allow `predict` to have a signature which accepts either tensors, raw, or list of raw inputs.

2. `state` - Again imagine the image classification app. You have a featurizer which is loaded on startup. it makes sense to include this as a part of the serving state, then you can use it in `preprocess` and `postprocess`. The state is arbitrary, so it can also be something like a tokenizer or other.

3. We still do not correctly handle container outputs. I *think* we can safely just do the padding of map outputs by just padding. I don't think it's possible to have an unbatched output.

4. We still do not correctly handle unbatched inputs. I handled optional inputs by discarding those not specified in `:shape`, but for inputs like `head_mask` where they are not batched, the API will have a fit and raise if their leading dim is not the same as `batch_size`

5. We also still have the question of starting a task to pad/split batches and do inference. I guess the only benefit here is we do not block the queue from filling up? Not sure I have enough info to make a decision ATM.

Otherwise, I will add tests tomorrow and then once we address these concerns I think this is good to merge :)