### PR TITLE
Update params initialization in Axon model guide

### DIFF
--- a/guides/model_creation/your_first_axon_model.livemd
+++ b/guides/model_creation/your_first_axon_model.livemd
@@ -82,7 +82,7 @@ predict_fn.(params :: map(tensor), input :: map(tensor) | tensor)
 `predict_fn` returns transformed inputs from your model's trainable parameters and the given inputs.
 
 ```elixir
-params = init_fn.(Nx.template({1, 8}, :f32), %{})
+params = init_fn.(Nx.template({1, 8}, :f32), %Axon.ModelState{})
 ```
 
 <!-- livebook:{"output":true} -->


### PR DESCRIPTION
The tutorial had just a map as the second argument of init_fn(), but it asks for %Axon.ModelState{} now