### PR TITLE
Update CIFAR10 example

### DIFF
--- a/examples/vision/cifar10.exs
+++ b/examples/vision/cifar10.exs
@@ -14,7 +14,8 @@ defmodule Cifar do
   defp transform_images({bin, type, shape}) do
     bin
     |> Nx.from_binary(type)
-    |> Nx.reshape({elem(shape, 0), 3, 32, 32})
+    |> Nx.reshape({elem(shape, 0), 3, 32, 32}, names: [:n, :c, :h, :w])
+    |> Nx.transpose(axes: [:n, :h, :w, :c])
     |> Nx.divide(255.0)
     |> Nx.to_batched(32)
     |> Enum.split(1500)
@@ -31,10 +32,10 @@ defmodule Cifar do
 
   defp build_model(input_shape) do
     Axon.input("input", shape: input_shape)
-    |> Axon.conv(32, kernel_size: {3, 3}, activation: :relu, channels: :first)
+    |> Axon.conv(32, kernel_size: {3, 3}, activation: :relu)
     |> Axon.batch_norm()
     |> Axon.max_pool(kernel_size: {2, 2})
-    |> Axon.conv(64, kernel_size: {3, 3}, activation: :relu, channels: :first)
+    |> Axon.conv(64, kernel_size: {3, 3}, activation: :relu)
     |> Axon.batch_norm()
     |> Axon.max_pool(kernel_size: {2, 2})
     |> Axon.flatten()

--- a/examples/vision/cifar10.exs
+++ b/examples/vision/cifar10.exs
@@ -1,8 +1,8 @@
 Mix.install([
-  {:axon, "~> 0.1.0"},
-  {:exla, "~> 0.2.2"},
-  {:nx, "~> 0.2.1"},
-  {:scidata, "~> 0.1.3"}
+  {:axon, "~> 0.4.1"},
+  {:exla, "~> 0.4.2"},
+  {:nx, "~> 0.4.2"},
+  {:scidata, "~> 0.1.9"}
 ])
 
 # Configure default platform with accelerator precedence as tpu > cuda > rocm > host
@@ -16,7 +16,7 @@ defmodule Cifar do
     |> Nx.from_binary(type)
     |> Nx.reshape({elem(shape, 0), 3, 32, 32})
     |> Nx.divide(255.0)
-    |> Nx.to_batched_list(32)
+    |> Nx.to_batched(32)
     |> Enum.split(1500)
   end
 

--- a/examples/vision/cifar10.exs
+++ b/examples/vision/cifar10.exs
@@ -31,12 +31,12 @@ defmodule Cifar do
 
   defp build_model(input_shape) do
     Axon.input("input", shape: input_shape)
-    |> Axon.conv(32, kernel_size: {3, 3}, activation: :relu, padding: :same)
+    |> Axon.conv(32, kernel_size: {3, 3}, activation: :relu, channels: :first)
     |> Axon.batch_norm()
-    |> Axon.max_pool(kernel_size: {2, 2}, padding: :same)
-    |> Axon.conv(64, kernel_size: {3, 3}, activation: :relu, padding: :same)
+    |> Axon.max_pool(kernel_size: {2, 2})
+    |> Axon.conv(64, kernel_size: {3, 3}, activation: :relu, channels: :first)
     |> Axon.batch_norm()
-    |> Axon.max_pool(kernel_size: {2, 2}, padding: :same)
+    |> Axon.max_pool(kernel_size: {2, 2})
     |> Axon.flatten()
     |> Axon.dense(64, activation: :relu)
     |> Axon.dropout(rate: 0.5)

--- a/examples/vision/cifar10.exs
+++ b/examples/vision/cifar10.exs
@@ -25,18 +25,18 @@ defmodule Cifar do
     |> Nx.from_binary(type)
     |> Nx.new_axis(-1)
     |> Nx.equal(Nx.tensor(Enum.to_list(0..9)))
-    |> Nx.to_batched_list(32)
+    |> Nx.to_batched(32)
     |> Enum.split(1500)
   end
 
   defp build_model(input_shape) do
     Axon.input("input", shape: input_shape)
-    |> Axon.conv(32, kernel_size: {3, 3}, activation: :relu)
+    |> Axon.conv(32, kernel_size: {3, 3}, activation: :relu, padding: :same)
     |> Axon.batch_norm()
-    |> Axon.max_pool(kernel_size: {2, 2})
-    |> Axon.conv(64, kernel_size: {3, 3}, activation: :relu)
+    |> Axon.max_pool(kernel_size: {2, 2}, padding: :same)
+    |> Axon.conv(64, kernel_size: {3, 3}, activation: :relu, padding: :same)
     |> Axon.batch_norm()
-    |> Axon.max_pool(kernel_size: {2, 2})
+    |> Axon.max_pool(kernel_size: {2, 2}, padding: :same)
     |> Axon.flatten()
     |> Axon.dense(64, activation: :relu)
     |> Axon.dropout(rate: 0.5)


### PR DESCRIPTION
Hey all 👋 

I wanted to experiment a bit with the CIFAR10 dataset using as starting point the example in the repo, but when I ran it I got back the following error:

```
❯ elixir examples/vision/cifar10.exs

00:26:35.804 [info] XLA service 0x7f94db905030 initialized for platform Host (this does not guarantee that XLA will be used). Devices:

00:26:35.806 [info]   StreamExecutor device (0): Host, Default Version
** (FunctionClauseError) no function clause matching in Axon.input/2

    The following arguments were given to Axon.input/2:

        # 1
        "input"

        # 2
        [shape: {nil, 3, 32, 32}]

    Attempted function clauses (showing 1 out of 1):

        def input(input_shape, name) when is_tuple(input_shape) and is_binary(name)

    (axon 0.1.0) lib/axon.ex:411: Axon.input/2
    examples/vision/cifar10.exs:33: Cifar.build_model/1
    examples/vision/cifar10.exs:66: Cifar.run/0
```

Therefore, I tried to update the implementation to use the latest latest version of Nx and Axon.

While updating the deps, I also update the implementation to:
* use `Nx.to_batched` instead of the deprecated `Nx.to_batched_list`
* transpose the inputs to have the `channels` axis as last to don't change the model implementation (note: Axon Conv layer [expects channels as last by default](https://github.com/elixir-nx/axon/blob/7c21ae75d34e68c946a8ff24a46f194f9d17003a/lib/axon/layers.ex#L356)).

To conclude, below you can find the output of the training and testing:

```
❯ elixir examples/vision/cifar10.exs

12:06:13.711 [info] TfrtCpuClient created.
#Axon<
  inputs: %{"input" => {nil, 32, 32, 3}}
  outputs: "softmax_0"
  nodes: 15
>


 Training Model


12:06:14.758 [debug] Forwarding options: [compiler: EXLA] to JIT compiler
Epoch: 0, Batch: 1450, Accuracy: 0.3524725 loss: 1.7826751
Epoch: 1, Batch: 1450, Accuracy: 0.4720236 loss: 1.6165651
Epoch: 2, Batch: 1450, Accuracy: 0.5339851 loss: 1.5129054
Epoch: 3, Batch: 1450, Accuracy: 0.5710936 loss: 1.4376966
Epoch: 4, Batch: 1450, Accuracy: 0.5962912 loss: 1.3778347
Epoch: 5, Batch: 1450, Accuracy: 0.6215758 loss: 1.3282862
Epoch: 6, Batch: 1450, Accuracy: 0.6390857 loss: 1.2851359
Epoch: 7, Batch: 1450, Accuracy: 0.6504776 loss: 1.2472833
Epoch: 8, Batch: 1450, Accuracy: 0.6667596 loss: 1.2139190
Epoch: 9, Batch: 1450, Accuracy: 0.6782400 loss: 1.1829219


 Testing Model


12:17:00.656 [debug] Forwarding options: [compiler: EXLA] to JIT compiler
Batch: 62, Accuracy: 0.6825397
```

Let me know if there is anything else I can do.
As always, thanks again for all the great work you are doing! 🙇 

Best.