### PR TITLE
Fix missing state in training

### DIFF
--- a/lib/axon/compiler.ex
+++ b/lib/axon/compiler.ex
@@ -1100,7 +1100,6 @@ defmodule Axon.Compiler do
               |> apply_hooks(:backward, mode, hooks)
               |> safe_policy_cast(policy, :output)
 
-            IO.inspect name
             new_state = Map.put(state, name, out_state)
             {new_out, new_state}
 

--- a/lib/axon/compiler.ex
+++ b/lib/axon/compiler.ex
@@ -1100,6 +1100,7 @@ defmodule Axon.Compiler do
               |> apply_hooks(:backward, mode, hooks)
               |> safe_policy_cast(policy, :output)
 
+            IO.inspect name
             new_state = Map.put(state, name, out_state)
             {new_out, new_state}
 

--- a/lib/axon/loop.ex
+++ b/lib/axon/loop.ex
@@ -408,7 +408,6 @@ defmodule Axon.Loop do
           |> Nx.add(batch_loss)
           |> Nx.divide(Nx.add(i, 1))
 
-        IO.inspect updated_state
         new_model_state = Axon.ModelState.update(model_state, updated_parameters, updated_state)
 
         %{

--- a/lib/axon/loop.ex
+++ b/lib/axon/loop.ex
@@ -1556,7 +1556,7 @@ defmodule Axon.Loop do
       is set, the loop will raise on any cache miss during the training loop. Defaults
       to true.
 
-    * `:force_garbage_collect?` - whether or not to force garbage collection after each
+    * `:force_garbage_collection?` - whether or not to force garbage collection after each
       iteration. This may help avoid OOMs when training large models, but it will slow
       training down.
 

--- a/lib/axon/loop.ex
+++ b/lib/axon/loop.ex
@@ -408,6 +408,7 @@ defmodule Axon.Loop do
           |> Nx.add(batch_loss)
           |> Nx.divide(Nx.add(i, 1))
 
+        IO.inspect updated_state
         new_model_state = Axon.ModelState.update(model_state, updated_parameters, updated_state)
 
         %{

--- a/lib/axon/model_state.ex
+++ b/lib/axon/model_state.ex
@@ -27,6 +27,7 @@ defmodule Axon.ModelState do
     updated_state =
       state
       |> tree_diff(frozen)
+      |> IO.inspect
       |> then(&tree_get(updated_state, &1))
 
     update_in(model_state, [Access.key!(:data)], fn data ->

--- a/lib/axon/model_state.ex
+++ b/lib/axon/model_state.ex
@@ -27,7 +27,6 @@ defmodule Axon.ModelState do
     updated_state =
       state
       |> tree_diff(frozen)
-      |> IO.inspect
       |> then(&tree_get(updated_state, &1))
 
     update_in(model_state, [Access.key!(:data)], fn data ->
@@ -228,8 +227,14 @@ defmodule Axon.ModelState do
 
   defp tree_get(data, access) when is_map(access) do
     Enum.reduce(access, %{}, fn {key, value}, acc ->
-      tree = tree_get(data[key], value)
-      Map.put(acc, key, tree)
+      case data do
+        %{^key => val} ->
+          tree = tree_get(val, value)
+          Map.put(acc, key, tree)
+
+        %{} ->
+          raise "#{key} not found"
+      end
     end)
   end
 

--- a/lib/axon/model_state.ex
+++ b/lib/axon/model_state.ex
@@ -241,7 +241,7 @@ defmodule Axon.ModelState do
     Enum.reduce(access, %{}, fn {key, value}, acc ->
       case data do
         %{^key => val} ->
-          tree = tree_get(val, value)
+          tree = tree_get(val, value, behavior)
           Map.put(acc, key, tree)
 
         %{} ->

--- a/lib/axon/model_state.ex
+++ b/lib/axon/model_state.ex
@@ -24,6 +24,8 @@ defmodule Axon.ModelState do
         updated_parameters,
         updated_state \\ %{}
       ) do
+    IO.inspect updated_state
+
     updated_state =
       state
       |> tree_diff(frozen)

--- a/lib/axon/model_state.ex
+++ b/lib/axon/model_state.ex
@@ -221,33 +221,27 @@ defmodule Axon.ModelState do
     Map.update(acc, key, inner, &nested_put(&1, rest, value))
   end
 
-  defp tree_get(data, access, behavior \\ :raise_on_missing)
-
-  defp tree_get(data, access, behavior) when is_list(access) do
+  defp tree_get(data, access) when is_list(access) do
     Enum.reduce(access, %{}, fn key, acc ->
       case data do
         %{^key => val} ->
           Map.put(acc, key, val)
 
         %{} ->
-          if behavior == :raise_on_missing,
-            do: raise "#{key} not found",
-            else: acc
+          acc
       end
     end)
   end
 
-  defp tree_get(data, access, behavior ) when is_map(access) do
+  defp tree_get(data, access) when is_map(access) do
     Enum.reduce(access, %{}, fn {key, value}, acc ->
       case data do
         %{^key => val} ->
-          tree = tree_get(val, value, behavior)
+          tree = tree_get(val, value)
           Map.put(acc, key, tree)
 
         %{} ->
-          if behavior == :raise_on_missing,
-            do: raise "#{key} not found",
-            else: acc
+          acc
       end
     end)
   end

--- a/lib/axon/model_state.ex
+++ b/lib/axon/model_state.ex
@@ -27,7 +27,7 @@ defmodule Axon.ModelState do
     updated_state =
       state
       |> tree_diff(frozen)
-      |> then(&tree_get(updated_state, &1, :ignore_missing))
+      |> then(&tree_get(updated_state, &1))
 
     update_in(model_state, [Access.key!(:data)], fn data ->
       data


### PR DESCRIPTION
There seems to be a case where we can initialize the state for a model and then take a path during training that doesn't result in all of the paths getting hit and thus we don't get the updated state for a particular layer. The correct behavior here is to just ignore it and don't update that state.