### PR TITLE
Fix compile-time warnings for Elixir 1.19.1

### DIFF
--- a/lib/axon/loop.ex
+++ b/lib/axon/loop.ex
@@ -1632,7 +1632,7 @@ defmodule Axon.Loop do
     final_metrics_map = loop_state.metrics
     loop_state = %{loop_state | metrics: zero_metrics}
 
-    {status, final_metrics_map, state} =
+    {status, final_metrics_map, %State{} = state} =
       case fire_event(:started, handler_fns, loop_state, debug?) do
         {:halt_epoch, state} ->
           {:halted, final_metrics_map, state}
@@ -1691,7 +1691,7 @@ defmodule Axon.Loop do
                         {:halt_loop, state} ->
                           {:halt, {final_metrics_map, state}}
 
-                        {:continue, state} ->
+                        {:continue, %State{} = state} ->
                           {:cont,
                            {batch_fn, Map.put(final_metrics_map, epoch, state.metrics),
                             %State{
@@ -1922,9 +1922,9 @@ defmodule Axon.Loop do
   end
 
   # Halts an epoch during looping
-  defp halt_epoch(handler_fns, batch_fn, final_metrics_map, loop_state, debug?) do
+  defp halt_epoch(handler_fns, batch_fn, final_metrics_map, %State{} = loop_state, debug?) do
     case fire_event(:epoch_halted, handler_fns, loop_state, debug?) do
-      {:halt_epoch, %{epoch: epoch, metrics: metrics} = state} ->
+      {:halt_epoch, %State{epoch: epoch, metrics: metrics} = state} ->
         final_metrics_map = Map.put(final_metrics_map, epoch, metrics)
         {:cont, {batch_fn, final_metrics_map, %State{state | epoch: epoch + 1, iteration: 0}}}
 

--- a/lib/axon/quantization/layers.ex
+++ b/lib/axon/quantization/layers.ex
@@ -46,12 +46,11 @@ defmodule Axon.Quantization.Layers do
 
   deftransformp reshape_scales(scales, y) do
     ones = List.to_tuple(List.duplicate(1, Nx.rank(y) - 1))
-    Nx.reshape(scales, Tuple.append(ones, :auto))
+    Nx.reshape(scales, :erlang.append_element(ones, :auto))
   end
 
   deftransformp reshape_output(output, x_shape) do
     all_but_last = Tuple.delete_at(x_shape, tuple_size(x_shape) - 1)
-    new_shape = Tuple.append(all_but_last, :auto)
-    Nx.reshape(output, new_shape)
+    Nx.reshape(output, :erlang.append_element(all_but_last, :auto))
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -14,11 +14,14 @@ defmodule Axon.MixProject do
       deps: deps(),
       docs: docs(),
       description: "Create and train neural networks in Elixir",
-      package: package(),
-      preferred_cli_env: [
-        docs: :docs,
-        "hex.publish": :docs
-      ]
+      package: package()
+    ]
+  end
+
+  def cli do
+    [
+      docs: :docs,
+      "hex.publish": :docs
     ]
   end
 


### PR DESCRIPTION
Fixes all compile-time warnings for Elixir 1.19.1:

```
==> axon
Compiling 27 files (.ex)
     warning: incompatible types given to Kernel.apply/2:

         apply(Axon.Initializers, [])

     given types:

         Axon.Initializers, empty_list()

     but expected one of:

         fun(), list(term())

     typing violation found at:
     │
 135 │                 apply(Axon.Initializers, [])
     │                 ~
     │
     └─ lib/axon/quantization.ex:135:17: Axon.Quantization.weight_only_quantized_dense/3

    warning: Tuple.append/2 is deprecated. Use insert_at instead
    │
 49 │     Nx.reshape(scales, Tuple.append(ones, :auto))
    │                              ~
    │
    └─ lib/axon/quantization/layers.ex:49:30: Axon.Quantization.Layers.reshape_scales/2
    └─ lib/axon/quantization/layers.ex:54:23: Axon.Quantization.Layers.reshape_output/2

    warning: got "@impl true" for function __stream__/7 but no behaviour specifies such callback. The known callbacks are:

      * Nx.Defn.Compiler.__compile__/4 (function)
      * Nx.Defn.Compiler.__jit__/5 (function)
      * Nx.Defn.Compiler.__partitions_options__/1 (function)
      * Nx.Defn.Compiler.__to_backend__/1 (function)

    │
 18 │   def __stream__(_, _, _, _, _, _, _), do: raise("not implemented")
    │   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    │
    └─ lib/axon/defn.ex:18: Axon.Defn (module)

      warning: a struct for Axon.Loop.State is expected on struct update:

          %Axon.Loop.State{
            state
            | epoch: epoch + 1,
              metrics: zero_metrics,
              iteration: 0,
              max_iteration: state.max_iteration
          }

      but got type:

          dynamic()

      where "state" was given the type:

          # type: dynamic()
          # from: lib/axon/loop.ex
          {:continue, state}

      when defining the variable "state", you must also pattern match on "%Axon.Loop.State{}".

      hint: given pattern matching is enough to catch typing errors, you may optionally convert the struct update into a map update. For example, instead of:

          user = some_function()
          %User{user | name: "John Doe"}

      it is enough to write:

          %User{} = user = some_function()
          %{user | name: "John Doe"}

      typing violation found at:
      │
 1695 │ ...                   %State{
      │                       ~
      │
      └─ lib/axon/loop.ex:1695:29: Axon.Loop.run/4

      warning: a struct for Axon.Loop.State is expected on struct update:

          %Axon.Loop.State{state | epoch: epoch + 1, iteration: 0}

      but got type:

          dynamic(%{..., epoch: term(), metrics: term()})

      where "state" was given the type:

          # type: dynamic(%{..., epoch: term(), metrics: term()})
          # from: lib/axon/loop.ex
          {:halt_epoch, %{epoch: epoch, metrics: metrics} = state}

      when defining the variable "state", you must also pattern match on "%Axon.Loop.State{}".

      hint: given pattern matching is enough to catch typing errors, you may optionally convert the struct update into a map update. For example, instead of:

          user = some_function()
          %User{user | name: "John Doe"}

      it is enough to write:

          %User{} = user = some_function()
          %{user | name: "John Doe"}

      typing violation found at:
      │
 1927 │         {:cont, {batch_fn, final_metrics_map, %State{state | epoch: epoch + 1, iteration: 0}}}
      │                                               ~
      │
      └─ lib/axon/loop.ex:1927:47: Axon.Loop.halt_epoch/5

Generated axon app

```