### PR TITLE
Doc fix for `rewrite_nodes`

### DIFF
--- a/lib/axon.ex
+++ b/lib/axon.ex
@@ -3773,7 +3773,7 @@ defmodule Axon do
   layers with `:tanh` layers:
 
       tanh_rewriter = fn [%Axon{} = x], _output ->
-        Axon.relu(x)
+        Axon.tanh(x)
       end
 
       Axon.rewrite_nodes(model, fn


### PR DESCRIPTION
Tiny doc fix - the `tanh_rewriter` example was using `relu` instead of `tanh`