### PR TITLE
Fix kino dependency

### DIFF
--- a/guides/model_creation/complex_models.livemd
+++ b/guides/model_creation/complex_models.livemd
@@ -5,8 +5,7 @@
 ```elixir
 Mix.install([
   {:axon, github: "elixir-nx/axon"},
-  {:nx, "~> 0.3.0", github: "elixir-nx/nx", sparse: "nx", override: true},
-  {:kino, "~> 0.7.0"}
+  {:kino, "~> 0.7"}
 ])
 ```
 

--- a/guides/model_creation/custom_layers.livemd
+++ b/guides/model_creation/custom_layers.livemd
@@ -5,8 +5,7 @@
 ```elixir
 Mix.install([
   {:axon, github: "elixir-nx/axon"},
-  {:nx, "~> 0.3.0", github: "elixir-nx/nx", sparse: "nx", override: true},
-  {:kino, "~> 0.7.0"}
+  {:kino, "~> 0.7"}
 ])
 ```
 

--- a/guides/model_creation/model_hooks.livemd
+++ b/guides/model_creation/model_hooks.livemd
@@ -4,8 +4,7 @@
 
 ```elixir
 Mix.install([
-  {:axon, github: "elixir-nx/axon"},
-  {:nx, "~> 0.3.0", github: "elixir-nx/nx", sparse: "nx", override: true}
+  {:axon, github: "elixir-nx/axon"}
 ])
 ```
 

--- a/guides/model_creation/multi_input_multi_output_models.livemd
+++ b/guides/model_creation/multi_input_multi_output_models.livemd
@@ -5,8 +5,7 @@
 ```elixir
 Mix.install([
   {:axon, github: "elixir-nx/axon"},
-  {:nx, "~> 0.3.0", github: "elixir-nx/nx", sparse: "nx", override: true},
-  {:kino, "~> 0.7.0"}
+  {:kino, "~> 0.7"}
 ])
 ```
 

--- a/guides/model_creation/sequential_models.livemd
+++ b/guides/model_creation/sequential_models.livemd
@@ -5,8 +5,7 @@
 ```elixir
 Mix.install([
   {:axon, github: "elixir-nx/axon"},
-  {:nx, "~> 0.3.0", github: "elixir-nx/nx", sparse: "nx", override: true},
-  {:kino, "~> 0.7.0"}
+  {:kino, "~> 0.7"}
 ])
 ```
 

--- a/guides/model_creation/your_first_axon_model.livemd
+++ b/guides/model_creation/your_first_axon_model.livemd
@@ -5,8 +5,7 @@
 ```elixir
 Mix.install([
   {:axon, github: "elixir-nx/axon"},
-  {:nx, github: "elixir-nx/nx", sparse: "nx", override: true},
-  {:kino, "~> 0.7.0"}
+  {:kino, "~> 0.7"}
 ])
 ```
 

--- a/guides/model_execution/accelerating_axon.livemd
+++ b/guides/model_execution/accelerating_axon.livemd
@@ -4,13 +4,11 @@
 
 ```elixir
 Mix.install([
-  {:axon, github: "elixir-nx/axon"},
-  {:exla, "~> 0.3.0", github: "elixir-nx/nx", sparse: "exla"},
-  {:torchx, github: "elixir-nx/nx", sparse: "torchx"},
-  {:nx, "~> 0.3.0", github: "elixir-nx/nx", sparse: "nx", override: true},
-  {:benchee, github: "akoutmos/benchee", branch: :adding_table_support},
-  {:kino_benchee, github: "livebook-dev/kino_benchee"},
-  {:kino, "~> 0.7.0", override: true}
+  {:axon, github: "elixir-nx/axon", override: true},
+  {:exla, "~> 0.5"},
+  {:torchx, "~> 0.5.3"},
+  {:benchee, "~> 1.1.0"},
+  {:kino, "~> 0.7", override: true}
 ])
 ```
 

--- a/guides/model_execution/training_and_inference_mode.livemd
+++ b/guides/model_execution/training_and_inference_mode.livemd
@@ -4,8 +4,7 @@
 
 ```elixir
 Mix.install([
-  {:axon, github: "elixir-nx/axon"},
-  {:nx, "~> 0.3.0", github: "elixir-nx/nx", sparse: "nx", override: true}
+  {:axon, github: "elixir-nx/axon"}
 ])
 ```
 

--- a/guides/training_and_evaluation/custom_models_loss_optimizers.livemd
+++ b/guides/training_and_evaluation/custom_models_loss_optimizers.livemd
@@ -4,8 +4,7 @@
 
 ```elixir
 Mix.install([
-  {:axon, github: "elixir-nx/axon"},
-  {:nx, "~> 0.3.0", github: "elixir-nx/nx", sparse: "nx", override: true}
+  {:axon, github: "elixir-nx/axon"}
 ])
 ```
 

--- a/guides/training_and_evaluation/instrumenting_loops_with_metrics.livemd
+++ b/guides/training_and_evaluation/instrumenting_loops_with_metrics.livemd
@@ -4,8 +4,7 @@
 
 ```elixir
 Mix.install([
-  {:axon, github: "elixir-nx/axon"},
-  {:nx, "~> 0.3.0", github: "elixir-nx/nx", sparse: "nx", override: true}
+  {:axon, github: "elixir-nx/axon"}
 ])
 ```
 

--- a/guides/training_and_evaluation/using_loop_event_handlers.livemd
+++ b/guides/training_and_evaluation/using_loop_event_handlers.livemd
@@ -4,8 +4,7 @@
 
 ```elixir
 Mix.install([
-  {:axon, github: "elixir-nx/axon"},
-  {:nx, "~> 0.3.0", github: "elixir-nx/nx", sparse: "nx", override: true}
+  {:axon, github: "elixir-nx/axon"}
 ])
 ```
 
@@ -166,7 +165,7 @@ You can also use event handlers for things as simple as implementing custom logg
 ```elixir
 model
 |> Axon.Loop.trainer(:mean_squared_error, :sgd)
-|> Axon.Loop.log(:epoch_completed, fn _state -> "epoch is over\n" end, :stdio)
+|> Axon.Loop.log(fn _state -> "epoch is over\n" end, device: :stdio)
 |> Axon.Loop.run(train_data, %{}, epochs: 5, iterations: 100)
 ```
 

--- a/guides/training_and_evaluation/writing_custom_event_handlers.livemd
+++ b/guides/training_and_evaluation/writing_custom_event_handlers.livemd
@@ -4,8 +4,7 @@
 
 ```elixir
 Mix.install([
-  {:axon, github: "elixir-nx/axon"},
-  {:nx, "~> 0.3.0", github: "elixir-nx/nx", sparse: "nx", override: true}
+  {:axon, github: "elixir-nx/axon"}
 ])
 ```
 

--- a/guides/training_and_evaluation/writing_custom_metrics.livemd
+++ b/guides/training_and_evaluation/writing_custom_metrics.livemd
@@ -4,8 +4,7 @@
 
 ```elixir
 Mix.install([
-  {:axon, github: "elixir-nx/axon"},
-  {:nx, "~> 0.3.0", github: "elixir-nx/nx", sparse: "nx", override: true}
+  {:axon, github: "elixir-nx/axon"}
 ])
 ```
 

--- a/guides/training_and_evaluation/your_first_evaluation_loop.livemd
+++ b/guides/training_and_evaluation/your_first_evaluation_loop.livemd
@@ -4,8 +4,7 @@
 
 ```elixir
 Mix.install([
-  {:axon, github: "elixir-nx/axon"},
-  {:nx, "~> 0.3.0", github: "elixir-nx/nx", sparse: "nx", override: true}
+  {:axon, github: "elixir-nx/axon"}
 ])
 ```
 

--- a/guides/training_and_evaluation/your_first_training_loop.livemd
+++ b/guides/training_and_evaluation/your_first_training_loop.livemd
@@ -4,8 +4,7 @@
 
 ```elixir
 Mix.install([
-  {:axon, github: "elixir-nx/axon"},
-  {:nx, "~> 0.3.0", github: "elixir-nx/nx", sparse: "nx", override: true}
+  {:axon, github: "elixir-nx/axon"}
 ])
 ```
 


### PR DESCRIPTION
Without this I get the following error:

```
Unchecked dependencies for environment dev:
* kino (Hex package)
  the dependency does not match the requirement "~> 0.7.0", got "0.9.4"
** (Mix.Error) Can't continue due to errors on dependencies
    (mix 1.14.2) lib/mix.ex:513: Mix.raise/2
    (mix 1.14.2) lib/mix/tasks/deps.loadpaths.ex:43: Mix.Tasks.Deps.Loadpaths.run/1
    (mix 1.14.2) lib/mix/task.ex:421: anonymous fn/3 in Mix.Task.run_task/4
    (mix 1.14.2) lib/mix.ex:782: anonymous fn/5 in Mix.install/2
    (elixir 1.14.2) lib/file.ex:1607: File.cd!/2
    (mix 1.14.2) lib/mix.ex:749: Mix.install/2
    #cell:setup:1: (file)
```