### PR TITLE
Fix precision issue

### DIFF
--- a/lib/axon/compiler.ex
+++ b/lib/axon/compiler.ex
@@ -203,13 +203,26 @@ defmodule Axon.Compiler do
           %{params | key => merge_params!(nested, value)}
 
         %{^key => template} ->
-          %{params | key => Nx.as_type(value, Nx.type(template))}
+          %{params | key => merge_type(key, template, value)}
 
         _ ->
           Logger.warning("found unexpected key in the initial parameters map: #{inspect(key)}")
           params
       end
     end)
+  end
+
+  defp merge_type(key, template, value) do
+    if Nx.type(template) != Nx.type(value) do
+      Logger.warning(
+        "initial type for parameter #{key} does not match policy," <>
+          " consider using Axon.MixedPrecision.cast before passing" <>
+          " initial state to model initialization function to avoid" <>
+          " type casts"
+      )
+    end
+
+    Nx.as_type(value, Nx.type(template))
   end
 
   def compile(graph, _opts) do

--- a/lib/axon/compiler.ex
+++ b/lib/axon/compiler.ex
@@ -202,8 +202,8 @@ defmodule Axon.Compiler do
         %{^key => %{} = nested} when not is_struct(nested) ->
           %{params | key => merge_params!(nested, value)}
 
-        %{^key => _} ->
-          %{params | key => value}
+        %{^key => template} ->
+          %{params | key => Nx.as_type(value, Nx.type(template))}
 
         _ ->
           Logger.warning("found unexpected key in the initial parameters map: #{inspect(key)}")

--- a/lib/axon/mixed_precision/policy.ex
+++ b/lib/axon/mixed_precision/policy.ex
@@ -10,9 +10,11 @@ defmodule Axon.MixedPrecision.Policy do
     def inspect(policy, _opts) do
       force_unfit(
         concat([
+          "#Axon.MixedPrecision.Policy<",
           "p=#{Nx.Type.to_string(policy.params)} ",
           "c=#{Nx.Type.to_string(policy.compute)} ",
-          "o=#{Nx.Type.to_string(policy.output)}"
+          "o=#{Nx.Type.to_string(policy.output)}",
+          ">"
         ])
       )
     end

--- a/test/axon/integration_test.exs
+++ b/test/axon/integration_test.exs
@@ -415,11 +415,12 @@ defmodule Axon.IntegrationTest do
     end
 
     test "mixed precision downcasts model when state is given to train" do
-      policy = Axon.MixedPrecision.create_policy(
-        params: {:f, 16},
-        compute: {:f, 16},
-        output: {:f, 16}
-      )
+      policy =
+        Axon.MixedPrecision.create_policy(
+          params: {:f, 16},
+          compute: {:f, 16},
+          output: {:f, 16}
+        )
 
       {train, _test} = get_test_data(100, 0, 10, {10}, 2, 1337)
 

--- a/test/axon/mixed_precision_test.exs
+++ b/test/axon/mixed_precision_test.exs
@@ -1,0 +1,4 @@
+defmodule Axon.MixedPrecisionTest do
+  use ExUnit.Case
+  doctest Axon.MixedPrecision
+end


### PR DESCRIPTION
Resolves #496 

When a user has a pretrained model with some initialized state, we do not cast that state to the model's desired policy if they try to use mixed precision. This fixes that.

It kind of makes me think though that maybe we should rethink mixed precision a bit? I'm not exactly sure how, but doing this implicitly feels weird to me. Maybe the alternative is to recommend the parameters in this case be cast to the desired type explicitly.