### PR TITLE
Add metric learning for image similarity search livebook

### DIFF
--- a/notebooks/vision/metric-learning.livemd
+++ b/notebooks/vision/metric-learning.livemd
@@ -2,10 +2,9 @@
 
 ```elixir
 Mix.install([
-  {:nx, "~> 0.9.2"},
-  {:axon, "~> 0.7.0"},
+  {:axon, "~> 0.7"},
   {:scidata, "~> 0.1.9"},
-  {:exla, "~> 0.9.2"},
+  {:exla, "~> 0.9"},
   {:stb_image, "~> 0.5.2"},
   {:kino_vega_lite, "~>0.1.13"}
 ])


### PR DESCRIPTION
This example builds on the initial work from [#175](https://github.com/elixir-nx/axon/pull/175), which provided a great starting point. It now includes a complete training loop, a contrastive-style objective function, and evaluation of learned embeddings on the CIFAR-10 dataset.

Feedback is very welcome, this is my first contribution of this kind to Axon, and I’m happy to adjust anything that could be more idiomatic or performant.