### PR TITLE
fix loss_scale atom typo in Axon.Loop.trainer

### DIFF
--- a/lib/axon/loop.ex
+++ b/lib/axon/loop.ex
@@ -696,7 +696,7 @@ defmodule Axon.Loop do
 
     # Build loss now so we can use it as a metric
     loss_fn = build_loss_fn(loss)
-    step_opts = Keyword.take(opts, [:gradient_accumulation_steps, :loss_cale, :seed])
+    step_opts = Keyword.take(opts, [:gradient_accumulation_steps, :loss_scale, :seed])
     {init_fn, step_fn} = train_step(model, loss_fn, optimizer, step_opts)
 
     log_interval = opts[:log] || 50


### PR DESCRIPTION
The trainer function is currently looking for :loss_cale in opts. This should pick out the right options and pass them to train_step