### PR TITLE
fix broken references to Polaris.Optimizers in lstm_generation.livemd

### DIFF
--- a/notebooks/text/lstm_generation.livemd
+++ b/notebooks/text/lstm_generation.livemd
@@ -171,7 +171,7 @@ IO.puts("Total batches: #{Enum.count(train_batches)}")
 
 params =
   model
-  |> Axon.Loop.trainer(:categorical_cross_entropy, Polaris.Optimizers.adam(learning_rate: 0.001))
+  |> Axon.Loop.trainer(:categorical_cross_entropy, :adam)
   |> Axon.Loop.run(Stream.zip(train_batches, result_batches), %{}, epochs: 20, compiler: EXLA)
 
 :ok
@@ -250,7 +250,7 @@ IO.puts("Total batches: #{Enum.count(train_batches)}")
 
 new_params =
   new_model
-  |> Axon.Loop.trainer(:categorical_cross_entropy, Polaris.Optimizers.adam(learning_rate: 0.001))
+  |> Axon.Loop.trainer(:categorical_cross_entropy, :adam)
   |> Axon.Loop.run(Stream.zip(train_batches, result_batches), %{}, epochs: 50, compiler: EXLA)
 
 :ok


### PR DESCRIPTION
Even after adding the `:polaris` dep at the top, the code cell referencing `Polaris.Optimizers.adam/1` errors out (with an error about a missing `Nx.pow`, which seems to now be `Nx.power`.

This PR replaces all references to `Polaris.Optimizers` in the LSTM generation notebook with just `:adam`. There are seemingly other doco livebooks where similar changes need to be made, but I haven't got around to testing them yet.