### PR TITLE
Update horses_or_humans.livemd with the correct dataset url

### DIFF
--- a/notebooks/vision/horses_or_humans.livemd
+++ b/notebooks/vision/horses_or_humans.livemd
@@ -24,7 +24,7 @@ We will be using the [Horses or Humans Dataset](https://laurencemoroney.com/data
 
 ```elixir
 %{body: files} =
-  Req.get!("https://storage.googleapis.com/laurencemoroney-blog.appspot.com/horse-or-human.zip")
+  Req.get!("https://storage.googleapis.com/learning-datasets/horse-or-human.zip")
 
 files = for {name, binary} <- files, do: {List.to_string(name), binary}
 ```


### PR DESCRIPTION
Run into the following error with the original url. It seems that the dataset has been moved.
```
<Error>
<Code>NoSuchBucket</Code>
<Message>The specified bucket does not exist.</Message>
</Error>
```