### PR TITLE
Do not cast integers in in Axon.MixedPrecision.cast/2

### DIFF
--- a/lib/axon/compiler.ex
+++ b/lib/axon/compiler.ex
@@ -1135,15 +1135,8 @@ defmodule Axon.Compiler do
       %Axon.None{} = none ->
         none
 
-      %Nx.Tensor{} = tensor ->
-        if not Nx.Type.integer?(Nx.type(tensor)) and not Nx.Type.integer?(type) do
-          Nx.as_type(tensor, type)
-        else
-          tensor
-        end
-
-      container ->
-        deep_new(container, fn tensor ->
+      container_or_tensor ->
+        deep_new(container_or_tensor, fn tensor ->
           if not Nx.Type.integer?(Nx.type(tensor)) and not Nx.Type.integer?(type) do
             Nx.as_type(tensor, type)
           else


### PR DESCRIPTION
Unifies the policy casting behaviour between the compiler and an explicit cast.