### PR TITLE
Add exception when dropout is outside expected range

### DIFF
--- a/lib/axon.ex
+++ b/lib/axon.ex
@@ -1375,7 +1375,7 @@ defmodule Axon do
 
     if opts[:rate] < 0 or opts[:rate] >= 1 do
       raise ArgumentError,
-        "The dropout rate needs to be >= 0 and < 1, got #{inspect(opts[:rate])}"
+            "The dropout rate needs to be >= 0 and < 1, got #{inspect(opts[:rate])}"
     end
 
     layer(dropout, [x],

--- a/lib/axon.ex
+++ b/lib/axon.ex
@@ -1361,6 +1361,7 @@ defmodule Axon do
       * `:name` - layer name.
 
       * `:rate` - dropout rate. Defaults to `0.5`.
+        Needs to be equal or greater than zero and less than one.
 
     """
     @doc type: :dropout
@@ -1371,6 +1372,11 @@ defmodule Axon do
 
   defp dropout(%Axon{} = x, dropout, opts) do
     opts = Keyword.validate!(opts, [:name, rate: 0.5])
+
+    if opts[:rate] < 0 or opts[:rate] >= 1 do
+      raise ArgumentError,
+        "The dropout rate needs to be >= 0 and < 1, got #{inspect(opts[:rate])}"
+    end
 
     layer(dropout, [x],
       name: opts[:name],

--- a/lib/axon/layers.ex
+++ b/lib/axon/layers.ex
@@ -1492,7 +1492,6 @@ defmodule Axon.Layers do
   @doc type: :dropout
   defn dropout(input, opts \\ []) do
     opts = keyword!(opts, [:rate, noise_shape: Nx.shape(input), mode: :inference])
-
     keep_prob = Nx.tensor(1, type: Nx.type(input)) - Nx.tensor(opts[:rate], type: Nx.type(input))
     mask = Nx.less(Nx.random_uniform(opts[:noise_shape], type: Nx.type(input)), keep_prob)
 

--- a/lib/axon/layers.ex
+++ b/lib/axon/layers.ex
@@ -1492,6 +1492,7 @@ defmodule Axon.Layers do
   @doc type: :dropout
   defn dropout(input, opts \\ []) do
     opts = keyword!(opts, [:rate, noise_shape: Nx.shape(input), mode: :inference])
+
     keep_prob = Nx.tensor(1, type: Nx.type(input)) - Nx.tensor(opts[:rate], type: Nx.type(input))
     mask = Nx.less(Nx.random_uniform(opts[:noise_shape], type: Nx.type(input)), keep_prob)
 

--- a/test/axon_test.exs
+++ b/test/axon_test.exs
@@ -391,9 +391,11 @@ defmodule AxonTest do
       opts = [rate: -0.1]
 
       for dropout <- @dropout_layers do
-        assert_raise ArgumentError, "The dropout rate needs to be >= 0 and < 1, got #{inspect(opts[:rate])}" , fn ->
-          apply(Axon, dropout, [Axon.input("input", shape: {nil, 32}), opts])
-        end
+        assert_raise ArgumentError,
+                     "The dropout rate needs to be >= 0 and < 1, got #{inspect(opts[:rate])}",
+                     fn ->
+                       apply(Axon, dropout, [Axon.input("input", shape: {nil, 32}), opts])
+                     end
       end
     end
 
@@ -401,9 +403,11 @@ defmodule AxonTest do
       opts = [rate: 1]
 
       for dropout <- @dropout_layers do
-        assert_raise ArgumentError, "The dropout rate needs to be >= 0 and < 1, got #{inspect(opts[:rate])}" , fn ->
-          apply(Axon, dropout, [Axon.input("input", shape: {nil, 32}), opts])
-        end
+        assert_raise ArgumentError,
+                     "The dropout rate needs to be >= 0 and < 1, got #{inspect(opts[:rate])}",
+                     fn ->
+                       apply(Axon, dropout, [Axon.input("input", shape: {nil, 32}), opts])
+                     end
       end
     end
   end

--- a/test/axon_test.exs
+++ b/test/axon_test.exs
@@ -386,6 +386,26 @@ defmodule AxonTest do
         assert opts[:rate] == 0.5
       end
     end
+
+    test "raises for rates below zero" do
+      opts = [rate: -0.1]
+
+      for dropout <- @dropout_layers do
+        assert_raise ArgumentError, "The dropout rate needs to be >= 0 and < 1, got #{inspect(opts[:rate])}" , fn ->
+          apply(Axon, dropout, [Axon.input("input", shape: {nil, 32}), opts])
+        end
+      end
+    end
+
+    test "raises for rates above or equal to one" do
+      opts = [rate: 1]
+
+      for dropout <- @dropout_layers do
+        assert_raise ArgumentError, "The dropout rate needs to be >= 0 and < 1, got #{inspect(opts[:rate])}" , fn ->
+          apply(Axon, dropout, [Axon.input("input", shape: {nil, 32}), opts])
+        end
+      end
+    end
   end
 
   @pooling_layers [:max_pool, :avg_pool, :lp_pool]


### PR DESCRIPTION
The dropout rate is always expected to be in the range of [0, 1). With these changes, now an exception is raised if this happens, instead of letting it crash with an arithmetic error.

Closes #367 