### PR TITLE
Do not cast integer to float unintentionally

### DIFF
--- a/lib/axon/compiler.ex
+++ b/lib/axon/compiler.ex
@@ -933,7 +933,7 @@ defmodule Axon.Compiler do
           out = Nx.Defn.Expr.metadata(Nx.Defn.Expr.tensor(out), %{axon_layer: op_name})
           %{stateful | output: out}
 
-        %Nx.Tensor{} = out
+          %Nx.Tensor{} = out
           Nx.Defn.Expr.metadata(Nx.Defn.Expr.tensor(out), %{axon_layer: op_name})
 
         out ->

--- a/lib/axon/compiler.ex
+++ b/lib/axon/compiler.ex
@@ -933,7 +933,7 @@ defmodule Axon.Compiler do
           out = Nx.Defn.Expr.metadata(Nx.Defn.Expr.tensor(out), %{axon_layer: op_name})
           %{stateful | output: out}
 
-          %Nx.Tensor{} = out
+        %Nx.Tensor{} = out ->
           Nx.Defn.Expr.metadata(Nx.Defn.Expr.tensor(out), %{axon_layer: op_name})
 
         out ->

--- a/lib/axon/compiler.ex
+++ b/lib/axon/compiler.ex
@@ -837,7 +837,7 @@ defmodule Axon.Compiler do
       # parameter map, so we just need to extract them and then apply
       # freezing and dtype policy
       parameter_inputs =
-        Enum.map(layer_params, fn %{type: type, name: v, frozen: frz} ->
+        Enum.map(layer_params, fn %{name: v, frozen: frz} ->
           param = params[name][v]
 
           cond do
@@ -1109,19 +1109,6 @@ defmodule Axon.Compiler do
 
       container ->
         deep_new(container, &Nx.shape/1)
-    end
-  end
-
-  defp safe_type(container_or_tensor) do
-    case container_or_tensor do
-      %Axon.None{} = none ->
-        none
-
-      %Nx.Tensor{} = tensor ->
-        Nx.type(tensor)
-
-      container ->
-        deep_new(container, &Nx.type/1)
     end
   end
 

--- a/lib/axon/layers.ex
+++ b/lib/axon/layers.ex
@@ -1795,7 +1795,7 @@ defmodule Axon.Layers do
   @doc type: :linear
   defn embedding(input, kernel, _opts \\ []) do
     assert_rank!("Axon.Layers.embedding", "kernel", kernel, 2)
-    Nx.take(kernel, Nx.as_type(input, {:s, 64}), axis: 0)
+    Nx.take(kernel, input, axis: 0)
   end
 
   ## Shape

--- a/test/axon/compiler_test.exs
+++ b/test/axon/compiler_test.exs
@@ -602,7 +602,7 @@ defmodule CompilerTest do
     test "initializes in default case" do
       model = Axon.input("input_0", shape: {nil, 1}) |> Axon.embedding(1, 1, name: "embedding")
 
-      input = random({1, 1})
+      input = random({1, 1}) |> Nx.as_type(:s64)
 
       assert {init_fn, _predict_fn} = Axon.build(model)
       assert %{"embedding" => %{"kernel" => kernel}} = init_fn.(input, %{})
@@ -615,7 +615,7 @@ defmodule CompilerTest do
         Axon.input("input_0", shape: {nil, 1})
         |> Axon.embedding(1, 1, name: "embedding", kernel_initializer: :zeros)
 
-      input = random({1, 1})
+      input = random({1, 1}) |> Nx.as_type(:s64)
 
       assert {init_fn, _predict_fn} = Axon.build(model1)
       assert %{"embedding" => %{"kernel" => kernel}} = init_fn.(input, %{})


### PR DESCRIPTION
Resolves #544
Also resolves #545 (we just don't wrap those layers with metadata)
Also resolves #464 

The issue in 544 was that we were casting embedding layer integer inputs to f16, and then casting back to s64 which causes all sorts of issues because of loss of precision. Now we just never cast integer types at all. We get the same outputs now with f16:

```
%{
  results: [
    %{
      text: "[INST] <<SYS>>\nYou are a bot.\n<</SYS>>\n\nHi, bot![/INST]  Hello! *chirp* *winking emoji* I'm so glad you said hi to me! I'm just an AI bot, here to help answer your questions and provide some fun and interesting responses. What's on your mind? 🤖"
    }
  ]
}
```