### PR TITLE
Return tuple of loop state and transformed state

### DIFF
--- a/lib/axon/loop.ex
+++ b/lib/axon/loop.ex
@@ -536,7 +536,7 @@ defmodule Axon.Loop do
     # Build loss now so we can use it as a metric
     loss_fn = build_loss_fn(loss)
     {init_fn, step_fn} = train_step(model, loss_fn, optimizer)
-    output_transform = fn state -> state.step_state[:model_state] end
+    output_transform = fn state -> {state, state.step_state[:model_state]} end
 
     loop =
       step_fn

--- a/lib/axon/loop.ex
+++ b/lib/axon/loop.ex
@@ -536,7 +536,7 @@ defmodule Axon.Loop do
     # Build loss now so we can use it as a metric
     loss_fn = build_loss_fn(loss)
     {init_fn, step_fn} = train_step(model, loss_fn, optimizer)
-    output_transform = fn state -> {state, state.step_state[:model_state]} end
+    output_transform = fn state -> state.step_state[:model_state] end
 
     loop =
       step_fn
@@ -1446,7 +1446,7 @@ defmodule Axon.Loop do
     {_, state} = fire_event(status, handler_fns, state, debug?)
     state = %State{state | metrics: final_metrics}
 
-    output_transform.(state)
+    {state, output_transform.(state)}
   end
 
   ## Helpers

--- a/test/axon/loop_test.exs
+++ b/test/axon/loop_test.exs
@@ -54,7 +54,7 @@ defmodule Axon.LoopTest do
           assert_equal(tar, Nx.tensor([[1]]))
           assert_equal(pred, Nx.tensor([[1]]))
 
-          assert_equal(transform.(state), %{})
+          assert_equal(transform.(state), {state, %{}})
         end
       end
     end
@@ -77,7 +77,7 @@ defmodule Axon.LoopTest do
       assert_equal(pred, Nx.tensor([[1]]))
       assert_equal(loss, Nx.tensor(5.0))
 
-      assert_equal(transform.(state), %{})
+      assert_equal(transform.(state), {state, %{}})
     end
 
     test "trainer/3 returns a supervised training loop with custom optimizer" do
@@ -97,7 +97,7 @@ defmodule Axon.LoopTest do
       assert_equal(tar, Nx.tensor([[1]]))
       assert_equal(pred, Nx.tensor([[1]]))
 
-      assert_equal(transform.(state), %{})
+      assert_equal(transform.(state), {state, %{}})
     end
 
     test "trainer/3 returns a supervised training loop with custom model" do
@@ -116,7 +116,7 @@ defmodule Axon.LoopTest do
       assert_equal(tar, Nx.tensor([[1]]))
       assert_equal(pred, Nx.tensor([[1]]))
 
-      assert_equal(transform.(state), %{})
+      assert_equal(transform.(state), {state, %{}})
     end
 
     test "trainer/3 returns a supervised training loop with multi-loss" do
@@ -142,7 +142,7 @@ defmodule Axon.LoopTest do
       assert_equal(pred, {Nx.tensor([[1]]), Nx.tensor([[1]])})
       assert_equal(loss, Nx.tensor(1.0))
 
-      assert_equal(transform.(state), %{})
+      assert_equal(transform.(state), {state, %{}})
     end
 
     test "trainer/3 raises on bad inputs" do

--- a/test/axon/loop_test.exs
+++ b/test/axon/loop_test.exs
@@ -200,9 +200,9 @@ defmodule Axon.LoopTest do
 
       ExUnit.CaptureIO.capture_io(fn ->
         assert {
-          %State{metrics: %{0 => %{"mean_absolute_error" => _}}},
-          %{0 => %{"mean_absolute_error" => _}}
-        } = Loop.run(loop, data, model_state)
+                 %State{metrics: %{0 => %{"mean_absolute_error" => _}}},
+                 %{0 => %{"mean_absolute_error" => _}}
+               } = Loop.run(loop, data, model_state)
       end)
     end
 
@@ -355,9 +355,9 @@ defmodule Axon.LoopTest do
         |> Loop.run([Nx.tensor(1)], %{}, epochs: 0)
 
       assert {
-        %State{epoch: 0, iteration: 0, times: %{}, metrics: %{}, step_state: %{}},
-        %State{epoch: 0, iteration: 0, times: %{}, metrics: %{}, step_state: pstate}
-       } = state
+               %State{epoch: 0, iteration: 0, times: %{}, metrics: %{}, step_state: %{}},
+               %State{epoch: 0, iteration: 0, times: %{}, metrics: %{}, step_state: pstate}
+             } = state
 
       assert pstate == %{}
     end

--- a/test/support/axon_test_util.ex
+++ b/test/support/axon_test_util.ex
@@ -63,14 +63,6 @@ defmodule AxonTestUtil do
     end
   end
 
-  def assert_equal(lhs, rhs) when is_struct(lhs) and is_struct(rhs) do
-    assert_equal(Map.from_struct(lhs), Map.from_struct(rhs))
-  end
-
-  def assert_equal(lhs, rhs) when is_integer(lhs) and is_integer(rhs) do
-    lhs == rhs
-  end
-
   def assert_equal(lhs, rhs) when is_map(lhs) and is_map(rhs) do
     lhs
     |> Map.values()

--- a/test/support/axon_test_util.ex
+++ b/test/support/axon_test_util.ex
@@ -63,6 +63,14 @@ defmodule AxonTestUtil do
     end
   end
 
+  def assert_equal(lhs, rhs) when is_struct(lhs) and is_struct(rhs) do
+    assert_equal(Map.from_struct(lhs), Map.from_struct(rhs))
+  end
+
+  def assert_equal(lhs, rhs) when is_integer(lhs) and is_integer(rhs) do
+    lhs == rhs
+  end
+
   def assert_equal(lhs, rhs) when is_map(lhs) and is_map(rhs) do
     lhs
     |> Map.values()


### PR DESCRIPTION
If I understood correctly #362 , the new output of the transform should be `{%Axon.Loop.State{...}, transformed_state}`, so this PR implements said change and updates the tests. This should be the case for other default transforms too? So far I just changed `trainer` but I guess `evaluator` should follow suit. Is that right @seanmor5 ?

Closes #362