### PR TITLE
Fix iteration counts

### DIFF
--- a/lib/axon/loop/state.ex
+++ b/lib/axon/loop/state.ex
@@ -60,8 +60,8 @@ defmodule Axon.Loop.State do
     event_counts: %{
       started: 0,
       epoch_started: 0,
-      iteration_started: 0,
-      iteration_completed: 0,
+      iteration_started: %{total: 0, epoch: 0},
+      iteration_completed: %{total: 0, epoch: 0},
       epoch_completed: 0,
       epoch_halted: 0,
       halted: 0,

--- a/lib/axon/model_state.ex
+++ b/lib/axon/model_state.ex
@@ -23,7 +23,7 @@ defmodule Axon.ModelState do
         } = model_state,
         updated_parameters,
         updated_state \\ %{}
-      ) do    
+      ) do
     updated_state =
       state
       |> tree_diff(frozen)
@@ -215,7 +215,7 @@ defmodule Axon.ModelState do
     Enum.reduce(access, %{}, &Map.put(&2, &1, Map.fetch!(data, &1)))
   end
 
-  defp tree_get(data, access) when is_map(access) do    
+  defp tree_get(data, access) when is_map(access) do
     Enum.reduce(access, %{}, fn {key, value}, acc ->
       tree = tree_get(data[key], value)
       Map.put(acc, key, tree)

--- a/test/axon/integration_test.exs
+++ b/test/axon/integration_test.exs
@@ -485,7 +485,9 @@ defmodule Axon.IntegrationTest do
           assert_greater_equal(last_epoch_metrics["validation_accuracy"], 0.60)
           assert_all_close(final_model_val_accuracy, last_epoch_metrics["validation_accuracy"])
           assert Nx.shape(Axon.predict(model, model_state, x_test)) == {10, 2}
-          assert Nx.type(model_state.data["dense_0"]["kernel"]) == unquote(Macro.escape(policy)).params
+
+          assert Nx.type(model_state.data["dense_0"]["kernel"]) ==
+                   unquote(Macro.escape(policy)).params
         end)
       end
 
@@ -536,7 +538,9 @@ defmodule Axon.IntegrationTest do
           assert_greater_equal(last_epoch_metrics["validation_accuracy"], 0.60)
           assert_all_close(final_model_val_accuracy, last_epoch_metrics["validation_accuracy"])
           assert Nx.shape(Axon.predict(model, model_state, x_test)) == {10, 2}
-          assert Nx.type(model_state.data["dense_0"]["kernel"]) == unquote(Macro.escape(policy)).params
+
+          assert Nx.type(model_state.data["dense_0"]["kernel"]) ==
+                   unquote(Macro.escape(policy)).params
         end)
       end
     end


### PR DESCRIPTION
There was an issue where we were only ever keeping tracking of total iteration completed/started events. This would lead to weird cases like the one described in #531 because the filters looked at total counts, but sometimes we really just care about per-epoch event counts. Rather than favor one over the other, we track both total and epoch iteration counts and allow filtering on both.

Resolves #531 