### PR TITLE
Fix typo in `Axon.Display.as_table`

### DIFF
--- a/lib/axon/display.ex
+++ b/lib/axon/display.ex
@@ -30,7 +30,7 @@ defmodule Axon.Display do
       Axon.Display.as_table(model, input)
   """
   def as_table(%Axon{output: id, nodes: nodes}, input_templates) do
-    assert_table_rex!("ax_table/2")
+    assert_table_rex!("as_table/2")
 
     title = "Model"
     header = ["Layer", "Input Shape", "Output Shape", "Options", "Parameters"]


### PR DESCRIPTION
Change `ax_table/2` to `as_table/2`