### PR TITLE
Fixed Axon.gru return value in docs

### DIFF
--- a/lib/axon.ex
+++ b/lib/axon.ex
@@ -2801,7 +2801,7 @@ defmodule Axon do
   GRUs apply `Axon.Layers.gru_cell/7` over an entire input
   sequence and return:
 
-      {{new_hidden}, output_sequence}
+      {output_sequence, {new_hidden}}
 
   You can use the output state as the hidden state of another
   GRU layer.


### PR DESCRIPTION
It looks like the docs have the return value for `Axon.gru` flipped the wrong way. Here's the last line of the function:

```
{output_sequence, {new_h}}
```