### PR TITLE
improved doc formatting by fixing indentation and escape characters

### DIFF
--- a/lib/axon.ex
+++ b/lib/axon.ex
@@ -143,9 +143,9 @@ defmodule Axon do
   parameters and possibly state. To define a custom layer, you just need to
   define a `defn` implementation:
 
-        defn my_layer(x, weight, _opts \\\\ []) do
-          Nx.atan2(x, weight)
-        end
+      defn my_layer(x, weight, _opts \\\\ []) do
+        Nx.atan2(x, weight)
+      end
 
   Notice the only stipulation is that your custom layer implementation must
   accept at least 1 input and a list of options. At execution time, every

--- a/lib/axon.ex
+++ b/lib/axon.ex
@@ -143,9 +143,9 @@ defmodule Axon do
   parameters and possibly state. To define a custom layer, you just need to
   define a `defn` implementation:
 
-      defn my_layer(x, weight, _opts \\ []) do
-        Nx.atan2(x, weight)
-      end
+        defn my_layer(x, weight, _opts \\\\ []) do
+          Nx.atan2(x, weight)
+        end
 
   Notice the only stipulation is that your custom layer implementation must
   accept at least 1 input and a list of options. At execution time, every

--- a/lib/axon/layers.ex
+++ b/lib/axon/layers.ex
@@ -1407,11 +1407,11 @@ defmodule Axon.Layers do
   ## Options
 
     * `:rate` - dropout rate. Used to determine probability a connection
-    will be dropped. Required.
+      will be dropped. Required.
 
     * `:noise_shape` - input noise shape. Shape of `mask` which can be useful
-    for broadcasting `mask` across feature channels or other dimensions.
-    Defaults to shape of input tensor.
+      for broadcasting `mask` across feature channels or other dimensions.
+      Defaults to shape of input tensor.
 
   ## References
 
@@ -1455,11 +1455,11 @@ defmodule Axon.Layers do
   ## Options
 
     * `:rate` - dropout rate. Used to determine probability a connection
-    will be dropped. Required.
+      will be dropped. Required.
 
     * `:noise_shape` - input noise shape. Shape of `mask` which can be useful
-    for broadcasting `mask` across feature channels or other dimensions.
-    Defaults to shape of input tensor.
+      for broadcasting `mask` across feature channels or other dimensions.
+      Defaults to shape of input tensor.
 
   ## References
 
@@ -1490,11 +1490,11 @@ defmodule Axon.Layers do
   ## Options
 
     * `:rate` - dropout rate. Used to determine probability a connection
-    will be dropped. Required.
+      will be dropped. Required.
 
     * `:noise_shape` - input noise shape. Shape of `mask` which can be useful
-    for broadcasting `mask` across feature channels or other dimensions.
-    Defaults to shape of input tensor.
+      for broadcasting `mask` across feature channels or other dimensions.
+      Defaults to shape of input tensor.
 
   ## References
 
@@ -1534,11 +1534,11 @@ defmodule Axon.Layers do
   ## Options
 
     * `:rate` - dropout rate. Used to determine probability a connection
-    will be dropped. Required.
+      will be dropped. Required.
 
     * `:noise_shape` - input noise shape. Shape of `mask` which can be useful
-    for broadcasting `mask` across feature channels or other dimensions.
-    Defaults to shape of input tensor.
+      for broadcasting `mask` across feature channels or other dimensions.
+      Defaults to shape of input tensor.
   """
   @doc type: :dropout
   defn feature_alpha_dropout(input, key, opts \\ []) do

--- a/lib/axon/layers.ex
+++ b/lib/axon/layers.ex
@@ -1407,11 +1407,11 @@ defmodule Axon.Layers do
   ## Options
 
     * `:rate` - dropout rate. Used to determine probability a connection
-      will be dropped. Required.
+    will be dropped. Required.
 
     * `:noise_shape` - input noise shape. Shape of `mask` which can be useful
-      for broadcasting `mask` across feature channels or other dimensions.
-      Defaults to shape of input tensor.
+    for broadcasting `mask` across feature channels or other dimensions.
+    Defaults to shape of input tensor.
 
   ## References
 
@@ -1455,11 +1455,11 @@ defmodule Axon.Layers do
   ## Options
 
     * `:rate` - dropout rate. Used to determine probability a connection
-      will be dropped. Required.
+    will be dropped. Required.
 
-    # `:noise_shape` - input noise shape. Shape of `mask` which can be useful
-      for broadcasting `mask` across feature channels or other dimensions.
-      Defaults to shape of input tensor.
+    * `:noise_shape` - input noise shape. Shape of `mask` which can be useful
+    for broadcasting `mask` across feature channels or other dimensions.
+    Defaults to shape of input tensor.
 
   ## References
 
@@ -1490,11 +1490,11 @@ defmodule Axon.Layers do
   ## Options
 
     * `:rate` - dropout rate. Used to determine probability a connection
-      will be dropped. Required.
+    will be dropped. Required.
 
-    # `:noise_shape` - input noise shape. Shape of `mask` which can be useful
-      for broadcasting `mask` across feature channels or other dimensions.
-      Defaults to shape of input tensor.
+    * `:noise_shape` - input noise shape. Shape of `mask` which can be useful
+    for broadcasting `mask` across feature channels or other dimensions.
+    Defaults to shape of input tensor.
 
   ## References
 
@@ -1534,11 +1534,11 @@ defmodule Axon.Layers do
   ## Options
 
     * `:rate` - dropout rate. Used to determine probability a connection
-      will be dropped. Required.
+    will be dropped. Required.
 
-    # `:noise_shape` - input noise shape. Shape of `mask` which can be useful
-      for broadcasting `mask` across feature channels or other dimensions.
-      Defaults to shape of input tensor.
+    * `:noise_shape` - input noise shape. Shape of `mask` which can be useful
+    for broadcasting `mask` across feature channels or other dimensions.
+    Defaults to shape of input tensor.
   """
   @doc type: :dropout
   defn feature_alpha_dropout(input, key, opts \\ []) do

--- a/lib/axon/loop.ex
+++ b/lib/axon/loop.ex
@@ -187,10 +187,10 @@ defmodule Axon.Loop do
   module:
 
     * `Axon.Loop.loop/3` - Creates a loop from step function and optional initialization
-    functions and output transform functions.
+      functions and output transform functions.
 
     * `Axon.Loop.trainer/3` - Creates a supervised training loop from model, loss, and
-    optimizer.
+      optimizer.
 
     * `Axon.Loop.evaluator/1` - Creates a supervised evaluator loop from model.
 

--- a/lib/axon/loop.ex
+++ b/lib/axon/loop.ex
@@ -186,13 +186,13 @@ defmodule Axon.Loop do
   Axon loops are typically created from one of the factory functions provided in this
   module:
 
-      * `Axon.Loop.loop/3` - Creates a loop from step function and optional initialization
-      functions and output transform functions.
+    * `Axon.Loop.loop/3` - Creates a loop from step function and optional initialization
+    functions and output transform functions.
 
-      * `Axon.Loop.trainer/3` - Creates a supervised training loop from model, loss, and
-      optimizer.
+    * `Axon.Loop.trainer/3` - Creates a supervised training loop from model, loss, and
+    optimizer.
 
-      * `Axon.Loop.evaluator/1` - Creates a supervised evaluator loop from model.
+    * `Axon.Loop.evaluator/1` - Creates a supervised evaluator loop from model.
 
   ## Running loops
 

--- a/lib/axon/metrics.ex
+++ b/lib/axon/metrics.ex
@@ -38,8 +38,8 @@ defmodule Axon.Metrics do
 
   ## Argument Shapes
 
-    * `y_true` - $\(d_0, d_1, ..., d_n\)$
-    * `y_pred` - $\(d_0, d_1, ..., d_n\)$
+    * `y_true` - $(d_0, d_1, ..., d_n)$
+    * `y_pred` - $(d_0, d_1, ..., d_n)$
 
   ## Examples
 
@@ -96,8 +96,8 @@ defmodule Axon.Metrics do
 
   ## Argument Shapes
 
-    * `y_true` - $\(d_0, d_1, ..., d_n\)$
-    * `y_pred` - $\(d_0, d_1, ..., d_n\)$
+    * `y_true` - $(d_0, d_1, ..., d_n)$
+    * `y_pred` - $(d_0, d_1, ..., d_n)$
 
   ## Options
 
@@ -127,8 +127,8 @@ defmodule Axon.Metrics do
 
   ## Argument Shapes
 
-    * `y_true` - $\(d_0, d_1, ..., d_n\)$
-    * `y_pred` - $\(d_0, d_1, ..., d_n\)$
+    * `y_true` - $(d_0, d_1, ..., d_n)$
+    * `y_pred` - $(d_0, d_1, ..., d_n)$
 
   ## Options
 
@@ -285,8 +285,8 @@ defmodule Axon.Metrics do
 
   ## Argument Shapes
 
-    * `y_true` - $\(d_0, d_1, ..., d_n\)$
-    * `y_pred` - $\(d_0, d_1, ..., d_n\)$
+    * `y_true` - $(d_0, d_1, ..., d_n)$
+    * `y_pred` - $(d_0, d_1, ..., d_n)$
 
   ## Options
 
@@ -314,8 +314,8 @@ defmodule Axon.Metrics do
 
   ## Argument Shapes
 
-    * `y_true` - $\(d_0, d_1, ..., d_n\)$
-    * `y_pred` - $\(d_0, d_1, ..., d_n\)$
+    * `y_true` - $(d_0, d_1, ..., d_n)$
+    * `y_pred` - $(d_0, d_1, ..., d_n)$
 
   ## Options
 
@@ -359,8 +359,8 @@ defmodule Axon.Metrics do
 
   ## Argument Shapes
 
-    * `y_true` - $\(d_0, d_1, ..., d_n\)$
-    * `y_pred` - $\(d_0, d_1, ..., d_n\)$
+    * `y_true` - $(d_0, d_1, ..., d_n)$
+    * `y_pred` - $(d_0, d_1, ..., d_n)$
 
   ## Examples
 
@@ -390,8 +390,8 @@ defmodule Axon.Metrics do
 
   ## Argument Shapes
 
-    * `y_true` - $\(d_0, d_1, ..., d_n\)$
-    * `y_pred` - $\(d_0, d_1, ..., d_n\)$
+    * `y_true` - $(d_0, d_1, ..., d_n)$
+    * `y_pred` - $(d_0, d_1, ..., d_n)$
 
   ## Examples
 


### PR DESCRIPTION
Some sections of the documentation are displaying incorrectly in ExDoc

cc: @josevalim @jonatanklosko @seanmor5 

before:
![image](https://github.com/elixir-nx/axon/assets/42756551/ccea25a2-4f54-488a-91c3-48ed1409ffef)
![image](https://github.com/elixir-nx/axon/assets/42756551/124ed482-ee0b-4ad1-b737-12fc606bb90c)
![image](https://github.com/elixir-nx/axon/assets/42756551/c3a992fa-bb6e-4dc8-be60-1ad5b25d5eec)
![image](https://github.com/elixir-nx/axon/assets/42756551/fa5d60a3-58cd-4e13-bf05-70d2603fb485)

after:
![image](https://github.com/elixir-nx/axon/assets/42756551/afcaee76-df4b-47da-8e85-cb485150aefb)
![image](https://github.com/elixir-nx/axon/assets/42756551/a9edc5ae-5747-4777-8d32-ef9d64a2e454)
![image](https://github.com/elixir-nx/axon/assets/42756551/85adb38d-4cc2-417a-932f-36f04fd8f7aa)
![image](https://github.com/elixir-nx/axon/assets/42756551/15b82d3a-eaa8-4285-aed0-aa20873cb062)
