### PR TITLE
Fixes horses_or_humans.exs example

### DIFF
--- a/examples/vision/horses_or_humans.exs
+++ b/examples/vision/horses_or_humans.exs
@@ -10,7 +10,8 @@ defmodule HorsesOrHumans do
   alias Axon.Loop.State
   import Nx.Defn
 
-  # Download and extract from https://laurencemoroney.com/datasets.html
+  # Download and extract from
+  # https://www.kaggle.com/datasets/sanikamal/horses-or-humans-dataset
   # or you can use Req to download and extract the zip file and iterate
   # over the resulting data
   @directories "examples/vision/{horses,humans}/*"

--- a/examples/vision/horses_or_humans.exs
+++ b/examples/vision/horses_or_humans.exs
@@ -1,6 +1,7 @@
 Mix.install([
   {:stb_image, "~> 0.5.2"},
   {:axon, "~> 0.5"},
+  {:polaris, "~> 0.1.0"},
   {:exla, "~> 0.5"},
   {:nx, "~> 0.5"}
 ])
@@ -43,14 +44,13 @@ defmodule HorsesOrHumans do
         do: Nx.tensor([1, 0], type: {:u, 8}),
         else: Nx.tensor([0, 1], type: {:u, 8})
 
-    {:ok, binary, shape, :u8, :rgba} = StbImage.from_file(filename)
+    {:ok, img} = StbImage.read_file(filename)
 
     {StbImage.to_nx(img), class}
   end
 
-  defp build_model(input_shape, transpose_shape) do
+  defp build_model(input_shape) do
     Axon.input("input", shape: input_shape)
-    |> Axon.transpose(transpose_shape)
     |> Axon.conv(16, kernel_size: {3, 3}, activation: :relu)
     |> Axon.max_pool(kernel_size: {2, 2})
     |> Axon.conv(32, kernel_size: {3, 3}, activation: :relu)
@@ -77,7 +77,7 @@ defmodule HorsesOrHumans do
   end
 
   def run() do
-    model = build_model({nil, 300, 300, 4}, [2, 0, 1]) |> IO.inspect()
+    model = build_model({nil, 300, 300, 4}) |> IO.inspect()
     optimizer = Polaris.Optimizers.adam(learning_rate: 1.0e-4)
     centralized_optimizer = Polaris.Updates.compose(Polaris.Updates.centralize(), optimizer)
 

--- a/examples/vision/horses_or_humans.exs
+++ b/examples/vision/horses_or_humans.exs
@@ -73,7 +73,7 @@ defmodule HorsesOrHumans do
     model
     |> Axon.Loop.trainer(:binary_cross_entropy, optimizer, log: 1)
     |> Axon.Loop.metric(:accuracy)
-    |> Axon.Loop.run(data, %{}, epochs: epochs, iterations: 100)
+    |> Axon.Loop.run(data, %{}, epochs: epochs, iterations: 100, compiler: EXLA)
   end
 
   def run() do

--- a/examples/vision/horses_or_humans.exs
+++ b/examples/vision/horses_or_humans.exs
@@ -1,7 +1,7 @@
 Mix.install([
   {:stb_image, "~> 0.5.2"},
   {:axon, "~> 0.5"},
-  {:polaris, "~> 0.1.0"},
+  {:polaris, "~> 0.1"},
   {:exla, "~> 0.5"},
   {:nx, "~> 0.5"}
 ])


### PR DESCRIPTION
- channels transpose no longer needed (it seems?)
- Polaris references in example needs polaris dependency until next axon is released
- Fix erroneous png parsing
- Updates dataset source URL