### PR TITLE
Fix event count for multiple handlers

### DIFF
--- a/lib/axon/loop.ex
+++ b/lib/axon/loop.ex
@@ -1881,14 +1881,14 @@ defmodule Axon.Loop do
   # attached to the loop.
   # TODO(seanmor5): Custom events
   defp fire_event(event, handler_fns, state, debug?) do
+    state = update_counts(state, event)
+
     handler_fns[event]
     |> Enum.reverse()
     |> Enum.reduce_while({:continue, state}, fn {handler, filter}, {_, state} ->
       if debug? do
         Logger.debug("Axon.Loop fired event #{inspect(event)}")
       end
-
-      state = update_counts(state, event)
 
       if filter.(state, event) do
         case handler.(state) do

--- a/test/axon/loop_test.exs
+++ b/test/axon/loop_test.exs
@@ -671,13 +671,8 @@ defmodule Axon.LoopTest do
 
       model
       |> Axon.Loop.trainer(:binary_cross_entropy, :sgd, log: -1)
-      |> continue_handler(event)
       |> send_handler(event, filter)
       |> Axon.Loop.run(data, %{}, epochs: epochs, iterations: iterations)
-    end
-
-    def continue_handler(loop, event) do
-      Axon.Loop.handle_event(loop, event, &{:continue, &1})
     end
 
     def send_handler(loop, event, filter) do

--- a/test/axon/loop_test.exs
+++ b/test/axon/loop_test.exs
@@ -611,8 +611,13 @@ defmodule Axon.LoopTest do
 
       model
       |> Axon.Loop.trainer(:binary_cross_entropy, :sgd, log: -1)
+      |> continue_handler(event)
       |> send_handler(event, filter)
       |> Axon.Loop.run(data, %{}, epochs: epochs, iterations: iterations)
+    end
+
+    def continue_handler(loop, event) do
+      Axon.Loop.handle_event(loop, event, &{:continue, &1})
     end
 
     def send_handler(loop, event, filter) do


### PR DESCRIPTION
If multiple event handlers are registered for the same event, the counter is incremented before each handler. This results in filters like `every: 10` to never match any events.