### PR TITLE
Remove extra usage of 'expected input' from error message in get_input/3

### DIFF
--- a/lib/axon/compiler.ex
+++ b/lib/axon/compiler.ex
@@ -598,7 +598,7 @@ defmodule Axon.Compiler do
 
         _ ->
           raise ArgumentError,
-                "invalid input given to model, expected input" <>
+                "invalid input given to model," <>
                   " expected input to be a tensor or a map" <>
                   " corresponding to correct input names"
       end


### PR DESCRIPTION
This PR fixes the duplicate wording in an error message in `get_input/3` from the `Axon.Compiler` module.