### PR TITLE
Provide deterministic builds

### DIFF
--- a/lib/axon.ex
+++ b/lib/axon.ex
@@ -240,9 +240,9 @@ defmodule Axon do
   to inference function except:
 
     * `:name` - layer name.
+    * `:op_name` - layer operation for inspection and building parameter map.
+    * `:mode` - if the layer should run only on `:inference` or `:train`. Defaults to `:both`
 
-    * `:op_name` - layer operation for inspection and building parameter
-      map.
 
   Note this means your layer should not use these as input options,
   as they will always be dropped during inference compilation.
@@ -3585,7 +3585,7 @@ defmodule Axon do
   @doc type: :model
   def serialize(%Axon{output: id, nodes: nodes}, params, opts \\ []) do
     Logger.warning(
-      "Attempting to serialize an Axon model. Serialiation is discouraged" <>
+      "Attempting to serialize an Axon model. Serialization is discouraged" <>
         " and will be deprecated, then removed in future releases. You should" <>
         " keep your model definitions as code and serialize your parameters using" <>
         " `Nx.serialize/2`."

--- a/lib/axon.ex
+++ b/lib/axon.ex
@@ -268,22 +268,23 @@ defmodule Axon do
     params = Enum.reverse(params)
     args = Enum.reverse(args)
 
+    {mode, opts} = Keyword.pop(opts, :mode, :both)
     {name, opts} = Keyword.pop(opts, :name)
-    {op_name, layer_opts} = Keyword.pop(opts, :op_name, :custom)
+    {op_name, opts} = Keyword.pop(opts, :op_name, :custom)
+    name = name(op_name, name)
 
     id = System.unique_integer([:positive, :monotonic])
-    name = name(op_name, name)
-    axon_node = make_node(id, op, name, op_name, inputs, params, args, layer_opts)
-
+    axon_node = make_node(id, op, name, op_name, mode, inputs, params, args, opts)
     %Axon{output: id, nodes: Map.put(updated_nodes, id, axon_node)}
   end
 
-  defp make_node(id, op, name, op_name, inputs, params, args, layer_opts) do
+  defp make_node(id, op, name, op_name, mode, inputs, params, args, layer_opts) do
     {:current_stacktrace, [_process_info, _axon_layer | stacktrace]} =
       Process.info(self(), :current_stacktrace)
 
     %Axon.Node{
       id: id,
+      mode: mode,
       name: name,
       parent: inputs,
       parameters: params,
@@ -1396,7 +1397,8 @@ defmodule Axon do
     layer(dropout, [x, key_state],
       name: opts[:name],
       rate: opts[:rate],
-      op_name: dropout
+      op_name: dropout,
+      mode: :train
     )
   end
 
@@ -3348,7 +3350,7 @@ defmodule Axon do
 
   ## Options
 
-    * `:mode` - one of `:inference` or `:training`. Forwarded to layers
+    * `:mode` - one of `:inference` or `:train`. Forwarded to layers
       to control differences in compilation at training or inference time.
       Defaults to `:inference`
 
@@ -3427,7 +3429,7 @@ defmodule Axon do
 
   ## Options
 
-    * `:mode` - one of `:inference` or `:training`. Forwarded to layers
+    * `:mode` - one of `:inference` or `:train`. Forwarded to layers
       to control differences in compilation at training or inference time.
       Defaults to `:inference`
 
@@ -3491,7 +3493,7 @@ defmodule Axon do
 
   ## Options
 
-    * `:mode` - one of `:inference` or `:training`. Forwarded to layers
+    * `:mode` - one of `:inference` or `:train`. Forwarded to layers
       to control differences in compilation at training or inference time.
       Defaults to `:inference`
 

--- a/lib/axon/compiler.ex
+++ b/lib/axon/compiler.ex
@@ -531,16 +531,6 @@ defmodule Axon.Compiler do
     name = name_fn.(op_name, op_counts)
     op_counts = Map.update(op_counts, op_name, 1, fn x -> x + 1 end)
 
-    # TODO: Hack for dropout with key, fix with a better implementation
-    opts =
-      if op in @dropout_layers do
-        <<data::unsigned-size(32), _rest::binary>> = :erlang.md5(name)
-        dropout_key = Nx.Random.fold_in(config.key, data) |> Nx.backend_copy(Nx.BinaryBackend)
-        [key: dropout_key] ++ opts
-      else
-        opts
-      end
-
     stacktrace = if debug?, do: stacktrace, else: []
 
     # Each model builds two functions: predict_fun and init_fun

--- a/lib/axon/compiler.ex
+++ b/lib/axon/compiler.ex
@@ -37,6 +37,8 @@ defmodule Axon.Compiler do
     key = Nx.backend_copy(key, Nx.Defn.Expr)
 
     {time, {root_id, {cache, _op_counts}}} =
+      # TODO: Key should not be part of model funs because it is not deterministic
+      # Once we remove it here, we should change Nx.backend_copy above to Nx.BinaryBackend
       :timer.tc(fn ->
         to_model_funs(id, nodes, {%{}, %{}}, mode, key)
       end)
@@ -234,8 +236,7 @@ defmodule Axon.Compiler do
          _
        ) do
     op_counts = Map.update(op_counts, :constant, 1, fn x -> x + 1 end)
-
-    tensor = Nx.backend_copy(tensor, Nx.Defn.Expr)
+    tensor = Nx.backend_copy(tensor, Nx.BinaryBackend)
 
     predict_fun = fn _params, _inputs, state, _cache, result_cache, _fn_stacktrace ->
       out = safe_as_type(tensor, output)

--- a/lib/axon/compiler.ex
+++ b/lib/axon/compiler.ex
@@ -36,9 +36,9 @@ defmodule Axon.Compiler do
     key = Keyword.get_lazy(opts, :key, fn -> Nx.Random.key(:erlang.system_time()) end)
     key = Nx.backend_copy(key, Nx.Defn.Expr)
 
+    # TODO: Key should not be part of model funs because it is not deterministic
+    # Once we remove it here, we should change Nx.backend_copy above to Nx.BinaryBackend
     {time, {root_id, {cache, _op_counts}}} =
-      # TODO: Key should not be part of model funs because it is not deterministic
-      # Once we remove it here, we should change Nx.backend_copy above to Nx.BinaryBackend
       :timer.tc(fn ->
         to_model_funs(id, nodes, {%{}, %{}}, mode, key)
       end)

--- a/lib/axon/layers.ex
+++ b/lib/axon/layers.ex
@@ -121,7 +121,7 @@ defmodule Axon.Layers do
     dense_impl(input, kernel, bias, opts)
   end
 
-  defnp dense_impl(input, kernel, bias, _opts \\ []) do
+  defnp dense_impl(input, kernel, bias, _opts) do
     assert_min_rank!("Axon.Layers.dense", "input", input, 2)
 
     input
@@ -182,7 +182,7 @@ defmodule Axon.Layers do
     bilinear_impl(input1, input2, kernel, bias, opts)
   end
 
-  defnp bilinear_impl(input1, input2, kernel, bias, _opts \\ []) do
+  defnp bilinear_impl(input1, input2, kernel, bias, _opts) do
     assert_min_rank!("Axon.Layers.bilinear", "input1", input1, 2)
     assert_min_rank!("Axon.Layers.bilinear", "input2", input2, 2)
     assert_equal_rank!("Axon.Layers.bilinear", "input1", input1, "input2", input2)
@@ -339,7 +339,7 @@ defmodule Axon.Layers do
     conv_impl(input, kernel, bias, opts)
   end
 
-  defnp conv_impl(input, kernel, bias, opts \\ []) do
+  defnp conv_impl(input, kernel, bias, opts) do
     assert_min_rank!("Axon.Layers.conv", "input", input, 3)
     assert_equal_rank!("Axon.Layers.conv", "input", input, "kernel", kernel)
 
@@ -478,7 +478,7 @@ defmodule Axon.Layers do
     conv_transpose_impl(input, kernel, bias, opts)
   end
 
-  defnp conv_transpose_impl(input, kernel, bias, opts \\ []) do
+  defnp conv_transpose_impl(input, kernel, bias, opts) do
     assert_min_rank!("Axon.Layers.conv_transpose", "input", input, 3)
     assert_equal_rank!("Axon.Layers.conv_transpose", "input", input, "kernel", kernel)
 
@@ -583,7 +583,7 @@ defmodule Axon.Layers do
     depthwise_conv_impl(inputs, kernel, bias, opts)
   end
 
-  defnp depthwise_conv_impl(input, kernel, bias, opts \\ []) do
+  defnp depthwise_conv_impl(input, kernel, bias, opts) do
     assert_min_rank!("Axon.Layers.depthwise_conv", "input", input, 3)
     assert_equal_rank!("Axon.Layers.depthwise_conv", "input", input, "kernel", kernel)
 

--- a/lib/axon/layers.ex
+++ b/lib/axon/layers.ex
@@ -1667,8 +1667,7 @@ defmodule Axon.Layers do
 
     dropout(input, key,
       rate: opts[:rate],
-      noise_shape: noise_shape,
-      mode: opts[:mode]
+      noise_shape: noise_shape
     )
   end
 

--- a/lib/axon/layers.ex
+++ b/lib/axon/layers.ex
@@ -1667,7 +1667,8 @@ defmodule Axon.Layers do
 
     dropout(input, key,
       rate: opts[:rate],
-      noise_shape: noise_shape
+      noise_shape: noise_shape,
+      mode: opts[:mode]
     )
   end
 

--- a/lib/axon/loss_scale.ex
+++ b/lib/axon/loss_scale.ex
@@ -35,7 +35,7 @@ defmodule Axon.LossScale do
   Implements static loss-scale.
   """
   def static(loss_scale \\ @default_loss_scale) do
-    loss_scale = Nx.backend_copy(loss_scale, Nx.Defn.Expr)
+    loss_scale = Nx.backend_copy(loss_scale, Nx.BinaryBackend)
     {fn -> init_static(loss_scale) end, &scale_static/2, &unscale_static/2}
   end
 
@@ -64,7 +64,7 @@ defmodule Axon.LossScale do
   Implements dynamic loss-scale.
   """
   def dynamic(loss_scale \\ @default_loss_scale, opts \\ []) do
-    loss_scale = Nx.backend_copy(loss_scale, Nx.Defn.Expr)
+    loss_scale = Nx.backend_copy(loss_scale, Nx.BinaryBackend)
 
     {
       fn -> init_dynamic(loss_scale) end,

--- a/lib/axon/node.ex
+++ b/lib/axon/node.ex
@@ -4,6 +4,7 @@ defmodule Axon.Node do
   defstruct [
     :id,
     :name,
+    :mode,
     :parent,
     :parameters,
     :args,

--- a/lib/axon/parameter.ex
+++ b/lib/axon/parameter.ex
@@ -1,4 +1,4 @@
 defmodule Axon.Parameter do
   @moduledoc false
-  defstruct [:id, :name, :shape, :initializer, type: {:f, 32}, frozen: false]
+  defstruct [:name, :shape, :initializer, type: {:f, 32}, frozen: false]
 end

--- a/test/axon/compiler_test.exs
+++ b/test/axon/compiler_test.exs
@@ -1129,8 +1129,8 @@ defmodule CompilerTest do
 
         input = Nx.random_uniform({1, 1, 32})
 
-        assert {init_fn, predict_fn} = Axon.build(mp_model)
-        assert Nx.type(predict_fn.(init_fn.(input, %{}), input)) == {:bf, 16}
+        assert {init_fn, predict_fn} = Axon.build(mp_model, mode: :train)
+        assert Nx.type(predict_fn.(init_fn.(input, %{}), input).prediction) == {:bf, 16}
       end
     end
 

--- a/test/axon/compiler_test.exs
+++ b/test/axon/compiler_test.exs
@@ -114,7 +114,7 @@ defmodule CompilerTest do
       x2 = Axon.dense(input, 64)
       model = Axon.add(x1, x2)
 
-      {init_fn, _predict_fn} = Axon.build(model)
+      {init_fn, _predict_fn} = Axon.build(model, debug: true)
       %Axon.CompileError{} = exception = catch_error(init_fn.(Nx.template({1, 16}, :f32), %{}))
 
       message = Exception.message(exception)

--- a/test/axon/compiler_test.exs
+++ b/test/axon/compiler_test.exs
@@ -5250,4 +5250,13 @@ defmodule CompilerTest do
       )
     end
   end
+
+  describe "determinism" do
+    test "builds the same model multiple times" do
+      builder = fn -> Axon.input("input", shape: {nil, 784}) |> Axon.dense(128) end
+      {_, predict_fn1} = Axon.Compiler.build(builder.(), [])
+      {_, predict_fn2} = Axon.Compiler.build(builder.(), [])
+      assert predict_fn1 == predict_fn2
+    end
+  end
 end

--- a/test/axon/compiler_test.exs
+++ b/test/axon/compiler_test.exs
@@ -1025,7 +1025,7 @@ defmodule CompilerTest do
 
         input = Nx.random_uniform({1, 1, 32})
 
-        assert {init_fn, _predict_fn} = Axon.build(model)
+        assert {init_fn, _predict_fn} = Axon.build(model, mode: :train)
         assert %{"dropout" => %{"key" => key}} = init_fn.(input, %{})
         assert_equal(key, Nx.Random.key(0))
       end
@@ -1073,13 +1073,13 @@ defmodule CompilerTest do
 
     test "computes forward pass with default options" do
       for dropout <- @dropout_layers do
-        model1 = apply(Axon, dropout, [Axon.input("input", shape: {nil, 1, 32})])
-        input1 = Nx.random_uniform({1, 1, 32}, type: {:f, 32})
+        model1 = apply(Axon, dropout, [Axon.input("input", shape: {nil, 32, 32})])
+        input1 = Nx.random_uniform({1, 32, 32}, type: {:f, 32})
 
         assert {init_fn, predict_fn} = Axon.build(model1, mode: :train)
         %{prediction: result1} = predict_fn.(init_fn.(input1, %{}), input1)
 
-        assert Nx.shape(result1) == {1, 1, 32}
+        assert Nx.shape(result1) == {1, 32, 32}
         assert Nx.type(result1) == {:f, 32}
         assert_not_equal(result1, input1)
 
@@ -1107,15 +1107,15 @@ defmodule CompilerTest do
 
     test "computes forward pass with custom options" do
       for dropout <- @dropout_layers do
-        opts1 = [rate: 0.25]
-        model1 = apply(Axon, dropout, [Axon.input("input", shape: {nil, 1, 32}), opts1])
-        input1 = Nx.random_uniform({1, 1, 32}, type: {:f, 32})
+        opts1 = [rate: 0.5]
+        model1 = apply(Axon, dropout, [Axon.input("input", shape: {nil, 32, 128}), opts1])
+        input1 = Nx.random_uniform({1, 32, 128}, type: {:f, 32})
 
         assert {init_fn, predict_fn} = Axon.build(model1, mode: :train)
 
         %{prediction: result} = predict_fn.(init_fn.(input1, %{}), input1)
 
-        assert Nx.shape(result) == {1, 1, 32}
+        assert Nx.shape(result) == {1, 32, 128}
         assert Nx.type(result) == {:f, 32}
         assert_not_equal(result, input1)
       end

--- a/test/axon/loop_test.exs
+++ b/test/axon/loop_test.exs
@@ -61,7 +61,7 @@ defmodule Axon.LoopTest do
 
     test "trainer/3 returns a supervised training loop with custom loss" do
       model = Axon.input("input", shape: {nil, 1})
-      custom_loss_fn = fn _, _ -> Nx.tensor(5.0, backend: Nx.Defn.Expr) end
+      custom_loss_fn = fn _, _ -> Nx.tensor(5.0, backend: Nx.BinaryBackend) end
 
       assert %Loop{init: init_fn, step: update_fn, output_transform: transform} =
                Loop.trainer(model, custom_loss_fn, :adam)


### PR DESCRIPTION
* Parameter IDs were removed
* Dropouts are completely removed from the network via a new :mode option
* Freezing traverse the nodes directly without relying on IDs
* Removed almost all usage of backend_copy(Nx.Defn.Expr)
* We use integers as cache keys after the cache is built