### PR TITLE
fix: fix Axon.Display for Tensor parameter templates

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,9 +40,6 @@ jobs:
         with:
           otp-version: "${{ matrix.otp }}"
           elixir-version: "${{ matrix.elixir }}"
-          hexpm-mirrors: |
-            https://builds.hex.pm
-            https://cdn.jsdelivr.net/hex
       - uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,6 +40,9 @@ jobs:
         with:
           otp-version: "${{ matrix.otp }}"
           elixir-version: "${{ matrix.elixir }}"
+          hexpm-mirrors: |
+            https://builds.hex.pm
+            https://cdn.jsdelivr.net/hex
       - uses: actions/cache@v3
         with:
           path: |

--- a/lib/axon/display.ex
+++ b/lib/axon/display.ex
@@ -186,6 +186,9 @@ defmodule Axon.Display do
         %Parameter{shape: {:tuple, shapes}}, acc ->
           Enum.reduce(shapes, acc, &(Nx.size(apply(&1, input_shapes)) + &2))
 
+        %Parameter{template: %Nx.Tensor{} = template}, acc ->
+          acc + Nx.size(template)
+
         %Parameter{template: shape_fn}, acc when is_function(shape_fn) ->
           acc + Nx.size(apply(shape_fn, input_shapes))
       end)
@@ -252,6 +255,11 @@ defmodule Axon.Display do
           |> List.to_tuple()
 
         "#{name}: tuple#{inspect(shapes)}"
+
+      %Parameter{name: name, template: %Nx.Tensor{} = template} ->
+        type = Nx.type(template)
+        shape = Nx.shape(template)
+        "#{name}: #{type_str(type)}#{shape_string(shape)}"
 
       %Parameter{name: name, template: shape_fn} when is_function(shape_fn) ->
         shape = Nx.shape(apply(shape_fn, input_shapes))

--- a/test/axon/display_test.exs
+++ b/test/axon/display_test.exs
@@ -1,0 +1,18 @@
+defmodule Axon.DisplayTest do
+  use ExUnit.Case, async: true
+
+  describe "as_table/2" do
+    test "renders layers with concrete parameter templates" do
+      model = Axon.input("input") |> Axon.dense(32)
+      input = Nx.template({1, 16}, :f32)
+
+      table = Axon.Display.as_table(model, input)
+
+      assert table =~ ~s|dense_0 ( dense )|
+      assert table =~ ~s|kernel: f32[16][32]|
+      assert table =~ ~s|bias: f32[32]|
+      assert table =~ ~s|Total Parameters: 544|
+      assert table =~ ~s|Total Parameters Memory: 2.18 kilobytes|
+    end
+  end
+end


### PR DESCRIPTION
Hi, thank you for this great library.
Doing examples in book Machine Learning in Elixir, I found out that this example is broken. This pr resolves this issue:

https://axon.hexdocs.pm/Axon.Display.html#as_table/2

Error was:

```
** (FunctionClauseError) no function clause matching in anonymous fn/2 in Axon.Display.do_axon_to_rows/6    
    
    The following arguments were given to anonymous fn/2 in Axon.Display.do_axon_to_rows/6:
    
        # 1
        %Axon.Parameter{
          name: "bias",
          template: #Nx.Tensor<
            f32[128]
            Nx.TemplateBackend
          >,
          shape: {128},
          initializer: #Function<23.85168475/2 in Axon.Initializers.zeros/0>,
          children: nil,
          type: {:f, 32},
          frozen: false,
          kind: :parameter
        }
    
        # 2
        100352
    
    (axon 0.8.1) lib/axon/display.ex:185: anonymous fn/2 in Axon.Display.do_axon_to_rows/6
    (elixir 1.19.3) lib/enum.ex:2520: Enum."-reduce/3-lists^foldl/2-0-"/3
    (axon 0.8.1) lib/axon/display.ex:185: Axon.Display.do_axon_to_rows/6
    (axon 0.8.1) lib/axon/display.ex:100: Axon.Display.axon_to_rows/6
    (axon 0.8.1) lib/axon/display.ex:172: anonymous fn/4 in Axon.Display.do_axon_to_rows/6
    (elixir 1.19.3) lib/enum.ex:1814: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
    (axon 0.8.1) lib/axon/display.ex:169: Axon.Display.do_axon_to_rows/6
    #cell:oqd7d7vohmodx3zi:1: (file)
```