### PR TITLE
Add an explicit update state method

### DIFF
--- a/lib/axon/updates.ex
+++ b/lib/axon/updates.ex
@@ -984,6 +984,14 @@ defmodule Axon.Updates do
     merge_state(new_params, state)
   end
 
+  @doc """
+  Updates the state within the given model state map and an
+  updated model state.
+  """
+  deftransform apply_state(params, state) do
+    merge_state(params, state)
+  end
+
   deftransformp merge_state(params, state) do
     case {params, state} do
       {params, nil} ->

--- a/test/axon/updates_test.exs
+++ b/test/axon/updates_test.exs
@@ -2240,4 +2240,27 @@ defmodule Axon.UpdatesTest do
       assert_all_close(actual_next_trace_e, expected_next_trace_e)
     end
   end
+
+  describe "apply_state/2" do
+    test "merges new state into state map" do
+      params = %{
+        a: Nx.tensor([1.0]),
+        b: %{
+          c: Nx.tensor([[1.0, 2.0, 3.0]])
+        },
+        d: %{e: Nx.tensor(2.0)}
+      }
+
+      state = %{a: Nx.tensor([2.0]), d: %{e: Nx.tensor(1.0)}}
+
+      new_state = apply_state(params, state)
+      assert new_state == %{
+        a: Nx.tensor([2.0]),
+        b: %{
+          c: Nx.tensor([[1.0, 2.0, 3.0]])
+        },
+        d: %{e: Nx.tensor(1.0)}
+      }
+    end
+  end
 end


### PR DESCRIPTION
cc @polvalente 

When updating a parameter map manually the state gets overridden and there's no public way to apply state updates individually. This introduces a method