### PR TITLE
fix: decay defaults for optimizers

### DIFF
--- a/lib/axon/optimizers.ex
+++ b/lib/axon/optimizers.ex
@@ -196,7 +196,6 @@ defmodule Axon.Optimizers do
     * `:momentum` - momentum term. If set, uses SGD with momentum and decay set
       to value of this term.
     * `:nesterov` - whether or not to use nesterov momentum. Defaults to `false`
-    * `:initial_scale` - initial value of EMA. Defaults to `0.0`
     * `:eps` - numerical stability term. Defaults to `1.0e-8`
   """
   def rmsprop(learning_rate \\ 1.0e-2, opts \\ []) do
@@ -207,9 +206,9 @@ defmodule Axon.Optimizers do
 
     combinator =
       if centered do
-        Updates.scale_by_stddev(opts)
+        Updates.scale_by_stddev(decay: opts[:decay])
       else
-        Updates.scale_by_rms(opts)
+        Updates.scale_by_rms(decay: opts[:decay])
       end
       |> scale_by_learning_rate(learning_rate)
 

--- a/lib/axon/optimizers.ex
+++ b/lib/axon/optimizers.ex
@@ -70,6 +70,8 @@ defmodule Axon.Optimizers do
     * [AdaBelief Optimizer: Adapting Stepsizes by the Belief in Observed Gradients](https://arxiv.org/abs/2010.07468)
   """
   def adabelief(learning_rate \\ 1.0e-3, opts \\ []) do
+    opts = Keyword.validate!(opts, b1: 0.9, b2: 0.999, eps: 0.0, eps_root: 1.0e-16)
+
     Updates.scale_by_belief(opts)
     |> scale_by_learning_rate(learning_rate)
   end
@@ -105,6 +107,8 @@ defmodule Axon.Optimizers do
     * [Adam: A Method for Stochastic Optimization](https://arxiv.org/abs/1412.6980)
   """
   def adam(learning_rate \\ 1.0e-3, opts \\ []) do
+    opts = Keyword.validate!(opts, b1: 0.9, b2: 0.999, eps: 1.0e-8, eps_root: 1.0e-15)
+
     Updates.scale_by_adam(opts)
     |> scale_by_learning_rate(learning_rate)
   end
@@ -145,6 +149,16 @@ defmodule Axon.Optimizers do
     * [Large Batch Optimization for Deep Learning: Training BERT in 76 minutes](https://arxiv.org/abs/1904.00962)
   """
   def lamb(learning_rate \\ 1.0e-2, opts \\ []) do
+    opts =
+      Keyword.validate!(opts,
+        decay: 0.95,
+        min_norm: 0.0,
+        b1: 0.9,
+        b2: 0.999,
+        eps: 0.0,
+        eps_root: 1.0e-16
+      )
+
     {decay, opts} = Keyword.pop(opts, :decay, 0.95)
     {min_norm, opts} = Keyword.pop(opts, :min_norm, 0.0)
 
@@ -163,6 +177,8 @@ defmodule Axon.Optimizers do
     * `:gamma` - used to compute variance of noise distribution. Defaults to `0.55`
   """
   def noisy_sgd(learning_rate \\ 1.0e-2, opts \\ []) do
+    opts = Keyword.validate!(opts, eta: 0.1, gamma: 0.55)
+
     scale_by_learning_rate(learning_rate)
     |> Updates.add_noise(opts)
   end
@@ -183,6 +199,9 @@ defmodule Axon.Optimizers do
     * [On the Variance of Adaptive Learning Rate and Beyond](https://arxiv.org/pdf/1908.03265.pdf)
   """
   def radam(learning_rate \\ 1.0e-3, opts \\ []) do
+    opts =
+      Keyword.validate!(opts, b1: 0.9, b2: 0.999, eps: 1.0e-8, eps_root: 1.0e-16, threshold: 5.0)
+
     Updates.scale_by_radam(opts)
     |> scale_by_learning_rate(learning_rate)
   end
@@ -200,6 +219,7 @@ defmodule Axon.Optimizers do
   """
   def rmsprop(learning_rate \\ 1.0e-2, opts \\ []) do
     opts = Keyword.validate!(opts, [:momentum, centered: false, nesterov: false, decay: 0.95])
+
     centered = opts[:centered]
     nesterov? = opts[:nesterov]
     momentum = opts[:momentum]
@@ -227,8 +247,10 @@ defmodule Axon.Optimizers do
     * `:nesterov` - whether or not to use nesterov momentum. Defaults to `false`
   """
   def sgd(learning_rate \\ 1.0e-2, opts \\ []) do
+    opts = Keyword.validate!(opts, [:momentum, nesterov: false])
+
     momentum = opts[:momentum]
-    nesterov? = opts[:nesterov] || false
+    nesterov? = opts[:nesterov]
 
     if momentum do
       Updates.trace(decay: momentum, nesterov: nesterov?)
@@ -254,6 +276,15 @@ defmodule Axon.Optimizers do
     * [Adaptive Methods for Nonconvex Optimization](https://papers.nips.cc/paper/2018/file/90365351ccc7437a1309dc64e4db32a3-Paper.pdf)
   """
   def yogi(learning_rate \\ 1.0e-2, opts \\ []) do
+    opts =
+      Keyword.validate!(opts,
+        initial_accumulator_value: 0.0,
+        b1: 0.9,
+        b2: 0.999,
+        eps: 1.0e-8,
+        eps_root: 0.0
+      )
+
     Updates.scale_by_yogi(opts)
     |> scale_by_learning_rate(learning_rate)
   end

--- a/lib/axon/optimizers.ex
+++ b/lib/axon/optimizers.ex
@@ -118,10 +118,10 @@ defmodule Axon.Optimizers do
     * `:b2` - second moment decay. Defaults to `0.999`
     * `:eps` - numerical stability term. Defaults to `1.0e-8`
     * `:eps_root` - numerical stability term. Defaults to `0.0`
-    * `:decay` - weight decay. Defaults to `0.0`
+    * `:decay` - weight decay. Defaults to `0.95`
   """
   def adamw(learning_rate \\ 1.0e-3, opts \\ []) do
-    {decay, opts} = Keyword.pop(opts, :decay, 0.0)
+    {decay, opts} = Keyword.pop(opts, :decay, 0.95)
 
     Updates.scale_by_adam(opts)
     |> Updates.add_decayed_weights(decay: decay)
@@ -137,7 +137,7 @@ defmodule Axon.Optimizers do
     * `:b2` - second moment decay. Defaults to `0.999`
     * `:eps` - numerical stability term. Defaults to `1.0e-8`
     * `:eps_root` - numerical stability term. Defaults to `0.0`
-    * `:decay` - weight decay. Defaults to `0.0`
+    * `:decay` - weight decay. Defaults to `0.95`
     * `:min_norm` - minimum norm value. Defaults to `0.0`
 
   ## References
@@ -145,7 +145,7 @@ defmodule Axon.Optimizers do
     * [Large Batch Optimization for Deep Learning: Training BERT in 76 minutes](https://arxiv.org/abs/1904.00962)
   """
   def lamb(learning_rate \\ 1.0e-2, opts \\ []) do
-    {decay, opts} = Keyword.pop(opts, :decay, 0.0)
+    {decay, opts} = Keyword.pop(opts, :decay, 0.95)
     {min_norm, opts} = Keyword.pop(opts, :min_norm, 0.0)
 
     Updates.scale_by_adam(opts)
@@ -197,13 +197,13 @@ defmodule Axon.Optimizers do
       to value of this term.
     * `:nesterov` - whether or not to use nesterov momentum. Defaults to `false`
     * `:initial_scale` - initial value of EMA. Defaults to `0.0`
-    * `:decay` - EMA decay rate. Defaults to `0.9`
     * `:eps` - numerical stability term. Defaults to `1.0e-8`
   """
   def rmsprop(learning_rate \\ 1.0e-2, opts \\ []) do
-    {centered, opts} = Keyword.pop(opts, :centered, false)
-    {nesterov?, opts} = Keyword.pop(opts, :nesterov, false)
-    {momentum, opts} = Keyword.pop(opts, :momentum, nil)
+    opts = Keyword.validate!(opts, [:momentum, centered: false, nesterov: false, decay: 0.95])
+    centered = opts[:centered]
+    nesterov? = opts[:nesterov]
+    momentum = opts[:momentum]
 
     combinator =
       if centered do

--- a/lib/axon/updates.ex
+++ b/lib/axon/updates.ex
@@ -239,7 +239,7 @@ defmodule Axon.Updates do
 
   ## Options
 
-      * `:decay` - EMA decay rate. Defaults to `0.9`.
+      * `:decay` - EMA decay rate. Defaults to `0.95`.
 
       * `:eps` - numerical stability term. Defaults to `1.0e-8`.
 
@@ -276,7 +276,7 @@ defmodule Axon.Updates do
   end
 
   defnp apply_scale_by_rms(x, %{nu: nu}, _params, opts \\ []) do
-    opts = keyword!(opts, decay: 0.9, eps: 1.0e-8)
+    opts = keyword!(opts, decay: 0.95, eps: 1.0e-8)
     decay = opts[:decay]
     eps = opts[:eps]
 
@@ -355,7 +355,7 @@ defmodule Axon.Updates do
 
   ## Options
 
-      * `:decay` - EMA decay rate. Defaults to `0.9`.
+      * `:decay` - EMA decay rate. Defaults to `0.95`.
 
       * `:eps` - numerical stability term. Defaults to `1.0e-8`.
 
@@ -393,7 +393,7 @@ defmodule Axon.Updates do
   end
 
   defnp apply_scale_by_stddev(x, %{mu: mu, nu: nu}, _params, opts \\ []) do
-    opts = keyword!(opts, decay: 0.9, eps: 1.0e-8)
+    opts = keyword!(opts, decay: 0.95, eps: 1.0e-8)
     decay = opts[:decay]
     eps = opts[:eps]
 
@@ -529,7 +529,7 @@ defmodule Axon.Updates do
   ## Options
 
     * `:decay` - decay rate for tracing past updates. Defaults
-      to `0.9`
+      to `0.95`
     * `:nesterov` - whether to use Nesterov momentum. Defaults
       to `false`
 
@@ -560,7 +560,7 @@ defmodule Axon.Updates do
   end
 
   defnp apply_trace(x, %{trace: trace}, _params, opts \\ []) do
-    opts = keyword!(opts, decay: 0.9, nesterov: false)
+    opts = keyword!(opts, decay: 0.95, nesterov: false)
     decay = opts[:decay]
 
     update_trace = deep_merge(x, trace, fn g, t -> t * decay + g end)
@@ -688,7 +688,7 @@ defmodule Axon.Updates do
 
   ## Options
 
-      * `:decay` - Rate of decay. Defaults to `0.0`.
+      * `:decay` - Rate of decay. Defaults to `0.95`.
   """
   def add_decayed_weights(combinator_or_opts \\ [])
 
@@ -704,7 +704,7 @@ defmodule Axon.Updates do
   def add_decayed_weights({init_fn, apply_fn} = combinator, opts)
       when is_function(init_fn, 1) and is_function(apply_fn, 3) and is_list(opts) do
     stateless(combinator, fn updates, params ->
-      opts = Nx.Defn.Kernel.keyword!(opts, decay: 0.0)
+      opts = Nx.Defn.Kernel.keyword!(opts, decay: 0.95)
       # Decay can be a tensor, that's why we preprocess it before-hand
       # and pass it as argument to defn instead of as an option.
       apply_weight_decay(updates, params, opts[:decay])

--- a/lib/axon/updates.ex
+++ b/lib/axon/updates.ex
@@ -771,7 +771,7 @@ defmodule Axon.Updates do
   Adds random Gaussian noise to the input.
 
   ## Options
-      
+
       * `:seed` - Random seed to use. Defaults to the
         current system time.
 

--- a/test/axon/optimizers_test.exs
+++ b/test/axon/optimizers_test.exs
@@ -218,8 +218,7 @@ defmodule OptimizersTest do
     end
 
     test "correctly optimizes simple loss centered case" do
-      optimizer =
-        Axon.Optimizers.rmsprop(@learning_rate, centered: true, initial_scale: 0.1, decay: 0.8)
+      optimizer = Axon.Optimizers.rmsprop(@learning_rate, centered: true, decay: 0.8)
 
       loss_fn = fn %{"x0" => x} -> Nx.multiply(x, x) end
       num_steps = @iterations
@@ -229,7 +228,7 @@ defmodule OptimizersTest do
     end
 
     test "correctly optimizes simple loss rms case" do
-      optimizer = Axon.Optimizers.rmsprop(@learning_rate, initial_scale: 0.1, decay: 0.8)
+      optimizer = Axon.Optimizers.rmsprop(@learning_rate, decay: 0.8)
       loss_fn = fn %{"x0" => x} -> Nx.multiply(x, x) end
       num_steps = @iterations
       x0 = %{"x0" => Nx.tensor([1.0])}
@@ -238,8 +237,7 @@ defmodule OptimizersTest do
     end
 
     test "correctly optimizes simple loss with momentum" do
-      optimizer =
-        Axon.Optimizers.rmsprop(@learning_rate, initial_scale: 0.1, decay: 0.8, momentum: 0.9)
+      optimizer = Axon.Optimizers.rmsprop(@learning_rate, decay: 0.8, momentum: 0.9)
 
       loss_fn = fn %{"x0" => x} -> Nx.multiply(x, x) end
       num_steps = @iterations

--- a/test/axon/updates_test.exs
+++ b/test/axon/updates_test.exs
@@ -1257,7 +1257,7 @@ defmodule Axon.UpdatesTest do
   describe "scale_by_rms" do
     test "constructs a stateful transformation" do
       params = %{a: Nx.tensor([1.0, 2.0, 3.0])}
-      assert {init_fn, update_fn} = scale_by_rms()
+      assert {init_fn, update_fn} = scale_by_rms(decay: 0.9)
       assert is_function(init_fn, 1)
       assert is_function(update_fn, 3)
       assert {rms_state} = init_fn.(params)
@@ -1277,7 +1277,7 @@ defmodule Axon.UpdatesTest do
 
     test "composes with itself" do
       params = %{a: Nx.tensor([1.0, 2.0, 3.0])}
-      assert {init_fn, update_fn} = scale_by_rms() |> scale_by_rms()
+      assert {init_fn, update_fn} = scale_by_rms(decay: 0.9) |> scale_by_rms(decay: 0.9)
       assert is_function(init_fn, 1)
       assert is_function(update_fn, 3)
       assert {rms_state_1, rms_state_2} = init_fn.(params)
@@ -1289,7 +1289,7 @@ defmodule Axon.UpdatesTest do
 
     test "composes with stateless transformation" do
       params = %{a: Nx.tensor([1.0, 2.0, 3.0])}
-      assert {init_fn, update_fn} = scale_by_rms() |> scale(1.0e-2)
+      assert {init_fn, update_fn} = scale_by_rms(decay: 0.9) |> scale(1.0e-2)
       assert is_function(init_fn, 1)
       assert is_function(update_fn, 3)
       assert {rms_state} = init_fn.(params)
@@ -1298,7 +1298,7 @@ defmodule Axon.UpdatesTest do
     end
 
     test "matches optax with simple container" do
-      assert {init_fn, update_fn} = scale_by_rms()
+      assert {init_fn, update_fn} = scale_by_rms(decay: 0.9)
       params = %{a: Nx.tensor([0.77100057, 0.98078091, 0.78499164])}
       updates = %{a: Nx.tensor([0.25156708, 0.30524656, 0.97350756])}
       state = init_fn.(params)
@@ -1314,7 +1314,7 @@ defmodule Axon.UpdatesTest do
     end
 
     test "matches optax with nested container" do
-      assert {init_fn, update_fn} = scale_by_rms()
+      assert {init_fn, update_fn} = scale_by_rms(decay: 0.9)
 
       params = %{
         a: %{
@@ -1348,7 +1348,7 @@ defmodule Axon.UpdatesTest do
     end
 
     test "supports generic container" do
-      assert {init_fn, update_fn} = scale_by_rms()
+      assert {init_fn, update_fn} = scale_by_rms(decay: 0.9)
 
       params = {
         {
@@ -1646,7 +1646,7 @@ defmodule Axon.UpdatesTest do
   describe "scale_by_stddev" do
     test "constructs a stateful transformation" do
       params = %{a: Nx.tensor([1.0, 2.0, 3.0])}
-      assert {init_fn, update_fn} = scale_by_stddev()
+      assert {init_fn, update_fn} = scale_by_stddev(decay: 0.9)
       assert is_function(init_fn, 1)
       assert is_function(update_fn, 3)
       assert {stddev_state} = init_fn.(params)
@@ -1657,7 +1657,7 @@ defmodule Axon.UpdatesTest do
 
     test "constructs a stateful transformation with options" do
       params = %{a: Nx.tensor([1.0, 2.0, 3.0])}
-      assert {init_fn, update_fn} = scale_by_stddev(initial_scale: 0.5)
+      assert {init_fn, update_fn} = scale_by_stddev(decay: 0.9, initial_scale: 0.5)
       assert is_function(init_fn, 1)
       assert is_function(update_fn, 3)
       assert {stddev_state} = init_fn.(params)
@@ -1670,7 +1670,8 @@ defmodule Axon.UpdatesTest do
       params = %{a: Nx.tensor([1.0, 2.0, 3.0])}
 
       assert {init_fn, update_fn} =
-               scale_by_stddev(initial_scale: 0.1) |> scale_by_stddev(initial_scale: 0.2)
+               scale_by_stddev(decay: 0.9, initial_scale: 0.1)
+               |> scale_by_stddev(decay: 0.9, initial_scale: 0.2)
 
       assert is_function(init_fn, 1)
       assert is_function(update_fn, 3)
@@ -1685,7 +1686,10 @@ defmodule Axon.UpdatesTest do
 
     test "composes with stateless transformation" do
       params = %{a: Nx.tensor([1.0, 2.0, 3.0])}
-      assert {init_fn, update_fn} = scale_by_stddev(initial_scale: 0.1) |> scale(1.0e-2)
+
+      assert {init_fn, update_fn} =
+               scale_by_stddev(decay: 0.9, initial_scale: 0.1) |> scale(1.0e-2)
+
       assert is_function(init_fn, 1)
       assert is_function(update_fn, 3)
       assert {stddev_state} = init_fn.(params)
@@ -1695,7 +1699,7 @@ defmodule Axon.UpdatesTest do
     end
 
     test "matches optax with simple container" do
-      assert {init_fn, update_fn} = scale_by_stddev()
+      assert {init_fn, update_fn} = scale_by_stddev(decay: 0.9)
       params = %{a: Nx.tensor([0.98013234, 0.0653057, 0.39361905])}
       updates = %{a: Nx.tensor([0.58050587, 0.04869076, 0.62340991])}
       state = init_fn.(params)
@@ -1713,7 +1717,7 @@ defmodule Axon.UpdatesTest do
     end
 
     test "matches optax with nested container" do
-      assert {init_fn, update_fn} = scale_by_stddev()
+      assert {init_fn, update_fn} = scale_by_stddev(decay: 0.9)
 
       params = %{
         a: %{
@@ -1752,7 +1756,7 @@ defmodule Axon.UpdatesTest do
     end
 
     test "supports generic container" do
-      assert {init_fn, update_fn} = scale_by_stddev()
+      assert {init_fn, update_fn} = scale_by_stddev(decay: 0.9)
 
       params = {
         {
@@ -2066,7 +2070,7 @@ defmodule Axon.UpdatesTest do
   describe "trace" do
     test "constructs a stateful transformation" do
       params = %{a: Nx.tensor([1.0, 2.0, 3.0])}
-      assert {init_fn, update_fn} = trace()
+      assert {init_fn, update_fn} = trace(decay: 0.9)
       assert is_function(init_fn, 1)
       assert is_function(update_fn, 3)
       assert {trace_state} = init_fn.(params)
@@ -2157,7 +2161,7 @@ defmodule Axon.UpdatesTest do
     end
 
     test "matches optax with simple container, nesterov: true" do
-      assert {init_fn, update_fn} = trace(nesterov: true)
+      assert {init_fn, update_fn} = trace(decay: 0.9, nesterov: true)
       params = %{a: Nx.tensor([0.05727068, 0.71336316, 0.52111667])}
       updates = %{a: Nx.tensor([0.99510349, 0.38321624, 0.37485662])}
       state = init_fn.(params)
@@ -2173,7 +2177,7 @@ defmodule Axon.UpdatesTest do
     end
 
     test "matches optax with nested container, nesterov: true" do
-      assert {init_fn, update_fn} = trace(nesterov: true)
+      assert {init_fn, update_fn} = trace(decay: 0.9, nesterov: true)
 
       params = %{
         a: %{
@@ -2207,7 +2211,7 @@ defmodule Axon.UpdatesTest do
     end
 
     test "supports generic container" do
-      assert {init_fn, update_fn} = trace(nesterov: true)
+      assert {init_fn, update_fn} = trace(decay: 0.9, nesterov: true)
 
       params = {
         {


### PR DESCRIPTION
Fixes defaults for :decay option in some optimizers.
RMSProp wasn't using the option, but I'm not sure if momentum is being used correctly there