### PR TITLE
Use templates as parameters

### DIFF
--- a/lib/axon/mixed_precision/policy.ex
+++ b/lib/axon/mixed_precision/policy.ex
@@ -8,14 +8,25 @@ defmodule Axon.MixedPrecision.Policy do
     import Inspect.Algebra
 
     def inspect(policy, _opts) do
+      policy = [
+        policy.params && "p=#{Nx.Type.to_string(policy.params)}",
+        policy.compute && "c=#{Nx.Type.to_string(policy.compute)}",
+        policy.output && "o=#{Nx.Type.to_string(policy.output)}"
+      ]
+
+      inner =
+        policy
+        |> Enum.reject(&is_nil/1)
+        |> Enum.intersperse(" ")
+
       force_unfit(
-        concat([
-          "#Axon.MixedPrecision.Policy<",
-          "p=#{Nx.Type.to_string(policy.params)} ",
-          "c=#{Nx.Type.to_string(policy.compute)} ",
-          "o=#{Nx.Type.to_string(policy.output)}",
-          ">"
-        ])
+        concat(
+          List.flatten([
+            "#Axon.MixedPrecision.Policy<",
+            inner,
+            ">"
+          ])
+        )
       )
     end
   end

--- a/lib/axon/parameter.ex
+++ b/lib/axon/parameter.ex
@@ -2,6 +2,7 @@ defmodule Axon.Parameter do
   @moduledoc false
   defstruct [
     :name,
+    :template,
     :shape,
     :initializer,
     :children,

--- a/mix.exs
+++ b/mix.exs
@@ -35,8 +35,8 @@ defmodule Axon.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:exla, "~> 0.7.0", [only: :test] ++ exla_opts()},
-      {:torchx, "~> 0.7.0", [only: :test] ++ torchx_opts()},
+      # {:exla, "~> 0.7.0", [only: :test] ++ exla_opts()},
+      # {:torchx, "~> 0.7.0", [only: :test] ++ torchx_opts()},
       {:nx, "~> 0.6.0 or ~> 0.7.0", nx_opts()},
       {:ex_doc, "~> 0.23", only: :docs},
       {:table_rex, "~> 3.1.1", optional: true},

--- a/mix.exs
+++ b/mix.exs
@@ -35,8 +35,8 @@ defmodule Axon.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      # {:exla, "~> 0.7.0", [only: :test] ++ exla_opts()},
-      # {:torchx, "~> 0.7.0", [only: :test] ++ torchx_opts()},
+      {:exla, "~> 0.7.0", [only: :test] ++ exla_opts()},
+      {:torchx, "~> 0.7.0", [only: :test] ++ torchx_opts()},
       {:nx, "~> 0.6.0 or ~> 0.7.0", nx_opts()},
       {:ex_doc, "~> 0.23", only: :docs},
       {:table_rex, "~> 3.1.1", optional: true},


### PR DESCRIPTION
Rather than requiring shape/type we can just use templates. The benefit is that this work supports using any Nx.Container as a model parameter. For right now we still support the old style under the `param` function, but this defers to the new `parameter` which requires templates.

There are certain places where using a container/composite parameter in place of a regular parameter makes sense. For example, if we want to initialize quantized models then we can create a quantized tensor container which represents a quantized parameter that can be converted back to a regular parameter.

In the future, I plan to unify the currently separated shape calculation and initialization process for a parameter. Realistically each parameter should just take input templates, do the shape calculation, and then initialize directly without any intermediate steps