### PR TITLE
docs: update `channels` default value mentioned in the docs

### DIFF
--- a/lib/axon/layers.ex
+++ b/lib/axon/layers.ex
@@ -241,7 +241,7 @@ defmodule Axon.Layers do
       Defaults to `1` or no dilation.
 
     * `:channels ` - channel configuration. One of `:first` or `:last`.
-      Defaults to `:first`.
+      Defaults to `:last`.
 
   ## Examples
 
@@ -412,7 +412,7 @@ defmodule Axon.Layers do
       Defaults to `1` or no dilation.
 
     * `:channels ` - channel configuration. One of `:first` or `:last`.
-      Defaults to `:first`.
+      Defaults to `:last`.
 
   ## Examples
 
@@ -535,7 +535,7 @@ defmodule Axon.Layers do
       Defaults to `1` or no dilation.
 
     * `:channels ` - channel configuration. One of `:first` or `:last`.
-      Defaults to `:first`.
+      Defaults to `:last`.
 
   """
   @doc type: :convolutional
@@ -627,7 +627,7 @@ defmodule Axon.Layers do
       Defaults to `1` or no dilation.
 
     * `:channels ` - channel configuration. One of `:first` or `:last`.
-      Defaults to `:first`.
+      Defaults to `:last`.
 
   ## References
 
@@ -694,7 +694,7 @@ defmodule Axon.Layers do
       Defaults to `1` or no dilation.
 
     * `:channels ` - channel configuration. One of `:first` or `:last`.
-      Defaults to `:first`.
+      Defaults to `:last`.
 
   ## References
 
@@ -751,7 +751,7 @@ defmodule Axon.Layers do
       dilation.
 
     * `:channels ` - channel configuration. One of `:first` or `:last`.
-      Defaults to `:first`.
+      Defaults to `:last`.
 
   ## Examples
 
@@ -834,7 +834,7 @@ defmodule Axon.Layers do
       dilation.
 
     * `:channels ` - channel configuration. One of `:first` or `:last`.
-      Defaults to `:first`.
+      Defaults to `:last`.
   """
   @doc type: :pooling
   defn avg_pool(input, opts \\ []) do
@@ -906,7 +906,7 @@ defmodule Axon.Layers do
       dilation.
 
     * `:channels ` - channel configuration. One of `:first` or `:last`.
-      Defaults to `:first`.
+      Defaults to `:last`.
 
   ## Examples
 
@@ -983,7 +983,7 @@ defmodule Axon.Layers do
       Required.
 
     * `:channels ` - channel configuration. One of `:first` or `:last`.
-      Defaults to `:first`.
+      Defaults to `:last`.
   """
   @doc type: :pooling
   defn adaptive_avg_pool(input, opts \\ []) do


### PR DESCRIPTION
Hey 👋 
I'm opening this small PR to fix a discrepancy in the docs for the option `channels` used in the Conv layers and others.

The default value for the `:channels` option is `:last` based on what I can see in the code (e.g. [here](https://github.com/elixir-nx/axon/blob/7c21ae75d34e68c946a8ff24a46f194f9d17003a/lib/axon/layers.ex#L356)).

Note that in the `Axon` module docs, the default value for the option is correct, only in the `Axon.Layers` it was outdated/incorrect (`:first`).

Cheers ✌️ 