### PR TITLE
Use layer key meta to split keys

### DIFF
--- a/lib/axon.ex
+++ b/lib/axon.ex
@@ -2729,13 +2729,11 @@ defmodule Axon do
 
       case initializer do
         fun when is_function(fun) ->
-          {out, _} = fun.(shape)
-          out
+          fun.(shape)
 
         fun when is_atom(fun) ->
           fun = apply(Axon.Initializers, fun, [])
-          {out, _} = fun.(shape, {:f, 32}, opts[:key])
-          out
+          fun.(shape, {:f, 32}, opts[:key])
       end
     end
 
@@ -3211,10 +3209,10 @@ defmodule Axon do
   @doc type: :model
   def compile(model, template, init_params \\ %{}, opts \\ []) when is_list(opts) do
     {init_fn, predict_fn} = build(model, opts)
-    init_compiled_fn = Nx.Defn.compile(init_fn, [template, init_params])
+    init_compiled_fn = Nx.Defn.compile(init_fn, [template, init_params], opts)
 
     predict_compiled_fn =
-      Nx.Defn.compile(predict_fn, [init_compiled_fn.(template, init_params), template])
+      Nx.Defn.compile(predict_fn, [init_compiled_fn.(template, init_params), template], opts)
 
     {init_compiled_fn, predict_compiled_fn}
   end

--- a/lib/axon/compiler.ex
+++ b/lib/axon/compiler.ex
@@ -86,7 +86,11 @@ defmodule Axon.Compiler do
 
       {time, params} =
         :timer.tc(fn ->
-          {_, {params, _, _}} = cache[root_id][:init].(template, cache, %{}, stacktrace, key)
+          param_keys = get_keys(nodes, key)
+
+          {_, {params, _}} =
+            cache[root_id][:init].(template, cache, %{}, stacktrace, param_keys)
+
           params
         end)
 
@@ -100,6 +104,58 @@ defmodule Axon.Compiler do
     end
 
     {init_fun, predict_fun}
+  end
+
+  defp get_keys(nodes, key) do
+    names_and_data =
+      nodes
+      |> Map.values()
+      |> Enum.reduce({[], %{}}, fn
+        %Axon.Node{op: op, name: name_fn, parameters: params}, {keys, op_counts} ->
+          name = name_fn.(op, op_counts)
+          op_counts = Map.update(op_counts, op, 1, &(&1 + 1))
+
+          keys =
+            Enum.reduce(params, keys, fn %Axon.Parameter{name: param_name, initializer: fun}, keys ->
+              {:arity, arity} = Function.info(fun, :arity)
+
+              cond do
+                arity == 2 ->
+                  keys
+
+                arity == 3 ->
+                  <<data::unsigned-size(32), _rest::binary>> = :erlang.md5(name <> "." <> param_name)
+                  [{{name, param_name}, data} | keys]
+
+                true ->
+                  raise ArgumentError, "bad initializer arity"
+              end
+            end)
+
+          {keys, op_counts}
+      end)
+      |> elem(0)
+
+    {names, data} = Enum.unzip(names_and_data)
+
+    case names do
+      [] ->
+        %{}
+
+      [_ | _] = names ->
+        keys_tensor =
+          data
+          |> Nx.stack()
+          |> then(&Nx.Random.fold_in(key, &1))
+
+        {keys_idxs, _} =
+          Enum.reduce(names, {%{}, 0}, fn {layer_name, param_name}, {acc, i} ->
+            acc = Map.update(acc, layer_name, %{param_name => i}, &Map.put(&1, param_name, i))
+            {acc, i + 1}
+          end)
+
+        {keys_idxs, keys_tensor}
+    end
   end
 
   defp merge_params!(params, init_params) do
@@ -151,23 +207,23 @@ defmodule Axon.Compiler do
     end
   end
 
-  defp call_init_cache(parent_id, template, params, cache, result_cache, fn_stacktrace, seed) do
+  defp call_init_cache(parent_id, template, params, cache, result_cache, fn_stacktrace, keys) do
     key = {:init_cache, parent_id}
 
-    {parent_shape, {parent_params, result_cache, seed}} =
+    {parent_shape, {parent_params, result_cache}} =
       case result_cache do
-        %{^key => {parent_shape, parent_params, seed}} ->
-          {parent_shape, {parent_params, result_cache, seed}}
+        %{^key => {parent_shape, parent_params}} ->
+          {parent_shape, {parent_params, result_cache}}
 
         %{} ->
-          {parent_shape, {parent_params, result_cache, seed}} =
-            cache[parent_id][:init].(template, cache, result_cache, fn_stacktrace, seed)
+          {parent_shape, {parent_params, result_cache}} =
+            cache[parent_id][:init].(template, cache, result_cache, fn_stacktrace, keys)
 
           {parent_shape,
-           {parent_params, Map.put(result_cache, key, {parent_shape, parent_params, seed}), seed}}
+           {parent_params, Map.put(result_cache, key, {parent_shape, parent_params})}}
       end
 
-    {parent_shape, {Map.merge(parent_params, params), result_cache, seed}}
+    {parent_shape, {Map.merge(parent_params, params), result_cache}}
   end
 
   defp recur_model_funs(
@@ -185,8 +241,8 @@ defmodule Axon.Compiler do
       {out, {state, result_cache}}
     end
 
-    init_fun = fn _template, _cache, result_cache, _fn_stacktrace, key ->
-      {Nx.shape(tensor), {%{}, result_cache, key}}
+    init_fun = fn _template, _cache, result_cache, _fn_stacktrace, _keys ->
+      {Nx.shape(tensor), {%{}, result_cache}}
     end
 
     model_funs = %{predict: predict_fun, init: init_fun}
@@ -223,9 +279,9 @@ defmodule Axon.Compiler do
       {res, {state, result_cache}}
     end
 
-    init_fun = fn template, _cache, result_cache, _fn_stacktrace, key ->
+    init_fun = fn template, _cache, result_cache, _fn_stacktrace, _keys ->
       input = get_input(template, name, optional?)
-      {safe_shape(input), {%{}, result_cache, key}}
+      {safe_shape(input), {%{}, result_cache}}
     end
 
     model_funs = %{predict: predict_fun, init: init_fun}
@@ -250,13 +306,13 @@ defmodule Axon.Compiler do
       {out, {state, result_cache}}
     end
 
-    init_fun = fn template, cache, result_cache, fn_stacktrace, key ->
-      {out, {params, result_cache, key}} =
-        call_init_cache(parent_id, template, %{}, cache, result_cache, fn_stacktrace, key)
+    init_fun = fn template, cache, result_cache, fn_stacktrace, keys ->
+      {out, {params, result_cache}} =
+        call_init_cache(parent_id, template, %{}, cache, result_cache, fn_stacktrace, keys)
 
       out = with %Axon.None{} <- out, do: %Axon.None{__propagate__: false}
 
-      {safe_shape(out), {params, result_cache, key}}
+      {safe_shape(out), {params, result_cache}}
     end
 
     model_funs = %{predict: predict_fun, init: init_fun}
@@ -302,11 +358,11 @@ defmodule Axon.Compiler do
       {input, {state, result_cache}}
     end
 
-    init_fun = fn template, cache, result_cache, fn_stacktrace, key ->
-      {parent_shape, {parent_params, result_cache, none?, key}} =
-        deep_map_reduce(parent_ids, {%{}, result_cache, false, key}, fn
-          parent_id, {params, result_cache, none?, key} ->
-            {parent_shape, {params, result_cache, key}} =
+    init_fun = fn template, cache, result_cache, fn_stacktrace, keys ->
+      {parent_shape, {parent_params, result_cache, none?}} =
+        deep_map_reduce(parent_ids, {%{}, result_cache, false}, fn
+          parent_id, {params, result_cache, none?} ->
+            {parent_shape, {params, result_cache}} =
               call_init_cache(
                 parent_id,
                 template,
@@ -314,16 +370,16 @@ defmodule Axon.Compiler do
                 cache,
                 result_cache,
                 fn_stacktrace,
-                key
+                keys
               )
 
             none? = none? or propagating_none?(parent_shape)
-            {parent_shape, {params, result_cache, none?, key}}
+            {parent_shape, {params, result_cache, none?}}
         end)
 
       parent_shape = if none?, do: %Axon.None{}, else: parent_shape
 
-      {parent_shape, {parent_params, result_cache, key}}
+      {parent_shape, {parent_params, result_cache}}
     end
 
     model_funs = %{predict: predict_fun, init: init_fun}
@@ -379,9 +435,9 @@ defmodule Axon.Compiler do
       {out, {state, result_cache}}
     end
 
-    init_fun = fn template, cache, result_cache, fn_stacktrace, key ->
-      {_parent_shape, {namespace_params, result_cache, key}} =
-        call_init_cache(parent_id, template, %{}, cache, result_cache, fn_stacktrace, key)
+    init_fun = fn template, cache, result_cache, fn_stacktrace, keys ->
+      {_parent_shape, {namespace_params, result_cache}} =
+        call_init_cache(parent_id, template, %{}, cache, result_cache, fn_stacktrace, keys)
 
       params =
         if namespace_params == %{} do
@@ -393,7 +449,7 @@ defmodule Axon.Compiler do
       {pred_expr, {_, result_cache}} =
         predict_fun.(params, template, %{}, cache, result_cache, fn_stacktrace)
 
-      {safe_shape(pred_expr), {params, result_cache, key}}
+      {safe_shape(pred_expr), {params, result_cache}}
     end
 
     model_funs = %{predict: predict_fun, init: init_fun}
@@ -690,7 +746,7 @@ defmodule Axon.Compiler do
          cache,
          result_cache,
          fn_stacktrace,
-         key,
+         keys,
          parent_ids,
          name,
          predict_fun,
@@ -698,22 +754,22 @@ defmodule Axon.Compiler do
          %{params: dtype},
          hooks
        ) do
-    {parent_shapes, {parent_params, result_cache, none?, key}} =
-      Enum.map_reduce(parent_ids, {%{}, result_cache, false, key}, fn
-        parent_id, {params, result_cache, none?, key} ->
-          {parent_shape, {params, result_cache, key}} =
-            call_init_cache(parent_id, template, params, cache, result_cache, fn_stacktrace, key)
+    {parent_shapes, {parent_params, result_cache, none?}} =
+      Enum.map_reduce(parent_ids, {%{}, result_cache, false}, fn
+        parent_id, {params, result_cache, none?} ->
+          {parent_shape, {params, result_cache}} =
+            call_init_cache(parent_id, template, params, cache, result_cache, fn_stacktrace, keys)
 
           none? = none? or propagating_none?(parent_shape)
-          {parent_shape, {params, result_cache, none?, key}}
+          {parent_shape, {params, result_cache, none?}}
       end)
 
     if none? do
-      {%Axon.None{}, {parent_params, result_cache, key}}
+      {%Axon.None{}, {parent_params, result_cache}}
     else
       layer_params =
         Enum.reduce(parameters, %{}, fn param, layer_params ->
-          init_param(name, param, layer_params, parent_shapes, dtype, key)
+          init_param(name, param, layer_params, parent_shapes, dtype, keys)
         end)
 
       layer_params = apply_hooks(layer_params, :initialize, nil, hooks)
@@ -728,58 +784,40 @@ defmodule Axon.Compiler do
       {pred_expr, {_, result_cache}} =
         predict_fun.(params, template, %{}, cache, result_cache, fn_stacktrace)
 
-      {safe_shape(pred_expr), {params, result_cache, key}}
+      {safe_shape(pred_expr), {params, result_cache}}
     end
   end
 
-  defp init_param(layer_name, param, layer_params, parent_shapes, dtype, key) do
+  defp init_param(layer_name, param, layer_params, parent_shapes, dtype, keys) do
     %{name: name, shape: shape, initializer: initializer} = param
 
     params =
       case shape do
         {:tuple, params} ->
           params =
-            Enum.with_index(params, fn shape, i ->
-              param_name = name <> "." <> "#{i}"
+            Enum.map(params, fn shape ->
               shape = apply(shape, parent_shapes)
-              apply_initializer(initializer, layer_name, param_name, shape, dtype, key)
+              apply_initializer(initializer, layer_name, name, shape, dtype, keys)
             end)
 
           List.to_tuple(params)
 
         shape ->
           shape = apply(shape, parent_shapes)
-          apply_initializer(initializer, layer_name, name, shape, dtype, key)
+          apply_initializer(initializer, layer_name, name, shape, dtype, keys)
       end
 
     Map.put(layer_params, name, params)
   end
 
-  @initializer_no_key [:zeros, :ones, :identity, :full]
-
-  defp apply_initializer(initializer, _layer_name, _param_name, shape, type, key)
-       when initializer in @initializer_no_key do
-    fun = apply(Axon.Initializers, initializer, [])
-    fun.(shape, type, key)
+  defp apply_initializer(initializer, _layer_name, _name, shape, type, _keys) when is_function(initializer, 2) do
+    initializer.(shape, type)
   end
 
-  defp apply_initializer(initializer, layer_name, param_name, shape, type, key)
-       when is_atom(initializer) do
-    <<data::unsigned-size(32), _rest::binary>> =
-      :crypto.hash(:sha, layer_name <> "." <> param_name)
-
-    key_to_use = Nx.Random.fold_in(key, data)
-    fun = apply(Axon.Initializers, initializer, [])
-    fun.(shape, type, key_to_use)
-  end
-
-  defp apply_initializer(initializer, layer_name, param_name, shape, type, key)
-       when is_function(initializer, 3) do
-    <<data::unsigned-size(32), _rest::binary>> =
-      :crypto.hash(:sha, layer_name <> "." <> param_name)
-
-    key_to_use = Nx.Random.fold_in(key, data)
-    initializer.(shape, type, key_to_use)
+  defp apply_initializer(initializer, layer_name, name, shape, type, {keys_idxs, keys_tensor}) when is_function(initializer, 3) do
+    key_idxs = keys_idxs[layer_name][name]
+    key = keys_tensor[[key_idxs]]
+    initializer.(shape, type, key)
   end
 
   defp maybe_freeze(param, true), do: Nx.Defn.Kernel.stop_grad(param)

--- a/lib/axon/compiler.ex
+++ b/lib/axon/compiler.ex
@@ -88,8 +88,7 @@ defmodule Axon.Compiler do
         :timer.tc(fn ->
           param_keys = get_keys(nodes, key)
 
-          {_, {params, _}} =
-            cache[root_id][:init].(template, cache, %{}, stacktrace, param_keys)
+          {_, {params, _}} = cache[root_id][:init].(template, cache, %{}, stacktrace, param_keys)
 
           params
         end)
@@ -114,7 +113,8 @@ defmodule Axon.Compiler do
           op_counts = Map.update(op_counts, op, 1, &(&1 + 1))
 
           keys =
-            Enum.reduce(params, keys, fn %Axon.Parameter{name: param_name, initializer: fun}, keys ->
+            Enum.reduce(params, keys, fn %Axon.Parameter{name: param_name, initializer: fun},
+                                         keys ->
               {:arity, arity} = Function.info(fun, :arity)
 
               cond do
@@ -122,7 +122,9 @@ defmodule Axon.Compiler do
                   keys
 
                 arity == 3 ->
-                  <<data::unsigned-size(32), _rest::binary>> = :erlang.md5(name <> "." <> param_name)
+                  <<data::unsigned-size(32), _rest::binary>> =
+                    :erlang.md5(name <> "." <> param_name)
+
                   [{{name, param_name}, data} | keys]
 
                 true ->

--- a/lib/axon/compiler.ex
+++ b/lib/axon/compiler.ex
@@ -757,20 +757,27 @@ defmodule Axon.Compiler do
 
   @initializer_no_key [:zeros, :ones, :identity, :full]
 
-  defp apply_initializer(initializer, _layer_name, _param_name, shape, type, key) when initializer in @initializer_no_key do
+  defp apply_initializer(initializer, _layer_name, _param_name, shape, type, key)
+       when initializer in @initializer_no_key do
     fun = apply(Axon.Initializers, initializer, [])
     fun.(shape, type, key)
   end
 
-  defp apply_initializer(initializer, layer_name, param_name, shape, type, key) when is_atom(initializer) do
-    <<data::unsigned-size(32), _rest::binary>> = :crypto.hash(:sha, layer_name <> "." <> param_name)
+  defp apply_initializer(initializer, layer_name, param_name, shape, type, key)
+       when is_atom(initializer) do
+    <<data::unsigned-size(32), _rest::binary>> =
+      :crypto.hash(:sha, layer_name <> "." <> param_name)
+
     key_to_use = Nx.Random.fold_in(key, data)
     fun = apply(Axon.Initializers, initializer, [])
     fun.(shape, type, key_to_use)
   end
 
-  defp apply_initializer(initializer, layer_name, param_name, shape, type, key) when is_function(initializer, 3) do
-    <<data::unsigned-size(32), _rest::binary>> = :crypto.hash(:sha, layer_name <> "." <> param_name)
+  defp apply_initializer(initializer, layer_name, param_name, shape, type, key)
+       when is_function(initializer, 3) do
+    <<data::unsigned-size(32), _rest::binary>> =
+      :crypto.hash(:sha, layer_name <> "." <> param_name)
+
     key_to_use = Nx.Random.fold_in(key, data)
     initializer.(shape, type, key_to_use)
   end

--- a/lib/axon/initializers.ex
+++ b/lib/axon/initializers.ex
@@ -47,7 +47,7 @@ defmodule Axon.Initializers do
   ## Examples
 
       iex> init_fn = Axon.Initializers.zeros()
-      iex> {out, _key} = init_fn.({2, 2}, {:f, 32}, Nx.Random.key(1))
+      iex> out = init_fn.({2, 2}, {:f, 32}, Nx.Random.key(1))
       iex> out
       #Nx.Tensor<
         f32[2][2]
@@ -58,8 +58,8 @@ defmodule Axon.Initializers do
       >
   """
   def zeros() do
-    fn shape, type, key ->
-      {zeros_impl(shape: shape, type: type), key}
+    fn shape, type, _key ->
+      zeros_impl(shape: shape, type: type)
     end
   end
 
@@ -74,7 +74,7 @@ defmodule Axon.Initializers do
   ## Examples
 
       iex> init_fn = Axon.Initializers.ones()
-      iex> {out, _key} = init_fn.({2, 2}, {:f, 32}, Nx.Random.key(1))
+      iex> out = init_fn.({2, 2}, {:f, 32}, Nx.Random.key(1))
       iex> out
       #Nx.Tensor<
         f32[2][2]
@@ -85,8 +85,8 @@ defmodule Axon.Initializers do
       >
   """
   def ones() do
-    fn shape, type, key ->
-      {ones_impl(shape: shape, type: type), key}
+    fn shape, type, _key ->
+      ones_impl(shape: shape, type: type)
     end
   end
 
@@ -101,7 +101,7 @@ defmodule Axon.Initializers do
   ## Examples
 
       iex> init_fn = Axon.Initializers.full(1.00)
-      iex> {out, _key} = init_fn.({2, 2}, {:f, 32}, Nx.Random.key(1))
+      iex> out = init_fn.({2, 2}, {:f, 32}, Nx.Random.key(1))
       iex> out
       #Nx.Tensor<
         f32[2][2]
@@ -112,8 +112,8 @@ defmodule Axon.Initializers do
       >
   """
   def full(value) do
-    fn shape, type, key ->
-      {full_impl(value, shape: shape, type: type), key}
+    fn shape, type, _key ->
+      full_impl(value, shape: shape, type: type)
     end
   end
 
@@ -128,7 +128,7 @@ defmodule Axon.Initializers do
   ## Examples
 
       iex> init_fn = Axon.Initializers.identity()
-      iex> {out, _key} = init_fn.({2, 2}, {:f, 32}, Nx.Random.key(1))
+      iex> out = init_fn.({2, 2}, {:f, 32}, Nx.Random.key(1))
       iex> out
       #Nx.Tensor<
         f32[2][2]
@@ -139,8 +139,8 @@ defmodule Axon.Initializers do
       >
   """
   def identity() do
-    fn shape, type, key ->
-      {identity_impl(shape: shape, type: type), key}
+    fn shape, type, _key ->
+      identity_impl(shape: shape, type: type)
     end
   end
 
@@ -159,14 +159,14 @@ defmodule Axon.Initializers do
   ## Examples
 
       iex> init_fn = Axon.Initializers.uniform()
-      iex> {t, _key} = init_fn.({2, 2}, {:f, 32}, Nx.Random.key(1))
+      iex> t = init_fn.({2, 2}, {:f, 32}, Nx.Random.key(1))
       iex> Nx.shape(t)
       {2, 2}
       iex> Nx.type(t)
       {:f, 32}
 
       iex> init_fn = Axon.Initializers.uniform(scale: 1.0e-3)
-      iex> {t, _key} = init_fn.({2, 2}, {:bf, 16}, Nx.Random.key(1))
+      iex> t = init_fn.({2, 2}, {:bf, 16}, Nx.Random.key(1))
       iex> Nx.shape(t)
       {2, 2}
       iex> Nx.type(t)
@@ -184,7 +184,7 @@ defmodule Axon.Initializers do
     opts = keyword!(opts, [:shape, type: {:f, 32}, scale: 1.0e-2])
     shape = Nx.shape(opts[:shape])
 
-    Nx.Random.uniform(key, Nx.negate(opts[:scale]), opts[:scale],
+    Nx.Random.uniform_split(key, Nx.negate(opts[:scale]), opts[:scale],
       type: opts[:type],
       shape: shape
     )
@@ -201,14 +201,14 @@ defmodule Axon.Initializers do
   ## Examples
 
       iex> init_fn = Axon.Initializers.normal()
-      iex> {t, _key} = init_fn.({2, 2}, {:f, 32}, Nx.Random.key(1))
+      iex> t = init_fn.({2, 2}, {:f, 32}, Nx.Random.key(1))
       iex> Nx.shape(t)
       {2, 2}
       iex> Nx.type(t)
       {:f, 32}
 
       iex> init_fn = Axon.Initializers.normal(mean: 1.0, scale: 1.0)
-      iex> {t, _key} = init_fn.({2, 2}, {:bf, 16}, Nx.Random.key(1))
+      iex> t = init_fn.({2, 2}, {:bf, 16}, Nx.Random.key(1))
       iex> Nx.shape(t)
       {2, 2}
       iex> Nx.type(t)
@@ -225,7 +225,7 @@ defmodule Axon.Initializers do
 
   defnp normal_impl(key, opts \\ []) do
     opts = keyword!(opts, [:shape, type: {:f, 32}, scale: 1.0e-2, mean: 0.0])
-    Nx.Random.normal(key, opts[:mean], opts[:scale], shape: opts[:shape], type: opts[:type])
+    Nx.Random.normal_split(key, opts[:mean], opts[:scale], shape: opts[:shape], type: opts[:type])
   end
 
   @doc """
@@ -242,14 +242,14 @@ defmodule Axon.Initializers do
   ## Examples
 
       iex> init_fn = Axon.Initializers.lecun_uniform()
-      iex> {t, _key} = init_fn.({2, 2}, {:f, 32}, Nx.Random.key(1))
+      iex> t = init_fn.({2, 2}, {:f, 32}, Nx.Random.key(1))
       iex> Nx.shape(t)
       {2, 2}
       iex> Nx.type(t)
       {:f, 32}
 
       iex> init_fn = Axon.Initializers.lecun_uniform(scale: 1.0e-3)
-      iex> {t, _key} = init_fn.({2, 2}, {:bf, 16}, Nx.Random.key(1))
+      iex> t = init_fn.({2, 2}, {:bf, 16}, Nx.Random.key(1))
       iex> Nx.shape(t)
       {2, 2}
       iex> Nx.type(t)
@@ -294,14 +294,14 @@ defmodule Axon.Initializers do
   ## Examples
 
       iex> init_fn = Axon.Initializers.lecun_normal()
-      iex> {t, _key} = init_fn.({2, 2}, {:f, 32}, Nx.Random.key(1))
+      iex> t = init_fn.({2, 2}, {:f, 32}, Nx.Random.key(1))
       iex> Nx.shape(t)
       {2, 2}
       iex> Nx.type(t)
       {:f, 32}
 
       iex> init_fn = Axon.Initializers.lecun_normal(scale: 1.0e-3)
-      iex> {t, _key} = init_fn.({2, 2}, {:bf, 16}, Nx.Random.key(1))
+      iex> t = init_fn.({2, 2}, {:bf, 16}, Nx.Random.key(1))
       iex> Nx.shape(t)
       {2, 2}
       iex> Nx.type(t)
@@ -349,14 +349,14 @@ defmodule Axon.Initializers do
   ## Examples
 
       iex> init_fn = Axon.Initializers.glorot_uniform()
-      iex> {t, _key} = init_fn.({2, 2}, {:f, 32}, Nx.Random.key(1))
+      iex> t = init_fn.({2, 2}, {:f, 32}, Nx.Random.key(1))
       iex> Nx.shape(t)
       {2, 2}
       iex> Nx.type(t)
       {:f, 32}
 
       iex> init_fn = Axon.Initializers.glorot_uniform(scale: 1.0e-3)
-      iex> {t, _key} = init_fn.({2, 2}, {:bf, 16}, Nx.Random.key(1))
+      iex> t = init_fn.({2, 2}, {:bf, 16}, Nx.Random.key(1))
       iex> Nx.shape(t)
       {2, 2}
       iex> Nx.type(t)
@@ -404,14 +404,14 @@ defmodule Axon.Initializers do
   ## Examples
 
       iex> init_fn = Axon.Initializers.glorot_normal()
-      iex> {t, _key} = init_fn.({2, 2}, {:f, 32}, Nx.Random.key(1))
+      iex> t = init_fn.({2, 2}, {:f, 32}, Nx.Random.key(1))
       iex> Nx.shape(t)
       {2, 2}
       iex> Nx.type(t)
       {:f, 32}
 
       iex> init_fn = Axon.Initializers.glorot_normal(scale: 1.0e-3)
-      iex> {t, _key} = init_fn.({2, 2}, {:bf, 16}, Nx.Random.key(1))
+      iex> t = init_fn.({2, 2}, {:bf, 16}, Nx.Random.key(1))
       iex> Nx.shape(t)
       {2, 2}
       iex> Nx.type(t)
@@ -456,14 +456,14 @@ defmodule Axon.Initializers do
   ## Examples
 
       iex> init_fn = Axon.Initializers.he_uniform()
-      iex> {t, _key} = init_fn.({2, 2}, {:f, 32}, Nx.Random.key(1))
+      iex> t = init_fn.({2, 2}, {:f, 32}, Nx.Random.key(1))
       iex> Nx.shape(t)
       {2, 2}
       iex> Nx.type(t)
       {:f, 32}
 
       iex> init_fn = Axon.Initializers.he_uniform(scale: 1.0e-3)
-      iex> {t, _key} = init_fn.({2, 2}, {:bf, 16}, Nx.Random.key(1))
+      iex> t = init_fn.({2, 2}, {:bf, 16}, Nx.Random.key(1))
       iex> Nx.shape(t)
       {2, 2}
       iex> Nx.type(t)
@@ -508,14 +508,14 @@ defmodule Axon.Initializers do
   ## Examples
 
       iex> init_fn = Axon.Initializers.he_normal()
-      iex> {t, _key} = init_fn.({2, 2}, {:f, 32}, Nx.Random.key(1))
+      iex> t = init_fn.({2, 2}, {:f, 32}, Nx.Random.key(1))
       iex> Nx.shape(t)
       {2, 2}
       iex> Nx.type(t)
       {:f, 32}
 
       iex> init_fn = Axon.Initializers.he_normal(scale: 1.0e-3)
-      iex> {t, _key} = init_fn.({2, 2}, {:bf, 16}, Nx.Random.key(1))
+      iex> t = init_fn.({2, 2}, {:bf, 16}, Nx.Random.key(1))
       iex> Nx.shape(t)
       {2, 2}
       iex> Nx.type(t)
@@ -564,21 +564,21 @@ defmodule Axon.Initializers do
   ## Examples
 
       iex> init_fn = Axon.Initializers.variance_scaling()
-      iex> {t, _key} = init_fn.({2, 2}, {:f, 32}, Nx.Random.key(1))
+      iex> t = init_fn.({2, 2}, {:f, 32}, Nx.Random.key(1))
       iex> Nx.shape(t)
       {2, 2}
       iex> Nx.type(t)
       {:f, 32}
 
       iex> init_fn = Axon.Initializers.variance_scaling(mode: :fan_out, distribution: :truncated_normal)
-      iex> {t, _key} = init_fn.({2, 2}, {:bf, 16}, Nx.Random.key(1))
+      iex> t = init_fn.({2, 2}, {:bf, 16}, Nx.Random.key(1))
       iex> Nx.shape(t)
       {2, 2}
       iex> Nx.type(t)
       {:bf, 16}
 
       iex> init_fn = Axon.Initializers.variance_scaling(mode: :fan_out, distribution: :normal)
-      iex> {t, _key} = init_fn.({64, 3, 32, 32}, {:f, 32}, Nx.Random.key(1))
+      iex> t = init_fn.({64, 3, 32, 32}, {:f, 32}, Nx.Random.key(1))
       iex> Nx.shape(t)
       {64, 3, 32, 32}
       iex> Nx.type(t)
@@ -664,14 +664,14 @@ defmodule Axon.Initializers do
   ## Examples
 
       iex> init_fn = Axon.Initializers.orthogonal()
-      iex> {t, _key} = init_fn.({3, 3}, {:f, 32}, Nx.Random.key(1))
+      iex> t = init_fn.({3, 3}, {:f, 32}, Nx.Random.key(1))
       iex> Nx.type(t)
       {:f, 32}
       iex> Nx.shape(t)
       {3, 3}
 
       iex> init_fn = Axon.Initializers.orthogonal()
-      iex> {t, _key} = init_fn.({1, 2, 3, 4}, {:f, 64}, Nx.Random.key(1))
+      iex> t = init_fn.({1, 2, 3, 4}, {:f, 64}, Nx.Random.key(1))
       iex> Nx.type(t)
       {:f, 64}
       iex> Nx.shape(t)
@@ -693,7 +693,7 @@ defmodule Axon.Initializers do
 
     assert_min_rank!("Axon.Initializers.orthogonal", "input_shape", shape, 2)
 
-    {{m, n}, {random_seed, key}} =
+    {{m, n}, random_seed} =
       transform({key, shape, distribution, type}, fn {key, shape, distribution, type} ->
         flat_shape =
           if tuple_size(shape) > 2 do
@@ -708,10 +708,10 @@ defmodule Axon.Initializers do
         out =
           case distribution do
             :uniform ->
-              Nx.Random.uniform(key, 0.0, 1.0, shape: flat_shape, type: type)
+              Nx.Random.uniform_split(key, 0.0, 1.0, shape: flat_shape, type: type)
 
             :normal ->
-              Nx.Random.normal(key, 0.0, 1.0, shape: flat_shape, type: type)
+              Nx.Random.normal_split(key, 0.0, 1.0, shape: flat_shape, type: type)
 
             dist ->
               raise ArgumentError,
@@ -728,7 +728,7 @@ defmodule Axon.Initializers do
       |> Nx.slice([0, 0], [m, n])
       |> Nx.reshape(shape)
 
-    {rand, key}
+    rand
   end
 
   # Variance scaling branches
@@ -740,7 +740,7 @@ defmodule Axon.Initializers do
 
     sigma = Nx.sqrt(variance)
 
-    Nx.Random.normal(key, 0.0, sigma, shape: shape, type: type)
+    Nx.Random.normal_split(key, 0.0, sigma, shape: shape, type: type)
   end
 
   defnp var_uniform(key, variance, opts \\ []) do
@@ -749,7 +749,7 @@ defmodule Axon.Initializers do
     type = opts[:type]
 
     limit = Nx.sqrt(3 * variance)
-    Nx.Random.uniform(key, -limit, limit, shape: shape, type: type)
+    Nx.Random.uniform_split(key, -limit, limit, shape: shape, type: type)
   end
 
   defnp var_truncated(key, variance, opts \\ []) do
@@ -762,8 +762,8 @@ defmodule Axon.Initializers do
       |> Nx.sqrt()
       |> Nx.divide(0.87962566103423978)
 
-    {rand, key} = Nx.Random.normal(key, 0.0, sigma, shape: shape, type: type)
-    {Nx.clip(rand, -2, 2), key}
+    rand = Nx.Random.normal_split(key, 0.0, sigma, shape: shape, type: type)
+    Nx.clip(rand, -2, 2)
   end
 
   defp compute_fans(shape) do

--- a/lib/axon/initializers.ex
+++ b/lib/axon/initializers.ex
@@ -47,7 +47,7 @@ defmodule Axon.Initializers do
   ## Examples
 
       iex> init_fn = Axon.Initializers.zeros()
-      iex> out = init_fn.({2, 2}, {:f, 32}, Nx.Random.key(1))
+      iex> out = init_fn.({2, 2}, {:f, 32})
       iex> out
       #Nx.Tensor<
         f32[2][2]
@@ -58,7 +58,7 @@ defmodule Axon.Initializers do
       >
   """
   def zeros() do
-    fn shape, type, _key ->
+    fn shape, type ->
       zeros_impl(shape: shape, type: type)
     end
   end
@@ -74,7 +74,7 @@ defmodule Axon.Initializers do
   ## Examples
 
       iex> init_fn = Axon.Initializers.ones()
-      iex> out = init_fn.({2, 2}, {:f, 32}, Nx.Random.key(1))
+      iex> out = init_fn.({2, 2}, {:f, 32})
       iex> out
       #Nx.Tensor<
         f32[2][2]
@@ -85,7 +85,7 @@ defmodule Axon.Initializers do
       >
   """
   def ones() do
-    fn shape, type, _key ->
+    fn shape, type ->
       ones_impl(shape: shape, type: type)
     end
   end
@@ -101,7 +101,7 @@ defmodule Axon.Initializers do
   ## Examples
 
       iex> init_fn = Axon.Initializers.full(1.00)
-      iex> out = init_fn.({2, 2}, {:f, 32}, Nx.Random.key(1))
+      iex> out = init_fn.({2, 2}, {:f, 32})
       iex> out
       #Nx.Tensor<
         f32[2][2]
@@ -112,7 +112,7 @@ defmodule Axon.Initializers do
       >
   """
   def full(value) do
-    fn shape, type, _key ->
+    fn shape, type ->
       full_impl(value, shape: shape, type: type)
     end
   end
@@ -128,7 +128,7 @@ defmodule Axon.Initializers do
   ## Examples
 
       iex> init_fn = Axon.Initializers.identity()
-      iex> out = init_fn.({2, 2}, {:f, 32}, Nx.Random.key(1))
+      iex> out = init_fn.({2, 2}, {:f, 32})
       iex> out
       #Nx.Tensor<
         f32[2][2]
@@ -139,7 +139,7 @@ defmodule Axon.Initializers do
       >
   """
   def identity() do
-    fn shape, type, _key ->
+    fn shape, type ->
       identity_impl(shape: shape, type: type)
     end
   end

--- a/lib/axon/shared.ex
+++ b/lib/axon/shared.ex
@@ -134,8 +134,7 @@ defmodule Axon.Shared do
       params,
       &deep_new(&1, fn x ->
         fun = Axon.Initializers.zeros()
-        {out, _} = fun.(Nx.shape(x), Nx.type(x), 1)
-        out
+        fun.(Nx.shape(x), Nx.type(x), 1)
       end)
     )
   end
@@ -148,8 +147,7 @@ defmodule Axon.Shared do
       params,
       &deep_new(&1, fn x ->
         fun = Axon.Initializers.full(value)
-        {out, _} = fun.(Nx.shape(x), Nx.type(x), 1)
-        out
+        fun.(Nx.shape(x), Nx.type(x), 1)
       end)
     )
   end

--- a/lib/axon/shared.ex
+++ b/lib/axon/shared.ex
@@ -134,7 +134,7 @@ defmodule Axon.Shared do
       params,
       &deep_new(&1, fn x ->
         fun = Axon.Initializers.zeros()
-        fun.(Nx.shape(x), Nx.type(x), 1)
+        fun.(Nx.shape(x), Nx.type(x))
       end)
     )
   end
@@ -147,7 +147,7 @@ defmodule Axon.Shared do
       params,
       &deep_new(&1, fn x ->
         fun = Axon.Initializers.full(value)
-        fun.(Nx.shape(x), Nx.type(x), 1)
+        fun.(Nx.shape(x), Nx.type(x))
       end)
     )
   end

--- a/test/axon/initializers_test.exs
+++ b/test/axon/initializers_test.exs
@@ -6,7 +6,7 @@ defmodule Axon.InitializersTest do
   describe "orthogonal/1" do
     test "property" do
       init_fn = Axon.Initializers.orthogonal()
-      {t1, _key} = init_fn.({3, 3}, {:f, 32}, Nx.Random.key(1))
+      t1 = init_fn.({3, 3}, {:f, 32}, Nx.Random.key(1))
       identity_left_t1 = t1 |> Nx.transpose() |> Nx.dot(t1)
 
       assert_all_close(identity_left_t1, Nx.eye(Nx.shape(identity_left_t1)),
@@ -22,7 +22,7 @@ defmodule Axon.InitializersTest do
       )
 
       init_fn = Axon.Initializers.orthogonal()
-      {t2, _key} = init_fn.({1, 2, 3, 4, 5}, {:f, 32}, Nx.Random.key(1))
+      t2 = init_fn.({1, 2, 3, 4, 5}, {:f, 32}, Nx.Random.key(1))
       t2 = Nx.reshape(t2, {24, 5})
 
       identity_left_t2 = t2 |> Nx.transpose() |> Nx.dot(t2)

--- a/test/axon_test.exs
+++ b/test/axon_test.exs
@@ -38,8 +38,8 @@ defmodule AxonTest do
                parameters: [weight, bias]
              } = nodes[id]
 
-      assert %Axon.Parameter{initializer: :glorot_uniform} = weight
-      assert %Axon.Parameter{initializer: :zeros} = bias
+      assert %Axon.Parameter{} = weight
+      assert %Axon.Parameter{} = bias
     end
 
     test "works with parameter initializer" do
@@ -49,8 +49,8 @@ defmodule AxonTest do
 
       assert %Axon.Node{op: :dense, parameters: [weight, bias]} = nodes[id]
 
-      assert %Axon.Parameter{initializer: :lecun_normal} = weight
-      assert %Axon.Parameter{initializer: :ones} = bias
+      assert %Axon.Parameter{} = weight
+      assert %Axon.Parameter{} = bias
     end
 
     test "works with activation" do
@@ -90,8 +90,8 @@ defmodule AxonTest do
       assert opts[:kernel_dilation] == 1
       assert opts[:input_dilation] == 1
 
-      assert %Axon.Parameter{initializer: :glorot_uniform} = kernel
-      assert %Axon.Parameter{initializer: :zeros} = bias
+      assert %Axon.Parameter{} = kernel
+      assert %Axon.Parameter{} = bias
     end
 
     test "works with activation" do
@@ -113,8 +113,8 @@ defmodule AxonTest do
       assert opts[:kernel_dilation] == 1
       assert opts[:input_dilation] == 1
 
-      assert %Axon.Parameter{initializer: :glorot_uniform} = kernel
-      assert %Axon.Parameter{initializer: :zeros} = bias
+      assert %Axon.Parameter{} = kernel
+      assert %Axon.Parameter{} = bias
     end
 
     test "fails on bad initializers" do
@@ -147,8 +147,8 @@ defmodule AxonTest do
       assert opts[:kernel_dilation] == 1
       assert opts[:input_dilation] == 1
 
-      assert %Axon.Parameter{initializer: :glorot_uniform} = kernel
-      assert %Axon.Parameter{initializer: :zeros} = bias
+      assert %Axon.Parameter{} = kernel
+      assert %Axon.Parameter{} = bias
     end
 
     test "works with activation" do
@@ -171,8 +171,8 @@ defmodule AxonTest do
       assert opts[:kernel_dilation] == 1
       assert opts[:input_dilation] == 1
 
-      assert %Axon.Parameter{initializer: :glorot_uniform} = kernel
-      assert %Axon.Parameter{initializer: :zeros} = bias
+      assert %Axon.Parameter{} = kernel
+      assert %Axon.Parameter{} = bias
     end
 
     test "fails on bad initializers" do
@@ -211,10 +211,10 @@ defmodule AxonTest do
       assert opts[:kernel_dilation] == 1
       assert opts[:input_dilation] == 1
 
-      assert %Axon.Parameter{initializer: :glorot_uniform} = k1
-      assert %Axon.Parameter{initializer: :glorot_uniform} = k2
-      assert %Axon.Parameter{initializer: :zeros} = b1
-      assert %Axon.Parameter{initializer: :zeros} = b2
+      assert %Axon.Parameter{} = k1
+      assert %Axon.Parameter{} = b1
+      assert %Axon.Parameter{} = k2
+      assert %Axon.Parameter{} = b2
     end
 
     test "works with activation" do
@@ -241,10 +241,10 @@ defmodule AxonTest do
       assert opts[:kernel_dilation] == 1
       assert opts[:input_dilation] == 1
 
-      assert %Axon.Parameter{initializer: :glorot_uniform} = k1
-      assert %Axon.Parameter{initializer: :glorot_uniform} = k2
-      assert %Axon.Parameter{initializer: :zeros} = b1
-      assert %Axon.Parameter{initializer: :zeros} = b2
+      assert %Axon.Parameter{} = k1
+      assert %Axon.Parameter{} = b1
+      assert %Axon.Parameter{} = k2
+      assert %Axon.Parameter{} = b2
     end
 
     test "fails on bad initializers" do
@@ -284,12 +284,12 @@ defmodule AxonTest do
       assert opts[:kernel_dilation] == 1
       assert opts[:input_dilation] == 1
 
-      assert %Axon.Parameter{initializer: :glorot_uniform} = k1
-      assert %Axon.Parameter{initializer: :glorot_uniform} = k2
-      assert %Axon.Parameter{initializer: :glorot_uniform} = k3
-      assert %Axon.Parameter{initializer: :zeros} = b1
-      assert %Axon.Parameter{initializer: :zeros} = b2
-      assert %Axon.Parameter{initializer: :zeros} = b3
+      assert %Axon.Parameter{} = k1
+      assert %Axon.Parameter{} = b1
+      assert %Axon.Parameter{} = k2
+      assert %Axon.Parameter{} = b2
+      assert %Axon.Parameter{} = k3
+      assert %Axon.Parameter{} = b3
     end
 
     test "works with activation" do
@@ -478,10 +478,10 @@ defmodule AxonTest do
         assert opts[:channel_index] == -1
         assert opts[:epsilon] == 1.0e-5
 
-        assert %Axon.Parameter{initializer: :glorot_uniform} = gamma
-        assert %Axon.Parameter{initializer: :zeros} = beta
-        assert %Axon.Parameter{initializer: :zeros} = mean
-        assert %Axon.Parameter{initializer: :ones} = var
+        assert %Axon.Parameter{} = gamma
+        assert %Axon.Parameter{} = beta
+        assert %Axon.Parameter{} = mean
+        assert %Axon.Parameter{} = var
       end
     end
 
@@ -495,10 +495,10 @@ defmodule AxonTest do
 
         assert %Axon.Node{parameters: [gamma, beta, mean, var]} = nodes[id]
 
-        assert %Axon.Parameter{initializer: :lecun_normal} = gamma
-        assert %Axon.Parameter{initializer: :ones} = beta
-        assert %Axon.Parameter{initializer: :zeros} = mean
-        assert %Axon.Parameter{initializer: :ones} = var
+        assert %Axon.Parameter{} = gamma
+        assert %Axon.Parameter{} = beta
+        assert %Axon.Parameter{} = mean
+        assert %Axon.Parameter{} = var
       end
     end
 
@@ -525,8 +525,8 @@ defmodule AxonTest do
       assert opts[:channel_index] == -1
       assert opts[:epsilon] == 1.0e-5
 
-      assert %Axon.Parameter{initializer: :glorot_uniform} = gamma
-      assert %Axon.Parameter{initializer: :zeros} = beta
+      assert %Axon.Parameter{} = gamma
+      assert %Axon.Parameter{} = beta
     end
 
     test "works with parameter initializer" do
@@ -538,8 +538,8 @@ defmodule AxonTest do
 
       assert %Axon.Node{parameters: [gamma, beta]} = nodes[id]
 
-      assert %Axon.Parameter{initializer: :lecun_normal} = gamma
-      assert %Axon.Parameter{initializer: :ones} = beta
+      assert %Axon.Parameter{} = gamma
+      assert %Axon.Parameter{} = beta
     end
 
     test "fails on bad initializers" do
@@ -564,8 +564,8 @@ defmodule AxonTest do
       assert opts[:epsilon] == 1.0e-5
       assert opts[:num_groups] == 3
 
-      assert %Axon.Parameter{initializer: :ones} = gamma
-      assert %Axon.Parameter{initializer: :zeros} = beta
+      assert %Axon.Parameter{} = gamma
+      assert %Axon.Parameter{} = beta
     end
 
     test "works with parameter initializer" do
@@ -575,8 +575,8 @@ defmodule AxonTest do
 
       assert %Axon.Node{parameters: [gamma, beta]} = nodes[id]
 
-      assert %Axon.Parameter{initializer: :lecun_normal} = gamma
-      assert %Axon.Parameter{initializer: :ones} = beta
+      assert %Axon.Parameter{} = gamma
+      assert %Axon.Parameter{} = beta
     end
 
     test "fails on bad initializer" do

--- a/test/support/axon_test_util.ex
+++ b/test/support/axon_test_util.ex
@@ -99,8 +99,7 @@ defmodule AxonTestUtil do
 
   def zeros(shape) do
     fun = Axon.Initializers.zeros()
-    {out, _} = fun.(shape, {:f, 32}, Nx.Random.key(1))
-    out
+    fun.(shape, {:f, 32}, Nx.Random.key(1))
   end
 
   defp check_optimizer_functions!(optimizer) do

--- a/test/support/axon_test_util.ex
+++ b/test/support/axon_test_util.ex
@@ -99,7 +99,7 @@ defmodule AxonTestUtil do
 
   def zeros(shape) do
     fun = Axon.Initializers.zeros()
-    fun.(shape, {:f, 32}, Nx.Random.key(1))
+    fun.(shape, {:f, 32})
   end
 
   defp check_optimizer_functions!(optimizer) do


### PR DESCRIPTION
Trying to align more with Flax's implementation which does not split keys but rather generates keys from layer meta