### PR TITLE
Include the folder for the guide links

### DIFF
--- a/guides/guides.md
+++ b/guides/guides.md
@@ -4,29 +4,29 @@ Axon is a library for creating and training neural networks in Elixir. The Axon 
 
 ## Model Creation
 
-* [Your first Axon model](your_first_axon_model.html)
-* [Sequential models](sequential_models.html)
-* [Complex models](complex_models.html)
-* [Multi-input / multi-output models](multi_input_multi_output_models.html)
-* [Custom layers](custom_layers.html)
-* [Model hooks](model_hooks.html)
+* [Your first Axon model](model_creation/your_first_axon_model.livemd)
+* [Sequential models](model_creation/sequential_models.livemd)
+* [Complex models](model_creation/complex_models.livemd)
+* [Multi-input / multi-output models](model_creation/multi_input_multi_output_models.livemd)
+* [Custom layers](model_creation/custom_layers.livemd)
+* [Model hooks](model_creation/model_hooks.livemd)
 
 ## Model Execution
 
-* [Accelerating Axon](accelerating_axon.html)
-* [Training and inference mode](training_and_inference_mode.html)
+* [Accelerating Axon](model_execution/accelerating_axon.livemd)
+* [Training and inference mode](model_execution/training_and_inference_mode.livemd)
 
 ## Training and Evaluation
 
-* [Your first training loop](your_first_training_loop.html)
-* [Instrumenting loops with metrics](instrumenting_loops_with_metrics.html)
-* [Your first evalutaion loop](your_first_evaluation_loop.html)
-* [Using loop event handlers](using_loop_event_handlers.html)
-* [Custom models, loss functions, and optimizers](custom_models_loss_optimizers.html)
-* [Writing custom metrics](writing_custom_metrics.html)
-* [Writing custom event handlers](writing_custom_event_handlers.html)
+* [Your first training loop](training_and_evaluation/your_first_training_loop.livemd)
+* [Instrumenting loops with metrics](training_and_evaluation/instrumenting_loops_with_metrics.livemd)
+* [Your first evalutaion loop](training_and_evaluation/your_first_evaluation_loop.livemd)
+* [Using loop event handlers](training_and_evaluation/using_loop_event_handlers.livemd)
+* [Custom models, loss functions, and optimizers](training_and_evaluation/custom_models_loss_optimizers.livemd)
+* [Writing custom metrics](training_and_evaluation/writing_custom_metrics.livemd)
+* [Writing custom event handlers](training_and_evaluation/writing_custom_event_handlers.livemd)
 
 ## Serialization
 
-* [Converting ONNX models to Axon](onnx_to_axon.html) 
+* [Converting ONNX models to Axon](serialization/onnx_to_axon.livemd) 
 


### PR DESCRIPTION
The guides readme links were broken.  This PR updates the links to the livemd version and include the correct folder its contained in.