### PR TITLE
Fix support for multiple hooks in `attach_hook`

### DIFF
--- a/lib/axon.ex
+++ b/lib/axon.ex
@@ -3139,7 +3139,7 @@ defmodule Axon do
 
     updated_nodes =
       Map.update!(nodes, id, fn axon_node ->
-        %{axon_node | hooks: [{on_event, mode, fun}]}
+        %{axon_node | hooks: [{on_event, mode, fun} | axon_node.hooks]}
       end)
 
     %{axon | nodes: updated_nodes}


### PR DESCRIPTION
The following code from the [model hooks](https://hexdocs.pm/axon/model_hooks.html) guide should call `IO.inspect` for both `hook1` and `hook2`. Instead it only runs `hook2`.

```elixir
model =
  Axon.input("data")
  |> Axon.dense(8)
  |> Axon.attach_hook(fn val -> IO.inspect(val, label: :hook1) end, on: :forward)
  |> Axon.attach_hook(fn val -> IO.inspect(val, label: :hook2) end, on: :forward)
  |> Axon.relu()

{init_fn, predict_fn} = Axon.build(model)
params = init_fn.(input, %{})

predict_fn.(params, input)
```

`Axon.attach_hook` should accumulate hooks instead of overwriting the `node.hooks` variable with the most recent hook.