### PR TITLE
Support container outputs in eval_step and Axon.Display

### DIFF
--- a/lib/axon/display.ex
+++ b/lib/axon/display.ex
@@ -237,8 +237,7 @@ defmodule Axon.Display do
     rendered =
       shapes
       |> Enum.sort()
-      |> Enum.map(&render_output_entry/1)
-      |> Enum.join(", ")
+      |> Enum.map_join(", ", &render_output_entry/1)
 
     "%{#{rendered}}"
   end

--- a/lib/axon/display.ex
+++ b/lib/axon/display.ex
@@ -224,12 +224,30 @@ defmodule Axon.Display do
     "#{type}#{shape}"
   end
 
+  defp render_output_shape(%Axon.None{}), do: "none"
+
   defp render_output_shape(shapes) when is_tuple(shapes) do
     shapes
     |> Tuple.to_list()
     |> Enum.map(&render_output_shape(&1))
     |> Enum.join(", ")
   end
+
+  defp render_output_shape(%{} = shapes) do
+    rendered =
+      shapes
+      |> Enum.sort()
+      |> Enum.map(&render_output_entry/1)
+      |> Enum.join(", ")
+
+    "%{#{rendered}}"
+  end
+
+  defp render_output_entry({key, shape}) when is_atom(key),
+    do: "#{key}: #{render_output_shape(shape)}"
+
+  defp render_output_entry({key, shape}),
+    do: "#{inspect(key)} => #{render_output_shape(shape)}"
 
   defp type_str({type, size}), do: "#{Atom.to_string(type)}#{size}"
 
@@ -376,11 +394,17 @@ defmodule Axon.Display do
 
   defp expand_output_shape(%Nx.Tensor{} = tensor), do: Nx.shape(tensor)
 
+  defp expand_output_shape(%Axon.None{}), do: :none
+
   defp expand_output_shape(shapes) when is_tuple(shapes) do
     shapes
     |> Tuple.to_list()
     |> Enum.map(&expand_output_shape/1)
     |> List.to_tuple()
+  end
+
+  defp expand_output_shape(%{} = shapes) do
+    Map.new(shapes, fn {key, shape} -> {key, expand_output_shape(shape)} end)
   end
 
   defp generate_mermaid_node_entry(%{id: id, op: :input, name: name, shape: shape}) do

--- a/lib/axon/loop.ex
+++ b/lib/axon/loop.ex
@@ -339,7 +339,10 @@ defmodule Axon.Loop do
         optimizer_state = init_optimizer_fn.(trainable_parameters)
         loss_scale_state = init_loss_scale.()
 
-        # TODO: is this expensive? Will it compute the entire forward?
+        # This traces the forward pass to learn the shape and type of the
+        # prediction, it does not compute it. zeros_like/1 reads only the
+        # shape and type off the traced tensors, so the forward expression
+        # is never referenced by the returned state and never lowered.
         %{prediction: output} = forward_model_fn.(model_state, inp)
 
         %{
@@ -476,7 +479,8 @@ defmodule Axon.Loop do
 
     init_fn = fn
       {inp, tar}, state ->
-        # TODO: Is this expensive
+        # Traces the forward pass for its shape and type only, see the
+        # equivalent call in train_step/3
         output = forward_model_fn.(state, inp)
 
         %{

--- a/lib/axon/loop.ex
+++ b/lib/axon/loop.ex
@@ -478,14 +478,11 @@ defmodule Axon.Loop do
       {inp, tar}, state ->
         # TODO: Is this expensive
         output = forward_model_fn.(state, inp)
-        output_type = Nx.type(output)
-        output_shape = Nx.shape(output)
-        y_pred = Nx.broadcast(Nx.tensor(0, type: output_type), output_shape)
 
         %{
           model_state: state,
           y_true: zeros_like(tar),
-          y_pred: y_pred
+          y_pred: zeros_like(output)
         }
 
       data, state ->

--- a/test/axon/display_test.exs
+++ b/test/axon/display_test.exs
@@ -14,5 +14,48 @@ defmodule Axon.DisplayTest do
       assert table =~ ~s|Total Parameters: 544|
       assert table =~ ~s|Total Parameters Memory: 2.18 kilobytes|
     end
+
+    test "renders container outputs" do
+      model =
+        Axon.container(%{
+          logits: Axon.input("input") |> Axon.dense(2),
+          hidden: Axon.input("input") |> Axon.dense(4)
+        })
+
+      input = Nx.template({1, 16}, :f32)
+
+      table = Axon.Display.as_table(model, input)
+
+      assert table =~ ~s|container_0 ( container )|
+      assert table =~ ~s|%{hidden: f32[1][4], logits: f32[1][2]}|
+    end
+
+    test "renders optional outputs which resolve to none" do
+      model =
+        Axon.container(%{
+          out: Axon.input("input") |> Axon.dense(2),
+          maybe: Axon.input("optional", optional: true) |> Axon.optional()
+        })
+
+      input = %{"input" => Nx.template({1, 16}, :f32)}
+
+      table = Axon.Display.as_table(model, input)
+
+      assert table =~ ~s|%{maybe: none, out: f32[1][2]}|
+    end
+  end
+
+  describe "as_graph/3" do
+    test "renders container outputs" do
+      model =
+        Axon.container({
+          Axon.input("input") |> Axon.dense(2),
+          Axon.input("optional", optional: true) |> Axon.optional()
+        })
+
+      input = %{"input" => Nx.template({1, 16}, :f32)}
+
+      assert %Kino.JS{} = Axon.Display.as_graph(model, input)
+    end
   end
 end

--- a/test/axon/loop_test.exs
+++ b/test/axon/loop_test.exs
@@ -233,6 +233,63 @@ defmodule Axon.LoopTest do
       assert %{y_true: _, y_pred: _} = apply(Nx.Defn.jit(step_fn), [{inp, tar}, pstate])
     end
 
+    test "eval_step/1 evaluates models which output a container" do
+      inp = Nx.tensor([[1.0]])
+      tar = Nx.tensor([[2.0]])
+
+      dense = Axon.input("input", shape: {nil, 1}) |> Axon.dense(1)
+
+      model =
+        Axon.container(%{
+          logits: dense,
+          maybe: Axon.input("optional", shape: {nil, 1}, optional: true) |> Axon.optional()
+        })
+
+      {init_fn, _} = Axon.build(model)
+      model_state = init_fn.(%{"input" => inp}, Axon.ModelState.empty())
+
+      {eval_init_fn, eval_step_fn} = Axon.Loop.eval_step(model)
+
+      assert %{y_pred: %{logits: logits, maybe: %Axon.None{}}} =
+               pstate = apply(Nx.Defn.jit(eval_init_fn), [{%{"input" => inp}, tar}, model_state])
+
+      assert_equal(logits, Nx.tensor([[0.0]]))
+
+      assert %{y_pred: %{logits: logits, maybe: %Axon.None{}}} =
+               apply(Nx.Defn.jit(eval_step_fn), [{%{"input" => inp}, tar}, pstate])
+
+      assert_equal(logits, Axon.predict(model, model_state, %{"input" => inp}).logits)
+    end
+
+    test "validate/4 works with models which output a container" do
+      inp = Nx.tensor([[1.0]])
+      tar = Nx.tensor([[2.0]])
+      data = List.duplicate({inp, tar}, 2)
+
+      model =
+        Axon.input("input", shape: {nil, 1})
+        |> Axon.dense(1)
+        |> then(&Axon.container(%{logits: &1}))
+
+      loss = fn y_true, %{logits: logits} ->
+        Axon.Losses.mean_squared_error(y_true, logits, reduction: :mean)
+      end
+
+      metric = fn y_true, %{logits: logits} ->
+        Axon.Metrics.mean_absolute_error(y_true, logits)
+      end
+
+      loop =
+        model
+        |> Axon.Loop.trainer(loss, :sgd)
+        |> Axon.Loop.metric(metric, "mae")
+        |> Axon.Loop.validate(model, data)
+
+      ExUnit.CaptureIO.capture_io(fn ->
+        assert %Axon.ModelState{} = Axon.Loop.run(loop, data, Axon.ModelState.empty(), epochs: 1)
+      end)
+    end
+
     test "train_step/3 updates stateful layers after single step" do
       val = Nx.broadcast(1, {1, 8})
 


### PR DESCRIPTION
Some models give back a group of tensors instead of just one, like `%{logits: ..., hidden_state: ...}`. The evaluation loop and the display functions only knew how to look at a single tensor, so they crashed on those models.

Now they walk through the whole group and handle each tensor inside it, including missing optional outputs. Closes #612.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
