### PR TITLE
Refactor containers

### DIFF
--- a/lib/axon/display.ex
+++ b/lib/axon/display.ex
@@ -3,7 +3,6 @@ defmodule Axon.Display do
   Module for rendering various visual representations of Axon models.
   """
 
-  import Axon.Shared
   alias Axon.Parameter
 
   @compile {:no_warn_undefined, TableRex.Table}

--- a/test/axon_test.exs
+++ b/test/axon_test.exs
@@ -874,8 +874,9 @@ defmodule AxonTest do
       out = Axon.input("input") |> Axon.dense(2)
       model = Axon.container({out, out})
 
-      assert shape = Axon.get_output_shape(model, Nx.template({1, 1}, :f32))
-      assert shape == {{1, 2}, {1, 2}}
+      assert {t1, t2} = Axon.get_output_shape(model, Nx.template({1, 1}, :f32))
+      assert Nx.shape(t1) == {1, 2}
+      assert Nx.shape(t2) == {1, 2}
     end
 
     test "doesn't raise on none output" do


### PR DESCRIPTION
Axon containers originally stored the container structure as the argument. This ends up being weird because every time we need to traverse the graph for compilation, display, graph manipulation, etc. we have to account for this special case. Now, we store the input nodes as regular args and generate a `restructure` fun for the container that will build it back to the original structure. 