### PR TITLE
Fix Axon.Loop.reduce_lr_on_plateau documentation

### DIFF
--- a/lib/axon/loop.ex
+++ b/lib/axon/loop.ex
@@ -1106,7 +1106,7 @@ defmodule Axon.Loop do
       |> Axon.Loop.trainer(loss, optim)
       |> Axon.Loop.metric(:accuracy)
       |> Axon.Loop.validate(model, val_data)
-      |> Axon.Loop.reduce_lr_on_plateau("accuracy")
+      |> Axon.Loop.reduce_lr_on_plateau("accuracy", mode: :max)
 
   ## Options
 

--- a/lib/axon/loop.ex
+++ b/lib/axon/loop.ex
@@ -1105,8 +1105,8 @@ defmodule Axon.Loop do
       model
       |> Axon.Loop.trainer(loss, optim)
       |> Axon.Loop.metric(:accuracy)
-      |> Axon.Loop.validate(val_data)
-      |> Axon.Loop.reduce_lr_on_plateau("validation_accuracy")
+      |> Axon.Loop.validate(model, val_data)
+      |> Axon.Loop.reduce_lr_on_plateau("accuracy")
 
   ## Options
 


### PR DESCRIPTION
Fix Axon.Loop.reduce_lr_on_plateau documentation
1. [`Axon.Loop.validate/3`](https://hexdocs.pm/axon/Axon.Loop.html#validate/3) expects the model as the first parameter
2. The accuracy metric is named "accuracy" by default, `validate` reuses the name.