### PR TITLE
Implement dropout as a passthrough

### DIFF
--- a/lib/axon.ex
+++ b/lib/axon.ex
@@ -2804,7 +2804,7 @@ defmodule Axon do
           "#{parent_name}_#{state_name}_hidden_state"
       end
 
-    fun = fn inputs, key, opts ->
+    fun = fn inputs, key, _opts ->
       shape = Axon.Shape.rnn_hidden_state(Nx.shape(inputs), units, rnn_type)
 
       case initializer do

--- a/test/axon/compiler_test.exs
+++ b/test/axon/compiler_test.exs
@@ -1143,6 +1143,17 @@ defmodule CompilerTest do
         assert_equal(predict_fn.(init_fn.(input, %{}), input), input)
       end
     end
+
+    test "initializes correctly when node appears with and without dropout" do
+      for dropout <- @dropout_layers do
+        input = Axon.input("input", shape: {nil, 1, 32})
+        model = Axon.add([input, apply(Axon, dropout, [input])])
+        input = Nx.random_uniform({1, 1, 32})
+
+        {init_fn, _predict_fn} = Axon.build(model)
+        assert %{} = init_fn.(input, %{})
+      end
+    end
   end
 
   describe "convolution" do

--- a/test/axon/compiler_test.exs
+++ b/test/axon/compiler_test.exs
@@ -5258,5 +5258,16 @@ defmodule CompilerTest do
       {_, predict_fn2} = Axon.Compiler.build(builder.(), [])
       assert predict_fn1 == predict_fn2
     end
+
+    test "builds a model with dropout" do
+      builder = fn ->
+        node = Axon.input("input", shape: {nil, 784})
+        Axon.add(Axon.dropout(node), node)
+      end
+
+      {_, predict_fn1} = Axon.Compiler.build(builder.(), [])
+      {_, predict_fn2} = Axon.Compiler.build(builder.(), [])
+      assert predict_fn1 == predict_fn2
+    end
   end
 end


### PR DESCRIPTION
The previous implementation of dropout would crash
when its child node was accessed directly in the graph.