### PR TITLE
Remove loop output transforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ model =
   |> Axon.dense(128)
   |> Axon.dense(10, activation: :softmax)
 
-model_state =
+%Axon.Loop.State{step_state: %{model_state: model_state}} =
   model
   |> Axon.Loop.trainer(:categorical_cross_entropy, Polaris.Optimizers.adamw(0.005))
   |> Axon.Loop.metric(:accuracy)

--- a/examples/basics/multi_input_example.exs
+++ b/examples/basics/multi_input_example.exs
@@ -27,9 +27,12 @@ defmodule XOR do
   end
 
   defp train_model(model, data, epochs) do
-    model
-    |> Axon.Loop.trainer(:binary_cross_entropy, :sgd)
-    |> Axon.Loop.run(data, %{}, epochs: epochs, iterations: 1000, compiler: EXLA)
+    %Axon.Loop.State{step_state: %{model_state: model_state}} =
+      model
+      |> Axon.Loop.trainer(:binary_cross_entropy, :sgd)
+      |> Axon.Loop.run(data, %{}, epochs: epochs, iterations: 1000, compiler: EXLA)
+
+    model_state
   end
 
   def run do

--- a/examples/basics/multi_output_example.exs
+++ b/examples/basics/multi_output_example.exs
@@ -60,7 +60,7 @@ defmodule Power do
     # as you are trying to optimize for 2 things at once and optimal solutions for each
     # might not lie on a clean "manifold" - e.g. what's good for one output might not
     # be good for another output
-    params =
+    %Axon.Loop.State{step_state: %{model_state: params}} =
       model
       |> Axon.Loop.trainer([mean_squared_error: 0.5, mean_squared_error: 0.5], :adam)
       |> Axon.Loop.run(data, %{}, iterations: 250, epochs: 5, compiler: EXLA)

--- a/examples/generative/fashionmnist_autoencoder.exs
+++ b/examples/generative/fashionmnist_autoencoder.exs
@@ -45,10 +45,13 @@ defmodule FashionMNIST do
   end
 
   defp train_model(model, train_images, epochs) do
-    model
-    |> Axon.Loop.trainer(:mean_squared_error, :adam)
-    |> Axon.Loop.metric(:mean_absolute_error, "Error")
-    |> Axon.Loop.run(Stream.zip(train_images, train_images), %{}, epochs: epochs, compiler: EXLA)
+    %Axon.Loop.State{step_state: %{model_state: model_state}} =
+      model
+      |> Axon.Loop.trainer(:mean_squared_error, :adam)
+      |> Axon.Loop.metric(:mean_absolute_error, "Error")
+      |> Axon.Loop.run(Stream.zip(train_images, train_images), %{}, epochs: epochs, compiler: EXLA)
+
+    model_state
   end
 
   def run do

--- a/examples/generative/text_generator.exs
+++ b/examples/generative/text_generator.exs
@@ -95,7 +95,7 @@ defmodule TextGenerator do
 
     IO.puts("Total batches: #{Enum.count(train_data)}")
 
-    params =
+    %Axon.Loop.State{step_state: %{model_state: params}} =
       model
       |> Axon.Loop.trainer(:categorical_cross_entropy, Polaris.Optimizers.adam(learning_rate: 0.001))
       |> Axon.Loop.run(Stream.zip(train_data, train_labels), %{}, epochs: 20, compiler: EXLA)

--- a/examples/structured/credit_card_fraud.exs
+++ b/examples/structured/credit_card_fraud.exs
@@ -118,9 +118,12 @@ defmodule CreditCardFraud do
   end
 
   defp train_model(model, loss, optimizer, train_data) do
-    model
-    |> Axon.Loop.trainer(loss, optimizer)
-    |> Axon.Loop.run(train_data, %{}, epochs: 30, compiler: EXLA)
+    %Axon.Loop.State{step_state: %{model_state: model_state}} =
+      model
+      |> Axon.Loop.trainer(loss, optimizer)
+      |> Axon.Loop.run(train_data, %{}, epochs: 30, compiler: EXLA)
+
+    model_state
   end
 
   def run() do

--- a/examples/vision/cifar10.exs
+++ b/examples/vision/cifar10.exs
@@ -47,10 +47,13 @@ defmodule Cifar do
   end
 
   defp train_model(model, train_images, train_labels, epochs) do
-    model
-    |> Axon.Loop.trainer(:categorical_cross_entropy, :adam)
-    |> Axon.Loop.metric(:accuracy, "Accuracy")
-    |> Axon.Loop.run(Stream.zip(train_images, train_labels), %{}, epochs: epochs, compiler: EXLA)
+    %Axon.Loop.State{step_state: %{model_state: model_state}} =
+      model
+      |> Axon.Loop.trainer(:categorical_cross_entropy, :adam)
+      |> Axon.Loop.metric(:accuracy, "Accuracy")
+      |> Axon.Loop.run(Stream.zip(train_images, train_labels), %{}, epochs: epochs, compiler: EXLA)
+
+    model_state
   end
 
   defp test_model(model, model_state, test_images, test_labels) do

--- a/examples/vision/cnn_image_denoising.exs
+++ b/examples/vision/cnn_image_denoising.exs
@@ -31,7 +31,7 @@ defmodule MnistDenoising do
     # Train with noisy images as input and train images as targets
     model = build_model({nil, @image_channels, @image_side_pixels, @image_side_pixels})
 
-    model_state =
+    %Axon.Loop.State{step_state: %{model_state: model_state}} =
       model
       |> Axon.Loop.trainer(:binary_cross_entropy, :adam)
       |> Axon.Loop.run(train_data, %{}, epochs: @epochs, compiler: EXLA)

--- a/examples/vision/mnist.exs
+++ b/examples/vision/mnist.exs
@@ -39,10 +39,16 @@ defmodule Mnist do
   end
 
   defp train_model(model, train_images, train_labels, epochs) do
-    model
-    |> Axon.Loop.trainer(:categorical_cross_entropy, Polaris.Optimizers.adamw(learning_rate: 0.005))
-    |> Axon.Loop.metric(:accuracy, "Accuracy")
-    |> Axon.Loop.run(Stream.zip(train_images, train_labels), %{}, epochs: epochs, compiler: EXLA)
+    %Axon.Loop.State{step_state: %{model_state: model_state}} =
+      model
+      |> Axon.Loop.trainer(
+        :categorical_cross_entropy,
+        Polaris.Optimizers.adamw(learning_rate: 0.005)
+      )
+      |> Axon.Loop.metric(:accuracy, "Accuracy")
+      |> Axon.Loop.run(Stream.zip(train_images, train_labels), %{}, epochs: epochs, compiler: EXLA)
+
+    model_state
   end
 
   defp test_model(model, model_state, test_images, test_labels) do

--- a/guides/cheatsheets/axon_pytorch.cheatmd
+++ b/guides/cheatsheets/axon_pytorch.cheatmd
@@ -462,8 +462,9 @@ Axon supports manual training loops but provides the `Axon.Loop` module for conv
 
 ```elixir
 # High-level approach using Axon.Loop:
-model_state = Axon.Loop.trainer(model, :categorical_cross_entropy, optimizer)
-               |> Axon.Loop.run(train_data, epochs: 10, compiler: EXLA)
+%Axon.Loop.State{step_state: %{model_state: model_state}} =
+  Axon.Loop.trainer(model, :categorical_cross_entropy, optimizer)
+  |> Axon.Loop.run(train_data, %{}, epochs: 10, compiler: EXLA)
 
 # Manual loop structure (simplified):
 model = # ...

--- a/guides/serialization/saving_and_loading.livemd
+++ b/guides/serialization/saving_and_loading.livemd
@@ -20,7 +20,7 @@ The model itself is just code, you define it once and reuse it. Only the learned
 
 ## Saving a Model After Training
 
-When you run a training loop, it returns the trained model state by default. Extract the parameters and serialize them:
+When you run a training loop, it returns the final loop state, which holds the trained model state in its step state. Extract the parameters and serialize them:
 
 ```elixir
 model =
@@ -39,10 +39,11 @@ train_data =
     {xs, Nx.sin(xs)}
   end)
 
-trained_model_state = Axon.Loop.run(loop, train_data, Axon.ModelState.empty(), epochs: 2, iterations: 100)
+%Axon.Loop.State{step_state: %{model_state: trained_model_state}} =
+  Axon.Loop.run(loop, train_data, Axon.ModelState.empty(), epochs: 2, iterations: 100)
 ```
 
-The training loop returns `model_state` by default (from `Axon.Loop.trainer/3`). For inference, we need the parameters—extract the `data` field from `ModelState`:
+The training loop returns the final `%Axon.Loop.State{}`, and loops built with `Axon.Loop.trainer/4` keep the trained model state under `step_state.model_state`. For inference, we need the parameters—extract the `data` field from `ModelState`:
 
 ```elixir
 # Extract parameters - trained_model_state.data contains the nested map of weights

--- a/guides/training_and_evaluation/writing_custom_metrics.livemd
+++ b/guides/training_and_evaluation/writing_custom_metrics.livemd
@@ -155,7 +155,7 @@ Epoch: 0, Batch: 950, loss: 0.0681635 my weird metric: -5.2842808
 }
 ```
 
-While the metric defaults are designed with supervised training loops in mind, they can be used for much more flexible purposes. By default, metrics look for the fields `:y_true` and `:y_pred` in the given loop's step state. They then apply the given metric function on those inputs. You can also define metrics which work on other fields. For example you can track the running average of a given parameter with a metric just by defining a custom output transform:
+While the metric defaults are designed with supervised training loops in mind, they can be used for much more flexible purposes. By default, metrics look for the fields `:y_true` and `:y_pred` in the given loop's step state. They then apply the given metric function on those inputs. You can also define metrics which work on other fields. For example you can track the running average of a given parameter with a metric just by defining a custom transform:
 
 ```elixir
 model =
@@ -166,15 +166,15 @@ model =
   |> Axon.relu()
   |> Axon.dense(1)
 
-output_transform = fn %{model_state: model_state} ->
+transform = fn %{model_state: model_state} ->
   [model_state["dense_0"]["kernel"]]
 end
 
 loop =
   model
   |> Axon.Loop.trainer(:mean_squared_error, :sgd)
-  |> Axon.Loop.metric(&Nx.mean/1, "dense_0_kernel_mean", :running_average, output_transform)
-  |> Axon.Loop.metric(&Nx.variance/1, "dense_0_kernel_var", :running_average, output_transform)
+  |> Axon.Loop.metric(&Nx.mean/1, "dense_0_kernel_mean", :running_average, transform)
+  |> Axon.Loop.metric(&Nx.variance/1, "dense_0_kernel_var", :running_average, transform)
 ```
 
 <!-- livebook:{"output":true} -->
@@ -209,7 +209,7 @@ loop =
 >
 ```
 
-Axon will apply your custom output transform to the loop's step state and forward the result to your custom metric function:
+Axon will apply your custom transform to the loop's step state and forward the result to your custom metric function:
 
 ```elixir
 train_data =
@@ -315,7 +315,7 @@ model =
   |> Axon.relu()
   |> Axon.dense(1)
 
-output_transform = fn %{model_state: model_state} ->
+transform = fn %{model_state: model_state} ->
   [model_state["dense_0"]["kernel"]]
 end
 
@@ -326,7 +326,7 @@ loop =
     &Nx.mean/1,
     "dense_0_kernel_ema_mean",
     &CustomAccumulator.running_ema/3,
-    output_transform
+    transform
   )
 ```
 

--- a/guides/training_and_evaluation/your_first_evaluation_loop.livemd
+++ b/guides/training_and_evaluation/your_first_evaluation_loop.livemd
@@ -40,7 +40,8 @@ data =
     {xs, ys}
   end)
 
-trained_model_state = Axon.Loop.run(train_loop, data, %{}, iterations: 1000)
+%Axon.Loop.State{step_state: %{model_state: trained_model_state}} =
+  Axon.Loop.run(train_loop, data, %{}, iterations: 1000)
 ```
 
 <!-- livebook:{"output":true} -->
@@ -102,7 +103,7 @@ Epoch: 0, Batch: 950, loss: 0.1285532
 }
 ```
 
-Running loops with `Axon.Loop.trainer/3` returns a trained model state which you can use to evaluate your model. To construct an evaluation loop, you just call `Axon.Loop.evaluator/1` with your pre-trained model:
+Running loops with `Axon.Loop.trainer/3` returns the final loop state, and the trained model state lives in `step_state.model_state`. You can use it to evaluate your model. To construct an evaluation loop, you just call `Axon.Loop.evaluator/1` with your pre-trained model:
 
 ```elixir
 test_loop = Axon.Loop.evaluator(model)
@@ -161,10 +162,13 @@ test_loop = test_loop |> Axon.Loop.metric(:mean_absolute_error)
 >
 ```
 
-Finally, you can run your loop on test data. Because you want to test your trained model, you need to provide your model's initial state to the test loop:
+Finally, you can run your loop on test data. Because you want to test your trained model, you need to provide your model's initial state to the test loop. The loop returns the final `%Axon.Loop.State{}`, and the aggregated metrics are in its `:metrics` field, keyed by epoch:
 
 ```elixir
-Axon.Loop.run(test_loop, data, trained_model_state, iterations: 1000)
+%Axon.Loop.State{metrics: metrics} =
+  Axon.Loop.run(test_loop, data, trained_model_state, iterations: 1000)
+
+metrics
 ```
 
 <!-- livebook:{"output":true} -->

--- a/guides/training_and_evaluation/your_first_training_loop.livemd
+++ b/guides/training_and_evaluation/your_first_training_loop.livemd
@@ -172,6 +172,13 @@ Epoch: 0, Batch: 950, loss: 0.0563023
 
 `Axon.Loop.run/4` expects a loop to execute, some data to loop over, and any initial state you explicitly want your loop to start with. `Axon.Loop.run/4` will then iterate over your data, executing a step function on each batch, and accumulating some generic loop state. In the case of a supervised training loop, this generic loop state actually represents training state including your model's trained parameters.
 
+`Axon.Loop.run/4` returns that final `%Axon.Loop.State{}`, so you can pattern match on it to grab just the trained model state:
+
+```elixir
+%Axon.Loop.State{step_state: %{model_state: trained_model_state}} =
+  Axon.Loop.run(loop, train_data, %{}, iterations: 1000)
+```
+
 `Axon.Loop.run/4` also accepts options which control the loops execution. This includes `:iterations` which controls the number of iterations per epoch a loop should execute for, and `:epochs` which controls the number of epochs a loop should execute for:
 
 ```elixir

--- a/lib/axon.ex
+++ b/lib/axon.ex
@@ -207,10 +207,10 @@ defmodule Axon do
 
       IO.inspect model
 
-      model_state =
+      %Axon.Loop.State{step_state: %{model_state: model_state}} =
         model
         |> Axon.Loop.trainer(:categorical_cross_entropy, Polaris.Optimizers.adamw(learning_rate: 0.005))
-        |> Axon.Loop.run(train_data, epochs: 10, compiler: EXLA)
+        |> Axon.Loop.run(train_data, %{}, epochs: 10, compiler: EXLA)
 
   See `Polaris.Updates` and `Axon.Loop` for a more in-depth treatment of
   model optimization and model training.

--- a/lib/axon/loop.ex
+++ b/lib/axon/loop.ex
@@ -66,13 +66,12 @@ defmodule Axon.Loop do
   state. For machine learning tasks, the initialization function will return things like
   initial model parameters and optimizer state.
 
-  Typically, the final output of the loop is the accumulated final state; however, you
-  may optionally apply an output transform to extract specific values at the end of the
-  loop. For example, `Axon.Loop.trainer/4` by default extracts trained model state:
+  The final output of the loop is the accumulated final state. If you are only interested
+  in specific values, you can extract them from the returned state. For example, loops
+  built with `Axon.Loop.trainer/4` keep the trained model state in the step state:
 
-      output_transform = fn state ->
-        state.step_state[:model_state]
-      end
+      %Axon.Loop.State{step_state: %{model_state: model_state}} =
+        Axon.Loop.run(loop, data)
 
   ## Initialize and Step
 
@@ -131,7 +130,7 @@ defmodule Axon.Loop do
       |> Axon.Loop.metric("Accuracy", :accuracy, fn %{y_true: y_, y_pred: y} -> [y_, y] end)
       |> Axon.Loop.run(data)
 
-  Because metrics work directly on `step_state`, you typically need to provide an output
+  Because metrics work directly on `step_state`, you typically need to provide a
   transform to indicate which values should be passed to your metric function. By default,
   Axon assumes a supervised training task with the fields `:y_true` and `:y_pred` present
   in the step state. See `Axon.Loop.metric/4` for more information.
@@ -186,8 +185,8 @@ defmodule Axon.Loop do
   Axon loops are typically created from one of the factory functions provided in this
   module:
 
-    * `Axon.Loop.loop/3` - Creates a loop from step function and optional initialization
-      functions and output transform functions.
+    * `Axon.Loop.loop/2` - Creates a loop from step function and an optional
+      initialization function.
 
     * `Axon.Loop.trainer/3` - Creates a supervised training loop from model, loss, and
       optimizer.
@@ -196,9 +195,10 @@ defmodule Axon.Loop do
 
   ## Running loops
 
-  In order to execute a loop, you should use `Axon.Loop.run/3`:
+  In order to execute a loop, you should use `Axon.Loop.run/4`, which returns the
+  final `%Axon.Loop.State{}`:
 
-      Axon.Loop.run(loop, data, epochs: 10)
+      Axon.Loop.run(loop, data, %{}, epochs: 10)
 
   ## Resuming loops
 
@@ -273,7 +273,6 @@ defmodule Axon.Loop do
     :init,
     :step,
     :attached_state,
-    :output_transform,
     metrics: %{},
     handlers: @default_handlers
   ]
@@ -515,8 +514,7 @@ defmodule Axon.Loop do
   ## Loop Factories
 
   @doc """
-  Creates a loop from `step_fn`, an optional `init_fn`, and an
-  optional `output_transform`.
+  Creates a loop from `step_fn` and an optional `init_fn`.
 
   `step_fn` is an arity-2 function which takes a batch and state
   and returns an updated step state:
@@ -541,18 +539,12 @@ defmodule Axon.Loop do
   within `Nx.Defn.jit/3`. While JIT-compilation will work with anonymous functions,
   `def`, and `defn`, it is recommended that you use the stricter `defn` to define
   both functions in order to avoid bugs or cryptic errors.
-
-  `output_transform/1` applies a transformation on the final accumulated loop state.
-  This is useful for extracting specific fields from a loop and piping them into
-  additional functions.
   """
-  def loop(step_fn, init_fn \\ &default_init/2, output_transform \\ & &1)
-      when is_function(step_fn, 2) and is_function(init_fn, 2) and
-             is_function(output_transform, 1) do
+  def loop(step_fn, init_fn \\ &default_init/2)
+      when is_function(step_fn, 2) and is_function(init_fn, 2) do
     %Loop{
       init: init_fn,
-      step: step_fn,
-      output_transform: output_transform
+      step: step_fn
     }
   end
 
@@ -601,6 +593,14 @@ defmodule Axon.Loop do
         model_state: container(tensor()), # Model parameters and state
         optimizer_state: container(tensor()) # Optimizer state associated with each parameter
       }
+
+  `Axon.Loop.run/4` returns the final `%Axon.Loop.State{}`, so you can extract the
+  trained model state from the loop's step state:
+
+      %Axon.Loop.State{step_state: %{model_state: trained_model_state}} =
+        model
+        |> Axon.Loop.trainer(:binary_cross_entropy, :adam)
+        |> Axon.Loop.run(data)
 
   ## Examples
 
@@ -659,11 +659,10 @@ defmodule Axon.Loop do
     {init_fn, step_fn} = train_step(model, loss_fn, optimizer, step_opts)
 
     log_interval = opts[:log] || 50
-    output_transform = fn state -> state.step_state[:model_state] end
 
     loop =
       step_fn
-      |> loop(init_fn, output_transform)
+      |> loop(init_fn)
       |> metric(loss_fn, "loss")
 
     if log_interval > 0 do
@@ -748,14 +747,18 @@ defmodule Axon.Loop do
       |> Axon.Loop.evaluator()
       |> Axon.Loop.run(data, trained_model_state, compiler: EXLA)
 
-  This function applies an output transform which returns the map of metrics accumulated
-  over the given loop.
+  `Axon.Loop.run/4` returns the final `%Axon.Loop.State{}`. The accumulated metrics
+  are available in the `:metrics` field, keyed by epoch:
+
+      %Axon.Loop.State{metrics: %{0 => metrics}} =
+        model
+        |> Axon.Loop.evaluator()
+        |> Axon.Loop.run(data, trained_model_state, compiler: EXLA)
   """
   def evaluator(model) do
     {init_fn, step_fn} = eval_step(model)
-    output_transform = fn state -> state.metrics end
 
-    loop(step_fn, init_fn, output_transform)
+    loop(step_fn, init_fn)
     |> log(&supervised_log_message_fn(&1, false), event: :iteration_completed)
   end
 
@@ -771,15 +774,15 @@ defmodule Axon.Loop do
 
   By default, metrics assume a supervised learning task and extract the fields
   `[:y_true, :y_pred]` from the step state. If you wish to work on a different
-  value, you can use an output transform. An output transform is a list of keys
-  to extract from the output state, or a function which returns a flattened list
-  of values to pass to the given metric function. Values received from output
-  transforms are passed to the given metric using:
+  value, you can use a transform. A transform is a list of keys to extract from
+  the step state, or a function which returns a flattened list of values to pass
+  to the given metric function. Values received from transforms are passed to the
+  given metric using:
 
-      value = output_transform.(step_state)
+      value = transform.(step_state)
       apply(metric, value)
 
-  Thus, even if you want your metric to work on a container, your output transform
+  Thus, even if you want your metric to work on a container, your transform
   must return a list.
 
   `metric` must be an atom which matches the name of a metric in `Axon.Metrics`, or
@@ -1017,10 +1020,12 @@ defmodule Axon.Loop do
     validation_loop = fn %State{metrics: metrics, step_state: step_state} = state ->
       %{model_state: model_state} = step_state
 
-      metrics =
+      %State{metrics: %{0 => validation_metrics}} =
         Enum.reduce(metric_fns, evaluator, fn {k, {_, v}}, loop -> metric(loop, v, k) end)
         |> run(validation_data, model_state)
-        |> Access.get(0)
+
+      metrics =
+        validation_metrics
         |> Map.new(fn {k, v} ->
           {"validation_#{k}", v}
         end)
@@ -1538,6 +1543,12 @@ defmodule Axon.Loop do
   `data` must be an Enumerable or Stream which yields batches of
   data on each iteration.
 
+  It returns the final `%Axon.Loop.State{}`. Values of interest, such as
+  the trained model state, can be extracted from the returned state:
+
+      %Axon.Loop.State{step_state: %{model_state: trained_model_state}} =
+        Axon.Loop.run(loop, data)
+
   ## Options
 
     * `:epochs` - max epochs to run loop for. Must be non-negative integer.
@@ -1627,8 +1638,7 @@ defmodule Axon.Loop do
       step: step_fn,
       handlers: handler_fns,
       metrics: metric_fns,
-      attached_state: attached_state,
-      output_transform: output_transform
+      attached_state: attached_state
     } = loop
 
     sample_data =
@@ -1763,8 +1773,9 @@ defmodule Axon.Loop do
         &Map.put(&2, &1, zero_metrics)
       )
 
-    state = %State{state | metrics: final_metrics_map, status: status}
-    output_transform.(state)
+    step_state = maybe_clear_donatable_marks(state.step_state, donate_state?)
+
+    %State{state | step_state: step_state, metrics: final_metrics_map, status: status}
   end
 
   ## Helpers
@@ -1904,6 +1915,19 @@ defmodule Axon.Loop do
   end
 
   defp maybe_donate_step_state(step_state, true), do: step_state
+
+  # A donated argument the step function returns as-is keeps its mark, so the
+  # final state must be swept before it is handed to the caller. Otherwise the
+  # mark would follow the caller out of the loop and donate buffers they never
+  # offered on their next `Nx.Defn.jit` call.
+  defp maybe_clear_donatable_marks(step_state, false), do: step_state
+
+  defp maybe_clear_donatable_marks(step_state, true) do
+    Nx.Defn.Composite.traverse(step_state, fn
+      %Nx.Tensor{donatable?: true} = tensor -> %{tensor | donatable?: false}
+      tensor -> tensor
+    end)
+  end
 
   defp max_iterations_reached?(max_iters, iters) do
     iters >= max_iters - 1 and max_iters > 0
@@ -2159,13 +2183,13 @@ defmodule Axon.Loop do
             " for more information"
   end
 
-  # Builds a metric function from an atom or function and an output transform.
+  # Builds a metric function from an atom or function and a transform.
   # A valid metric is an atom which matches the name of a function in
   # Axon.Metrics or a function which takes an arbitrary number of parameters
-  # and returns an output of arbitrary shape/type. Output transforms are field(s)
+  # and returns an output of arbitrary shape/type. Transforms are field(s)
   # to extract from the step state, or a function which transforms the step
   # state before it is passed to the metric function.
-  # TODO(seanmor5): Reconsider the form of output transform
+  # TODO(seanmor5): Reconsider the form of the metric transform
   defp build_metric_fn(metric, accumulator, transform_or_fields) do
     transform_fn =
       case transform_or_fields do
@@ -2186,7 +2210,7 @@ defmodule Axon.Loop do
 
         invalid ->
           raise ArgumentError,
-                "Invalid output transform #{inspect(invalid)}, a valid output" <>
+                "Invalid metric transform #{inspect(invalid)}, a valid" <>
                   " transform is an atom or list of atoms specifying field(s)" <>
                   " to extract from the step state, or an arity-1 function" <>
                   " applied to the step state"

--- a/lib/axon/loop/state.ex
+++ b/lib/axon/loop/state.ex
@@ -2,6 +2,13 @@ defmodule Axon.Loop.State do
   @moduledoc """
   Accumulated state in an Axon.Loop.
 
+  This is what `Axon.Loop.run/4` returns. Any values of interest, such as
+  the trained model state of a supervised training loop, are extracted from
+  the returned state:
+
+      %Axon.Loop.State{step_state: %{model_state: model_state}} =
+        Axon.Loop.run(loop, data)
+
   Loop state is a struct:
 
       %State{

--- a/notebooks/basics/xor.livemd
+++ b/notebooks/basics/xor.livemd
@@ -68,7 +68,7 @@ It's time to train our model. In this case we use *binary cross entropy* for the
 ```elixir
 epochs = 10
 
-params =
+%Axon.Loop.State{step_state: %{model_state: params}} =
   model
   |> Axon.Loop.trainer(:binary_cross_entropy, :sgd)
   |> Axon.Loop.run(data, %{}, epochs: epochs, iterations: 1000)

--- a/notebooks/generative/fashionmnist_autoencoder.livemd
+++ b/notebooks/generative/fashionmnist_autoencoder.livemd
@@ -96,7 +96,7 @@ epochs = 5
 batched_images = Nx.to_batched(train_images, batch_size)
 train_batches = Stream.zip(batched_images, batched_images)
 
-params =
+%Axon.Loop.State{step_state: %{model_state: params}} =
   model
   |> Axon.Loop.trainer(:mean_squared_error, :adam)
   |> Axon.Loop.metric(:mean_absolute_error, "Error")

--- a/notebooks/generative/mnist_autoencoder_using_kino.livemd
+++ b/notebooks/generative/mnist_autoencoder_using_kino.livemd
@@ -195,7 +195,7 @@ Let's see what an element of the input and target look like
 Looks right (and tricky). Let's see how the model does.
 
 ```elixir
-params =
+%Axon.Loop.State{step_state: %{model_state: params}} =
   model
   |> Axon.Loop.trainer(:mean_squared_error, Polaris.Optimizers.adamw(learning_rate: 0.001))
   |> Axon.Loop.validate(model, test_data)

--- a/notebooks/structured/credit_card_fraud.livemd
+++ b/notebooks/structured/credit_card_fraud.livemd
@@ -153,7 +153,7 @@ loss =
 
 optimizer = Polaris.Optimizers.adam(learning_rate: 1.0e-2)
 
-params =
+%Axon.Loop.State{step_state: %{model_state: params}} =
   model
   |> Axon.Loop.trainer(loss, optimizer)
   |> Axon.Loop.run(batched_train, %{}, epochs: 30, compiler: EXLA)

--- a/notebooks/text/lstm_generation.livemd
+++ b/notebooks/text/lstm_generation.livemd
@@ -170,7 +170,7 @@ result_batches = Nx.to_batched(train_results, batch_size)
 
 IO.puts("Total batches: #{Enum.count(train_batches)}")
 
-params =
+%Axon.Loop.State{step_state: %{model_state: params}} =
   model
   |> Axon.Loop.trainer(:categorical_cross_entropy, Polaris.Optimizers.adam(learning_rate: 0.001))
   |> Axon.Loop.run(Stream.zip(train_batches, result_batches), %{}, epochs: 20, compiler: EXLA)
@@ -249,7 +249,7 @@ result_batches = Nx.to_batched(train_results, batch_size)
 
 IO.puts("Total batches: #{Enum.count(train_batches)}")
 
-new_params =
+%Axon.Loop.State{step_state: %{model_state: new_params}} =
   new_model
   |> Axon.Loop.trainer(:categorical_cross_entropy, Polaris.Optimizers.adam(learning_rate: 0.001))
   |> Axon.Loop.run(Stream.zip(train_batches, result_batches), %{}, epochs: 50, compiler: EXLA)

--- a/notebooks/time_series/apple_stock_prices.livemd
+++ b/notebooks/time_series/apple_stock_prices.livemd
@@ -237,7 +237,8 @@ We are ready to create our training loop and run it. Since our network is simple
 optimizer = Polaris.Optimizers.sgd(learning_rate: 0.04)
 loop = Axon.Loop.trainer(model, :mean_squared_error, optimizer)
 
-trained_model_state = Axon.Loop.run(loop, train_data, %{}, epochs: 100)
+%Axon.Loop.State{step_state: %{model_state: trained_model_state}} =
+  Axon.Loop.run(loop, train_data, %{}, epochs: 100)
 ```
 
 Finally, we make predictions over the train and test sets so we can evaluate our model.

--- a/notebooks/vision/horses_or_humans.livemd
+++ b/notebooks/vision/horses_or_humans.livemd
@@ -201,7 +201,7 @@ data = HorsesHumans.DataProcessing.data_stream(files, batch_size)
 
 optimizer = Polaris.Optimizers.adam(learning_rate: 1.0e-4)
 
-params =
+%Axon.Loop.State{step_state: %{model_state: params}} =
   model
   |> Axon.Loop.trainer(:categorical_cross_entropy, optimizer, log: 1)
   |> Axon.Loop.metric(:accuracy)

--- a/notebooks/vision/mnist.livemd
+++ b/notebooks/vision/mnist.livemd
@@ -82,7 +82,7 @@ All `Axon` models start with an input layer to tell subsequent layers what shape
 In Axon we express the task of training using a declarative loop API. First, we need to specify a loss function and optimizer, there are many built-in variants to choose from. In this example, we'll use *categorical cross-entropy* and the *Adam* optimizer. We will also keep track of the *accuracy* metric. Finally, we run training loop passing our batched images and labels. We'll train for 10 epochs using the `EXLA` compiler.
 
 ```elixir
-params =
+%Axon.Loop.State{step_state: %{model_state: params}} =
   model
   |> Axon.Loop.trainer(:categorical_cross_entropy, :adam)
   |> Axon.Loop.metric(:accuracy, "Accuracy")

--- a/test/axon/integration_test.exs
+++ b/test/axon/integration_test.exs
@@ -29,7 +29,7 @@ defmodule Axon.IntegrationTest do
       end)
 
     ExUnit.CaptureIO.capture_io(fn ->
-      model_state =
+      %{step_state: %{model_state: model_state}} =
         model
         |> Axon.Loop.trainer(:binary_cross_entropy, :sgd)
         |> Axon.Loop.run(data, Axon.ModelState.empty(), iterations: 100, epochs: 20)
@@ -40,7 +40,7 @@ defmodule Axon.IntegrationTest do
         |> Axon.Loop.metric(:accuracy)
         |> Axon.Loop.run(data, model_state, iterations: 100)
 
-      assert_greater_equal(get_in(eval_results, [0, "accuracy"]), 0.9)
+      assert_greater_equal(get_in(eval_results.metrics, [0, "accuracy"]), 0.9)
     end)
   end
 
@@ -69,8 +69,6 @@ defmodule Axon.IntegrationTest do
           :categorical_cross_entropy,
           Polaris.Optimizers.adam(learning_rate: 5.0e-3)
         )
-        # TODO: Fix default output transform
-        |> Map.update(:output_transform, nil, fn _ -> & &1 end)
         |> Axon.Loop.metric(:accuracy)
         |> Axon.Loop.validate(model, train)
         |> Axon.Loop.run(train, Axon.ModelState.empty(), epochs: 10)
@@ -84,7 +82,7 @@ defmodule Axon.IntegrationTest do
         |> Axon.Loop.metric(:accuracy)
         |> Axon.Loop.run(train, model_state)
 
-      assert %{0 => %{"accuracy" => final_model_val_accuracy}} = eval_results
+      assert %{metrics: %{0 => %{"accuracy" => final_model_val_accuracy}}} = eval_results
 
       assert_greater_equal(last_epoch_metrics["validation_accuracy"], 0.7)
       assert_all_close(final_model_val_accuracy, last_epoch_metrics["validation_accuracy"])
@@ -117,8 +115,6 @@ defmodule Axon.IntegrationTest do
           :categorical_cross_entropy,
           Polaris.Optimizers.adam(learning_rate: 5.0e-3)
         )
-        # TODO: Fix default output transform
-        |> Map.update(:output_transform, nil, fn _ -> & &1 end)
         |> Axon.Loop.metric(:accuracy)
         |> Axon.Loop.validate(model, train)
         |> Axon.Loop.run(train, Axon.ModelState.empty(), epochs: 10)
@@ -132,7 +128,7 @@ defmodule Axon.IntegrationTest do
         |> Axon.Loop.metric(:accuracy)
         |> Axon.Loop.run(train, model_state)
 
-      assert %{0 => %{"accuracy" => final_model_val_accuracy}} = eval_results
+      assert %{metrics: %{0 => %{"accuracy" => final_model_val_accuracy}}} = eval_results
 
       assert_greater_equal(last_epoch_metrics["validation_accuracy"], 0.7)
       assert_all_close(final_model_val_accuracy, last_epoch_metrics["validation_accuracy"])
@@ -168,8 +164,6 @@ defmodule Axon.IntegrationTest do
           :categorical_cross_entropy,
           Polaris.Optimizers.adam(learning_rate: 5.0e-3)
         )
-        # TODO: Fix default output transform
-        |> Map.update(:output_transform, nil, fn _ -> & &1 end)
         |> Axon.Loop.metric(:accuracy)
         |> Axon.Loop.validate(model, train)
         |> Axon.Loop.run(train, Axon.ModelState.empty(), epochs: 10)
@@ -183,7 +177,7 @@ defmodule Axon.IntegrationTest do
         |> Axon.Loop.metric(:accuracy)
         |> Axon.Loop.run(train, model_state)
 
-      assert %{0 => %{"accuracy" => final_model_val_accuracy}} = eval_results
+      assert %{metrics: %{0 => %{"accuracy" => final_model_val_accuracy}}} = eval_results
 
       assert_greater_equal(last_epoch_metrics["validation_accuracy"], 0.7)
       assert_all_close(final_model_val_accuracy, last_epoch_metrics["validation_accuracy"])
@@ -218,8 +212,6 @@ defmodule Axon.IntegrationTest do
           :categorical_cross_entropy,
           Polaris.Optimizers.adam(learning_rate: 5.0e-3)
         )
-        # TODO: Fix default output transform
-        |> Map.update(:output_transform, nil, fn _ -> & &1 end)
         |> Axon.Loop.metric(:accuracy)
         |> Axon.Loop.validate(model, train)
         |> Axon.Loop.run(train, Axon.ModelState.empty(), epochs: 10)
@@ -233,7 +225,7 @@ defmodule Axon.IntegrationTest do
         |> Axon.Loop.metric(:accuracy)
         |> Axon.Loop.run(train, model_state)
 
-      assert %{0 => %{"accuracy" => final_model_val_accuracy}} = eval_results
+      assert %{metrics: %{0 => %{"accuracy" => final_model_val_accuracy}}} = eval_results
 
       assert_greater_equal(last_epoch_metrics["validation_accuracy"], 0.7)
       assert_all_close(final_model_val_accuracy, last_epoch_metrics["validation_accuracy"])
@@ -265,8 +257,6 @@ defmodule Axon.IntegrationTest do
           Polaris.Optimizers.adam(learning_rate: 5.0e-3),
           seed: 1
         )
-        # TODO: Fix default output transform
-        |> Map.update(:output_transform, nil, fn _ -> & &1 end)
         |> Axon.Loop.metric(:accuracy)
         |> Axon.Loop.validate(model, train)
         |> Axon.Loop.run(train, Axon.ModelState.empty(), epochs: 10)
@@ -278,8 +268,6 @@ defmodule Axon.IntegrationTest do
           Polaris.Optimizers.adam(learning_rate: 5.0e-3),
           seed: 1
         )
-        # TODO: Fix default output transform
-        |> Map.update(:output_transform, nil, fn _ -> & &1 end)
         |> Axon.Loop.metric(:accuracy)
         |> Axon.Loop.validate(model, train)
         |> Axon.Loop.run(train, Axon.ModelState.empty(), epochs: 10)
@@ -340,8 +328,6 @@ defmodule Axon.IntegrationTest do
               :categorical_cross_entropy,
               Polaris.Optimizers.unquote(optimizer)(unquote_splicing(args))
             )
-            # TODO: Fix default output transform
-            |> Map.update(:output_transform, nil, fn _ -> & &1 end)
             |> Axon.Loop.metric(:accuracy)
             |> Axon.Loop.validate(model, train)
             |> Axon.Loop.run(train, Axon.ModelState.empty(), epochs: 10)
@@ -355,7 +341,7 @@ defmodule Axon.IntegrationTest do
             |> Axon.Loop.metric(:accuracy)
             |> Axon.Loop.run(train, model_state)
 
-          assert %{0 => %{"accuracy" => final_model_val_accuracy}} = eval_results
+          assert %{metrics: %{0 => %{"accuracy" => final_model_val_accuracy}}} = eval_results
 
           assert_greater_equal(last_epoch_metrics["validation_accuracy"], 0.7)
           assert_all_close(final_model_val_accuracy, last_epoch_metrics["validation_accuracy"])
@@ -395,7 +381,7 @@ defmodule Axon.IntegrationTest do
         |> Axon.nx(fn seq -> Nx.squeeze(seq[[0..-1//1, -1, 0..-1//1]]) end)
 
       ExUnit.CaptureIO.capture_io(fn ->
-        %Axon.ModelState{data: dynamic} =
+        %{step_state: %{model_state: %Axon.ModelState{data: dynamic}}} =
           dynamic_model
           |> Axon.Loop.trainer(
             :mean_squared_error,
@@ -404,7 +390,7 @@ defmodule Axon.IntegrationTest do
           )
           |> Axon.Loop.run(train, Axon.ModelState.empty(), epochs: 1)
 
-        %Axon.ModelState{data: static} =
+        %{step_state: %{model_state: %Axon.ModelState{data: static}}} =
           static_model
           |> Axon.Loop.trainer(
             :mean_squared_error,
@@ -457,8 +443,6 @@ defmodule Axon.IntegrationTest do
           results =
             model
             |> Axon.Loop.trainer(:categorical_cross_entropy, :adam, loss_scale: unquote(scale))
-            # TODO: Fix default output transform
-            |> Map.update(:output_transform, nil, fn _ -> & &1 end)
             |> Axon.Loop.metric(:accuracy)
             |> Axon.Loop.validate(model, train)
             |> Axon.Loop.run(train, Axon.ModelState.empty(), epochs: 10)
@@ -472,7 +456,7 @@ defmodule Axon.IntegrationTest do
             |> Axon.Loop.metric(:accuracy)
             |> Axon.Loop.run(train, model_state)
 
-          assert %{0 => %{"accuracy" => final_model_val_accuracy}} = eval_results
+          assert %{metrics: %{0 => %{"accuracy" => final_model_val_accuracy}}} = eval_results
 
           assert_greater_equal(last_epoch_metrics["validation_accuracy"], 0.60)
           assert_all_close(final_model_val_accuracy, last_epoch_metrics["validation_accuracy"])
@@ -510,8 +494,6 @@ defmodule Axon.IntegrationTest do
           results =
             model
             |> Axon.Loop.trainer(:categorical_cross_entropy, :adam, loss_scale: unquote(scale))
-            # TODO: Fix default output transform
-            |> Map.update(:output_transform, nil, fn _ -> & &1 end)
             |> Axon.Loop.metric(:accuracy)
             |> Axon.Loop.validate(model, train)
             |> Axon.Loop.run(train, Axon.ModelState.empty(), epochs: 10)
@@ -525,7 +507,7 @@ defmodule Axon.IntegrationTest do
             |> Axon.Loop.metric(:accuracy)
             |> Axon.Loop.run(train, model_state)
 
-          assert %{0 => %{"accuracy" => final_model_val_accuracy}} = eval_results
+          assert %{metrics: %{0 => %{"accuracy" => final_model_val_accuracy}}} = eval_results
 
           assert_greater_equal(last_epoch_metrics["validation_accuracy"], 0.60)
           assert_all_close(final_model_val_accuracy, last_epoch_metrics["validation_accuracy"])
@@ -571,8 +553,6 @@ defmodule Axon.IntegrationTest do
         results =
           mp_model
           |> Axon.Loop.trainer(:categorical_cross_entropy, :adam, loss_scale: :dynamic)
-          # TODO: Fix default output transform
-          |> Map.update(:output_transform, nil, fn _ -> & &1 end)
           |> Axon.Loop.metric(:accuracy)
           |> Axon.Loop.validate(model, train)
           |> Axon.Loop.run(train, initial_state, epochs: 10)
@@ -586,7 +566,7 @@ defmodule Axon.IntegrationTest do
           |> Axon.Loop.metric(:accuracy)
           |> Axon.Loop.run(train, model_state)
 
-        assert %{0 => %{"accuracy" => final_model_val_accuracy}} = eval_results
+        assert %{metrics: %{0 => %{"accuracy" => final_model_val_accuracy}}} = eval_results
 
         assert_greater_equal(last_epoch_metrics["validation_accuracy"], 0.60)
         assert_all_close(final_model_val_accuracy, last_epoch_metrics["validation_accuracy"])

--- a/test/axon/loop_test.exs
+++ b/test/axon/loop_test.exs
@@ -6,15 +6,14 @@ defmodule Axon.LoopTest do
   alias Axon.Loop.State
 
   describe "factories" do
-    test "loop/3 creates a basic loop with defaults" do
+    test "loop/2 creates a basic loop with defaults" do
       step_fn = fn _, _ -> Nx.tensor(1) end
 
-      assert %Loop{init: init_fn, step: update_fn, output_transform: transform} =
+      assert %Loop{init: init_fn, step: update_fn} =
                Loop.loop(step_fn)
 
       assert_equal(init_fn.(Nx.tensor(1), %{}), %{})
       assert_equal(update_fn.({}, %{}), Nx.tensor(1))
-      assert_equal(transform.(%{}), %{})
     end
 
     test "trainer/3 returns a supervised training loop with basic case" do
@@ -40,22 +39,18 @@ defmodule Axon.LoopTest do
 
       for loss <- valid_axon_losses do
         for optimizer <- valid_axon_optimizers do
-          assert %Loop{init: init_fn, step: update_fn, output_transform: transform} =
+          assert %Loop{init: init_fn, step: update_fn} =
                    Loop.trainer(model, loss, optimizer)
 
           assert %{model_state: %Axon.ModelState{}} =
                    pstate =
                    init_fn.({Nx.tensor([[1]]), Nx.tensor([[1]])}, Axon.ModelState.empty())
 
-          state = %State{step_state: pstate}
-
           assert %{model_state: %{}, y_true: tar, y_pred: pred} =
                    apply(Nx.Defn.jit(update_fn), [{Nx.tensor([[1]]), Nx.tensor([[1]])}, pstate])
 
           assert_equal(tar, Nx.tensor([[1]]))
           assert_equal(pred, Nx.tensor([[1]]))
-
-          assert_equal(transform.(state), Axon.ModelState.empty())
         end
       end
     end
@@ -64,13 +59,11 @@ defmodule Axon.LoopTest do
       model = Axon.input("input", shape: {nil, 1})
       custom_loss_fn = fn _, _ -> Nx.tensor(5.0, backend: Nx.Defn.Expr) end
 
-      assert %Loop{init: init_fn, step: update_fn, output_transform: transform} =
+      assert %Loop{init: init_fn, step: update_fn} =
                Loop.trainer(model, custom_loss_fn, :adam)
 
       assert %{model_state: %{}} =
                pstate = init_fn.({Nx.tensor([[1]]), Nx.tensor([[1]])}, Axon.ModelState.empty())
-
-      state = %State{step_state: pstate}
 
       assert %{model_state: %{}, y_true: tar, y_pred: pred, loss: loss} =
                apply(Nx.Defn.jit(update_fn), [{Nx.tensor([[1]]), Nx.tensor([[1]])}, pstate])
@@ -78,49 +71,39 @@ defmodule Axon.LoopTest do
       assert_equal(tar, Nx.tensor([[1]]))
       assert_equal(pred, Nx.tensor([[1]]))
       assert_equal(loss, Nx.tensor(5.0))
-
-      assert_equal(transform.(state), Axon.ModelState.empty())
     end
 
     test "trainer/3 returns a supervised training loop with custom optimizer" do
       model = Axon.input("input", shape: {nil, 1})
       optimizer = Polaris.Optimizers.rmsprop(learning_rate: 1.0e-3)
 
-      assert %Loop{init: init_fn, step: update_fn, output_transform: transform} =
+      assert %Loop{init: init_fn, step: update_fn} =
                Loop.trainer(model, :mean_squared_error, optimizer)
 
       assert %{model_state: %{}} =
                pstate = init_fn.({Nx.tensor([[1]]), Nx.tensor([[1]])}, Axon.ModelState.empty())
 
-      state = %State{step_state: pstate}
-
       assert %{model_state: %{}, y_true: tar, y_pred: pred} =
                apply(Nx.Defn.jit(update_fn), [{Nx.tensor([[1]]), Nx.tensor([[1]])}, pstate])
 
       assert_equal(tar, Nx.tensor([[1]]))
       assert_equal(pred, Nx.tensor([[1]]))
-
-      assert_equal(transform.(state), Axon.ModelState.empty())
     end
 
     test "trainer/3 returns a supervised training loop with custom model" do
       model = Axon.input("input", shape: {nil, 1}) |> Axon.build(mode: :train)
 
-      assert %Loop{init: init_fn, step: update_fn, output_transform: transform} =
+      assert %Loop{init: init_fn, step: update_fn} =
                Loop.trainer(model, :mean_squared_error, :adam)
 
       assert %{model_state: %{}} =
                pstate = init_fn.({Nx.tensor([[1]]), Nx.tensor([[1]])}, Axon.ModelState.empty())
-
-      state = %State{step_state: pstate}
 
       assert %{model_state: %{}, y_true: tar, y_pred: pred} =
                apply(Nx.Defn.jit(update_fn), [{Nx.tensor([[1]]), Nx.tensor([[1]])}, pstate])
 
       assert_equal(tar, Nx.tensor([[1]]))
       assert_equal(pred, Nx.tensor([[1]]))
-
-      assert_equal(transform.(state), Axon.ModelState.empty())
     end
 
     test "trainer/3 returns a supervised training loop with multi-loss" do
@@ -128,7 +111,7 @@ defmodule Axon.LoopTest do
         {Axon.input("input_0", shape: {nil, 1}), Axon.input("input_1", shape: {nil, 1})}
         |> Axon.container()
 
-      assert %Loop{init: init_fn, step: update_fn, output_transform: transform} =
+      assert %Loop{init: init_fn, step: update_fn} =
                Loop.trainer(model, [mean_squared_error: 0.5, mean_absolute_error: 0.5], :adam)
 
       assert %{model_state: %{}} =
@@ -137,8 +120,6 @@ defmodule Axon.LoopTest do
                  {%{"input_0" => Nx.tensor([[2]]), "input_1" => Nx.tensor([[2]])}, Nx.tensor(0)},
                  Axon.ModelState.empty()
                )
-
-      state = %State{step_state: pstate}
 
       assert %{model_state: %{}, y_true: tar, y_pred: pred, loss: loss} =
                apply(Nx.Defn.jit(update_fn), [
@@ -150,8 +131,6 @@ defmodule Axon.LoopTest do
       assert_equal(tar, {Nx.tensor([[2]]), Nx.tensor([[2]])})
       assert_equal(pred, {Nx.tensor([[1]]), Nx.tensor([[1]])})
       assert_equal(loss, Nx.tensor(1.0))
-
-      assert_equal(transform.(state), Axon.ModelState.empty())
     end
 
     test "trainer/3 raises on bad inputs" do
@@ -182,21 +161,17 @@ defmodule Axon.LoopTest do
 
       expected_pred = Axon.predict(model, model_state, inp)
 
-      assert %Loop{init: init_fn, step: update_fn, output_transform: transform} =
+      assert %Loop{init: init_fn, step: update_fn} =
                Loop.evaluator(model)
 
       assert %{model_state: _, y_true: _, y_pred: _} =
                pstate = init_fn.({Nx.tensor([[1]]), Nx.tensor([[2]])}, model_state)
-
-      state = %State{step_state: pstate, metrics: %{"my_metric" => {}}}
 
       assert %{y_true: tar, y_pred: pred} =
                apply(Nx.Defn.jit(update_fn), [{Nx.tensor([[1]]), Nx.tensor([[2]])}, pstate])
 
       assert_equal(tar, Nx.tensor([[2]]))
       assert_equal(pred, expected_pred)
-
-      assert_equal(transform.(state), %{"my_metric" => {}})
     end
 
     test "evaluator/1 runs a supervised evaluator loop" do
@@ -212,7 +187,8 @@ defmodule Axon.LoopTest do
       assert %Loop{} = loop = Loop.metric(loop, :mean_absolute_error)
 
       assert ExUnit.CaptureIO.capture_io(fn ->
-               assert %{0 => %{"mean_absolute_error" => _}} = Loop.run(loop, data, model_state)
+               assert %State{metrics: %{0 => %{"mean_absolute_error" => _}}} =
+                        Loop.run(loop, data, model_state)
              end) =~ "Batch"
     end
 
@@ -286,7 +262,8 @@ defmodule Axon.LoopTest do
         |> Axon.Loop.validate(model, data)
 
       ExUnit.CaptureIO.capture_io(fn ->
-        assert %Axon.ModelState{} = Axon.Loop.run(loop, data, Axon.ModelState.empty(), epochs: 1)
+        assert %Axon.Loop.State{step_state: %{model_state: %Axon.ModelState{}}} =
+                 Axon.Loop.run(loop, data, Axon.ModelState.empty(), epochs: 1)
       end)
     end
 
@@ -349,7 +326,7 @@ defmodule Axon.LoopTest do
              end) =~ "Metric accuracy declared twice in loop."
     end
 
-    test "computes running average by default with supervised output transform" do
+    test "computes running average by default with supervised transform" do
       step_fn = fn _, _ -> 1 end
 
       loop =
@@ -372,7 +349,7 @@ defmodule Axon.LoopTest do
       assert_equal(avg_acc_fun.(cur_avg_acc, List.wrap(output), i), Nx.tensor(0.75))
     end
 
-    test "computes a running sum with custom output transform" do
+    test "computes a running sum with custom transform" do
       step_fn = fn _, _ -> 1 end
 
       loop =
@@ -925,7 +902,6 @@ defmodule Axon.LoopTest do
                event_counts: %{iteration_completed: %{total: 15}}
              } =
                loop
-               |> Map.put(:output_transform, & &1)
                |> Loop.checkpoint(event: :iteration_completed, filter: [every: {:epoch, 2}])
                |> Loop.run(data, Axon.ModelState.empty(), epochs: 3)
 
@@ -1022,8 +998,6 @@ defmodule Axon.LoopTest do
         state1 =
           model
           |> Axon.Loop.trainer(:binary_cross_entropy, :sgd)
-          # TODO: Make this an actual function or configurable
-          |> Map.put(:output_transform, & &1)
           |> Axon.Loop.run(data, Axon.ModelState.empty(), epochs: 3, iterations: 5)
 
         model
@@ -1111,7 +1085,7 @@ defmodule Axon.LoopTest do
 
       # Otherwise the mark would follow the caller out of the loop and donate
       # buffers they never offered on their next `Nx.Defn.jit` call.
-      assert map_leaves(result, &Nx.donatable?/1) |> Enum.uniq() == [false]
+      assert map_leaves(result.step_state, &Nx.donatable?/1) |> Enum.uniq() == [false]
     end
 
     test "donating state does not change the parameters a loop converges to" do
@@ -1121,7 +1095,7 @@ defmodule Axon.LoopTest do
 
       run = fn donate? ->
         ExUnit.CaptureIO.capture_io(fn ->
-          result =
+          %Axon.Loop.State{step_state: %{model_state: model_state}} =
             model
             |> Axon.Loop.trainer(
               :mean_squared_error,
@@ -1132,7 +1106,7 @@ defmodule Axon.LoopTest do
               donate_state?: donate?
             )
 
-          send(self(), {:result, result})
+          send(self(), {:result, model_state})
         end)
 
         assert_receive {:result, result}
@@ -1147,7 +1121,7 @@ defmodule Axon.LoopTest do
       data = donation_data()
 
       ExUnit.CaptureIO.capture_io(fn ->
-        assert %Axon.ModelState{} =
+        assert %Axon.Loop.State{step_state: %{model_state: %Axon.ModelState{}}} =
                  model
                  |> Axon.Loop.trainer(:mean_squared_error, :sgd)
                  |> Axon.Loop.run(data, Axon.ModelState.empty(),
@@ -1174,7 +1148,7 @@ defmodule Axon.LoopTest do
 
       run = fn donate? ->
         ExUnit.CaptureIO.capture_io(fn ->
-          result =
+          %Axon.Loop.State{step_state: %{model_state: model_state}} =
             model
             |> Axon.Loop.trainer(:mean_squared_error, :sgd)
             |> Axon.Loop.run(data, Nx.backend_copy(frozen_state),
@@ -1182,7 +1156,7 @@ defmodule Axon.LoopTest do
               donate_state?: donate?
             )
 
-          send(self(), {:result, result})
+          send(self(), {:result, model_state})
         end)
 
         assert_receive {:result, result}
@@ -1321,7 +1295,6 @@ defmodule Axon.LoopTest do
           |> Axon.Loop.metric(my_metric, "counter", :running_sum)
           |> Axon.Loop.early_stop("counter", mode: :min, patience: 2)
           # TODO: This API needs to change
-          |> Map.update(:output_transform, nil, fn _ -> & &1 end)
           |> Axon.Loop.run(data, Axon.ModelState.empty(), epochs: 5, iterations: 5)
 
         assert %{epoch: 3} = state
@@ -1349,7 +1322,6 @@ defmodule Axon.LoopTest do
           |> Axon.Loop.metric(my_metric, "counter", :running_sum)
           |> Axon.Loop.early_stop("counter", mode: :max, patience: 2)
           # TODO: This API needs to change
-          |> Map.update(:output_transform, nil, fn _ -> & &1 end)
           |> Axon.Loop.run(data, Axon.ModelState.empty(), epochs: 5, iterations: 5)
 
         assert %{epoch: 3} = state
@@ -1414,7 +1386,6 @@ defmodule Axon.LoopTest do
           |> Axon.Loop.metric(my_metric, "counter", :running_sum)
           |> Axon.Loop.reduce_lr_on_plateau("counter", factor: 0.5, mode: :min, patience: 2)
           # TODO: This API needs to change
-          |> Map.update(:output_transform, nil, fn _ -> & &1 end)
           |> Axon.Loop.run(data, Axon.ModelState.empty(), epochs: 7, iterations: 5)
 
         assert %{step_state: %{optimizer_state: optimizer_state}} = state
@@ -1450,7 +1421,6 @@ defmodule Axon.LoopTest do
           |> Axon.Loop.metric(my_metric, "counter", :running_sum)
           |> Axon.Loop.reduce_lr_on_plateau("counter", factor: 0.5, mode: :max, patience: 2)
           # TODO: This API needs to change
-          |> Map.update(:output_transform, nil, fn _ -> & &1 end)
           |> Axon.Loop.run(data, Axon.ModelState.empty(), epochs: 7, iterations: 5)
 
         assert %{step_state: %{optimizer_state: optimizer_state}} = state

--- a/test/axon/serialization_guide_test.exs
+++ b/test/axon/serialization_guide_test.exs
@@ -41,7 +41,7 @@ defmodule Axon.SerializationGuideTest do
         end)
 
       # Train
-      trained_model_state =
+      %Axon.Loop.State{step_state: %{model_state: trained_model_state}} =
         Axon.Loop.run(loop, train_data, Axon.ModelState.empty(), epochs: 2, iterations: 50)
 
       # Extract and save params (as in guide)
@@ -137,7 +137,7 @@ defmodule Axon.SerializationGuideTest do
       # Resume - should complete without error
       result = Axon.Loop.run(resumed_loop, train_data, Axon.ModelState.empty(), epochs: 2)
 
-      assert %Axon.ModelState{} = result
+      assert %Axon.Loop.State{step_state: %{model_state: %Axon.ModelState{}}} = result
     end
   end
 end


### PR DESCRIPTION
Closes #362.

Loops no longer carry an `output_transform`. `Axon.Loop.run/4` always returns the final `%Axon.Loop.State{}`, so you never accidentally lose the entire training state — callers extract what they need:

```elixir
%Axon.Loop.State{step_state: %{model_state: trained_model_state}} =
  Axon.Loop.run(loop, data)
```

## Breaking changes

* `Axon.Loop.loop/3` is now `Axon.Loop.loop/2` — step function plus an optional init function
* `Axon.Loop.trainer/4` no longer returns only `step_state.model_state`
* `Axon.Loop.evaluator/1` no longer returns only `state.metrics` (they're at `state.metrics[epoch]`)

## Notes

* `Axon.Loop.validate/4` was the only internal consumer of a transform; it now pattern matches `%State{metrics: %{0 => validation_metrics}}` off the evaluator run.
* Tests previously worked around the trainer's default transform with `Map.put(:output_transform, & &1)` (plus a `# TODO: Fix default output transform` comment). Those are all gone.
* The *metric* transform (`Axon.Loop.metric/5`'s last argument) was also called an "output transform" in docs and error messages. That naming is now just "transform" to avoid confusion with the removed concept — the argument itself is unchanged.
* Guides, notebooks, examples, the cheatsheet, and the README are updated to destructure the returned state. Stale cell outputs in the livemd guides were already out of date and were not regenerated.

## Verification

`mix test` → 822 passed (198 doctests, 624 tests).

`mix test --only integration` fails on the same pre-existing flaky set as the unmodified baseline (verified by stashing and re-running on `main`): `bce with simple xor model`, `f64 input test`, `image classification test`, `rnns static and dynamic unroll match`, and the mixed-precision accuracy checks vary run to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)