### PR TITLE
Add support for global layer options

### DIFF
--- a/lib/axon/compiler.ex
+++ b/lib/axon/compiler.ex
@@ -50,7 +50,8 @@ defmodule Axon.Compiler do
     debug? = Keyword.get(opts, :debug, false)
     mode = Keyword.get(opts, :mode, :inference)
     seed = Keyword.get_lazy(opts, :seed, fn -> :erlang.system_time() end)
-    config = %{mode: mode, debug?: debug?}
+    global_layer_options = Keyword.get(opts, :global_layer_options, [])
+    config = %{mode: mode, debug?: debug?, global_layer_options: global_layer_options}
 
     {time, {root_id, {cache, _op_counts, _block_cache}}} =
       :timer.tc(fn ->
@@ -718,6 +719,7 @@ defmodule Axon.Compiler do
            parameters: layer_params,
            args: args,
            opts: opts,
+           global_options: global_options,
            policy: policy,
            hooks: hooks,
            op_name: op_name,
@@ -725,7 +727,7 @@ defmodule Axon.Compiler do
          },
          nodes,
          cache_and_counts,
-         %{mode: mode, debug?: debug?} = config
+         %{mode: mode, debug?: debug?, global_layer_options: global_layer_options} = config
        )
        when (is_function(op) or is_atom(op)) and is_list(inputs) do
     # Traverse to accumulate cache and get parent_ids for
@@ -761,10 +763,12 @@ defmodule Axon.Compiler do
         name,
         args,
         opts,
+        global_options,
         policy,
         layer_params,
         hooks,
         mode,
+        global_layer_options,
         stacktrace
       )
 
@@ -841,10 +845,12 @@ defmodule Axon.Compiler do
          name,
          args,
          opts,
+         global_options,
          %{output: output, compute: compute},
          layer_params,
          hooks,
          mode,
+         global_layer_options,
          layer_stacktrace
        ) do
     # Recurse graph inputs and invoke cache to get parent results,
@@ -914,7 +920,12 @@ defmodule Axon.Compiler do
 
       # Compute arguments to be forwarded and ensure `:mode` is included
       # for inference/training behavior dependent functions
-      args = Enum.reverse(tensor_inputs, [Keyword.put(opts, :mode, mode)])
+      layer_opts =
+        opts
+        |> Keyword.merge(Keyword.take(global_layer_options, global_options))
+        |> Keyword.put(:mode, mode)
+
+      args = Enum.reverse(tensor_inputs, [layer_opts])
 
       # For built-in layers we always just apply the equivalent function
       # in Axon.Layers. The implication of this is that every function which

--- a/lib/axon/node.ex
+++ b/lib/axon/node.ex
@@ -12,6 +12,7 @@ defmodule Axon.Node do
     :policy,
     :hooks,
     :opts,
+    :global_options,
     :op_name,
     :stacktrace
   ]

--- a/test/axon/compiler_test.exs
+++ b/test/axon/compiler_test.exs
@@ -5837,4 +5837,27 @@ defmodule CompilerTest do
       assert predict_fn.(params, x) == Nx.add(x, a)
     end
   end
+
+  describe "global layer options" do
+    test "global options are forwarded to the layer when declared" do
+      input = Axon.input("input")
+
+      model =
+        Axon.layer(
+          fn input, opts ->
+            assert Keyword.has_key?(opts, :option1)
+            refute Keyword.has_key?(opts, :option2)
+            input
+          end,
+          [input],
+          global_options: [:option1]
+        )
+
+      {_, predict_fn} = Axon.build(model, global_layer_options: [option1: true, option2: true])
+
+      params = %{}
+      input = random({1, 1}, type: {:f, 32})
+      predict_fn.(params, input)
+    end
+  end
 end


### PR DESCRIPTION
This allows to configure model layers at Axon-compilation time. This is useful if we want to make some compilation-time decisions when calling the model, without building a different model altogether.

API-wise the options are passed as

```elixir
Axon.build(model, global_layer_options: [output_hidden_states: true])
```

Those options are merged into layer options, but only when declared explicitly, like so:

```elixir
Axon.layer(
  fn hidden_state,  opts ->
    if opts[:output_hidden_states] do
      ...
    else
      ...
    end
  end,
  [input],
  global_options: [:output_hidden_states]
)
```

We could pass them nested too and access as `opts[:global_options][:output_hidden_states]`, but this would break all existing layers that have options allowlist using `keyword!`. I actually think that merging them in a flat manner is better, because they can be validated with `keyword!` in the exact same way.

Naming suggestions are welcome, for example I was considering `:global_layer_options -> :layer_options` and `:global_options -> :expose_options`, though not sure if "expose" is clear enough.