### PR TITLE
Fixes credit_card_fraud.exs example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ axon-*.tar
 # Downloaded fixtures
 examples/vision/horses/
 examples/vision/humans/
+examples/structured/creditcard.csv
 
 # Temporary files for e.g. tests
 /tmp/

--- a/examples/structured/credit_card_fraud.exs
+++ b/examples/structured/credit_card_fraud.exs
@@ -126,7 +126,7 @@ defmodule CreditCardFraud do
     model
     |> Axon.Loop.evaluator()
     |> metrics()
-    |> Axon.Loop.handle(:epoch_completed, &summarize/1)
+    |> Axon.Loop.handle_event(:epoch_completed, &summarize/1)
     |> Axon.Loop.run(test_data, model_state, compiler: EXLA)
   end
 
@@ -144,12 +144,12 @@ defmodule CreditCardFraud do
     fraud = Nx.sum(train_targets) |> Nx.to_number()
     legit = Nx.size(train_targets) - fraud
 
-    batched_train_inputs = Nx.to_batched_list(train_inputs, 2048)
-    batched_train_targets = Nx.to_batched_list(train_targets, 2048)
+    batched_train_inputs = Nx.to_batched(train_inputs, 2048)
+    batched_train_targets = Nx.to_batched(train_targets, 2048)
     batched_train = Stream.zip(batched_train_inputs, batched_train_targets)
 
-    batched_test_inputs = Nx.to_batched_list(test_inputs, 2048)
-    batched_test_targets = Nx.to_batched_list(test_targets, 2048)
+    batched_test_inputs = Nx.to_batched(test_inputs, 2048)
+    batched_test_targets = Nx.to_batched(test_targets, 2048)
     batched_test = Stream.zip(batched_test_inputs, batched_test_targets)
 
     IO.puts("# of legit transactions (train): #{legit}")

--- a/examples/structured/credit_card_fraud.exs
+++ b/examples/structured/credit_card_fraud.exs
@@ -1,8 +1,9 @@
 Mix.install([
   {:axon, "~> 0.5"},
+  {:polaris, "~> 0.1"},
   {:exla, "~> 0.5"},
   {:nx, "~> 0.5"},
-  {:explorer, "~> 0.5"}
+  {:explorer, "~> 0.2.0"}
 ])
 
 defmodule CreditCardFraud do


### PR DESCRIPTION
Seems the example was written for `explorer 0.2` and never adapted to support latest explorer.

For now quick fix to go back to compatible explorer version.
Haven't had time to see which/how many updates necessary to make it work with explorer 0.5.

Thanks!