### PR TITLE
Fix Fashion MNIST autoencoder example

### DIFF
--- a/examples/generative/fashionmnist_autoencoder.exs
+++ b/examples/generative/fashionmnist_autoencoder.exs
@@ -57,7 +57,7 @@ defmodule FashionMNIST do
 
     sample_image =
       train_images
-      |> hd()
+      |> Enum.fetch!(0)
       |> Nx.slice_along_axis(0, 1)
       |> Nx.reshape({1, 1, 28, 28})
 

--- a/examples/generative/fashionmnist_autoencoder.exs
+++ b/examples/generative/fashionmnist_autoencoder.exs
@@ -22,7 +22,7 @@ defmodule Fashionmist do
     defp decoder(x) do
       x
       |> Axon.dense(784, activation: :sigmoid)
-      |> Axon.reshape({1, 28, 28})
+      |> Axon.reshape({:batch, 1, 28, 28})
     end
 
     def build_model(input_shape, latent_dim) do

--- a/examples/generative/fashionmnist_autoencoder.exs
+++ b/examples/generative/fashionmnist_autoencoder.exs
@@ -10,7 +10,6 @@ EXLA.set_as_nx_default([:tpu, :cuda, :rocm, :host])
 
 defmodule FashionMNIST do
   require Axon
-  alias Axon.Loop.State
 
   defmodule Autoencoder do
     defp encoder(x, latent_dim) do

--- a/examples/generative/fashionmnist_autoencoder.exs
+++ b/examples/generative/fashionmnist_autoencoder.exs
@@ -8,7 +8,7 @@ Mix.install([
 # Configure default platform with accelerator precedence as tpu > cuda > rocm > host
 EXLA.set_as_nx_default([:tpu, :cuda, :rocm, :host])
 
-defmodule Fashionmist do
+defmodule FashionMNIST do
   require Axon
   alias Axon.Loop.State
 
@@ -71,4 +71,4 @@ defmodule Fashionmist do
   end
 end
 
-Fashionmist.run()
+FashionMNIST.run()

--- a/examples/generative/fashionmnist_autoencoder.exs
+++ b/examples/generative/fashionmnist_autoencoder.exs
@@ -1,8 +1,8 @@
 Mix.install([
-  {:axon, "~> 0.1.0"},
-  {:exla, "~> 0.2.2"},
-  {:nx, "~> 0.2.1"},
-  {:scidata, "~> 0.1.6"}
+  {:axon, "~> 0.3.0"},
+  {:exla, "~> 0.4.1"},
+  {:nx, "~> 0.4.1"},
+  {:scidata, "~> 0.1.9"}
 ])
 
 # Configure default platform with accelerator precedence as tpu > cuda > rocm > host

--- a/examples/generative/fashionmnist_autoencoder.exs
+++ b/examples/generative/fashionmnist_autoencoder.exs
@@ -36,7 +36,7 @@ defmodule FashionMNIST do
     |> Nx.from_binary(type)
     |> Nx.reshape({elem(shape, 0), 1, 28, 28})
     |> Nx.divide(255.0)
-    |> Nx.to_batched_list(32)
+    |> Nx.to_batched(32)
   end
 
   defp train_model(model, train_images, epochs) do


### PR DESCRIPTION
The Fashion MNIST autoencoder example throws the same error as the examples in #437. This PR fixes the autoencoder by updating the dependencies and fixing breaking changes.

Summary of changes:
- Update dependencies to latest versions
- Add `:batch` placeholder for dynamic batch size
- Update deprecated `Nx` function `to_batched_list/3` to `to_batched/3`
- Use `Enum.fetch!/2` since `hd/1` does not work on a stream
- Remove unused alias for `Axon.Loop.State`
- Fix spelling of MNIST in module name