### PR TITLE
Log iteration instead of batch in Axon.Loop progress output

### DIFF
--- a/guides/training_and_evaluation/custom_models_loss_optimizers.livemd
+++ b/guides/training_and_evaluation/custom_models_loss_optimizers.livemd
@@ -117,7 +117,7 @@ Axon.Loop.run(loop, train_data, %{}, iterations: 500)
 <!-- livebook:{"output":true} -->
 
 ```
-Epoch: 0, Batch: 500, loss: 0.3053460
+Epoch: 0, Iteration: 500, loss: 0.3053460
 ```
 
 <!-- livebook:{"output":true} -->
@@ -270,7 +270,7 @@ model
 <!-- livebook:{"output":true} -->
 
 ```
-Epoch: 0, Batch: 1000, loss: 0.1098235
+Epoch: 0, Iteration: 1000, loss: 0.1098235
 ```
 
 <!-- livebook:{"output":true} -->
@@ -375,7 +375,7 @@ model
 <!-- livebook:{"output":true} -->
 
 ```
-Epoch: 0, Batch: 1000, loss: 0.0992607
+Epoch: 0, Iteration: 1000, loss: 0.0992607
 ```
 
 <!-- livebook:{"output":true} -->

--- a/guides/training_and_evaluation/instrumenting_loops_with_metrics.livemd
+++ b/guides/training_and_evaluation/instrumenting_loops_with_metrics.livemd
@@ -83,7 +83,7 @@ Axon.Loop.run(loop, train_data, %{}, iterations: 1000)
 <!-- livebook:{"output":true} -->
 
 ```
-Epoch: 0, Batch: 950, loss: 0.0590630 mean_absolute_error: 0.1463431
+Epoch: 0, Iteration: 950, loss: 0.0590630 mean_absolute_error: 0.1463431
 ```
 
 <!-- livebook:{"output":true} -->
@@ -151,7 +151,7 @@ model
 <!-- livebook:{"output":true} -->
 
 ```
-Epoch: 0, Batch: 950, loss: 0.0607362 model error: 0.1516546
+Epoch: 0, Iteration: 950, loss: 0.0607362 model error: 0.1516546
 ```
 
 <!-- livebook:{"output":true} -->
@@ -219,7 +219,7 @@ model
 <!-- livebook:{"output":true} -->
 
 ```
-Epoch: 0, Batch: 950, loss: 0.0688004 total error: 151.4876404
+Epoch: 0, Iteration: 950, loss: 0.0688004 total error: 151.4876404
 ```
 
 <!-- livebook:{"output":true} -->

--- a/guides/training_and_evaluation/using_loop_event_handlers.livemd
+++ b/guides/training_and_evaluation/using_loop_event_handlers.livemd
@@ -102,11 +102,11 @@ Axon.Loop.run(loop, train_data, %{}, epochs: 5, iterations: 100)
 <!-- livebook:{"output":true} -->
 
 ```
-Epoch: 0, Batch: 50, loss: 0.5345965
-Epoch: 1, Batch: 50, loss: 0.4578816
-Epoch: 2, Batch: 50, loss: 0.4527244
-Epoch: 3, Batch: 50, loss: 0.4466343
-Epoch: 4, Batch: 50, loss: 0.4401709
+Epoch: 0, Iteration: 50, loss: 0.5345965
+Epoch: 1, Iteration: 50, loss: 0.4578816
+Epoch: 2, Iteration: 50, loss: 0.4527244
+Epoch: 3, Iteration: 50, loss: 0.4466343
+Epoch: 4, Iteration: 50, loss: 0.4401709
 ```
 
 <!-- livebook:{"output":true} -->
@@ -174,15 +174,15 @@ model
 <!-- livebook:{"output":true} -->
 
 ```
-Epoch: 0, Batch: 50, loss: 0.3220241
+Epoch: 0, Iteration: 50, loss: 0.3220241
 epoch is over
-Epoch: 1, Batch: 50, loss: 0.2309804
+Epoch: 1, Iteration: 50, loss: 0.2309804
 epoch is over
-Epoch: 2, Batch: 50, loss: 0.1759415
+Epoch: 2, Iteration: 50, loss: 0.1759415
 epoch is over
-Epoch: 3, Batch: 50, loss: 0.1457551
+Epoch: 3, Iteration: 50, loss: 0.1457551
 epoch is over
-Epoch: 4, Batch: 50, loss: 0.1247821
+Epoch: 4, Iteration: 50, loss: 0.1247821
 epoch is over
 ```
 
@@ -251,11 +251,11 @@ model
 <!-- livebook:{"output":true} -->
 
 ```
-Epoch: 0, Batch: 50, loss: 0.3180207
-Epoch: 1, Batch: 50, loss: 0.1975918
-Epoch: 2, Batch: 50, loss: 0.1353940
-Epoch: 3, Batch: 50, loss: 0.1055405
-Epoch: 4, Batch: 50, loss: 0.0890203
+Epoch: 0, Iteration: 50, loss: 0.3180207
+Epoch: 1, Iteration: 50, loss: 0.1975918
+Epoch: 2, Iteration: 50, loss: 0.1353940
+Epoch: 3, Iteration: 50, loss: 0.1055405
+Epoch: 4, Iteration: 50, loss: 0.0890203
 ```
 
 <!-- livebook:{"output":true} -->

--- a/guides/training_and_evaluation/writing_custom_event_handlers.livemd
+++ b/guides/training_and_evaluation/writing_custom_event_handlers.livemd
@@ -102,15 +102,15 @@ Axon.Loop.run(loop, train_data, %{}, epochs: 5, iterations: 100)
 <!-- livebook:{"output":true} -->
 
 ```
-Epoch: 0, Batch: 50, loss: 0.0990703
+Epoch: 0, Iteration: 50, loss: 0.0990703
 My weird handler: fired
-Epoch: 1, Batch: 50, loss: 0.0567622
+Epoch: 1, Iteration: 50, loss: 0.0567622
 My weird handler: fired
-Epoch: 2, Batch: 50, loss: 0.0492784
+Epoch: 2, Iteration: 50, loss: 0.0492784
 My weird handler: fired
-Epoch: 3, Batch: 50, loss: 0.0462587
+Epoch: 3, Iteration: 50, loss: 0.0462587
 My weird handler: fired
-Epoch: 4, Batch: 50, loss: 0.0452806
+Epoch: 4, Iteration: 50, loss: 0.0452806
 My weird handler: fired
 ```
 
@@ -198,7 +198,7 @@ model
 <!-- livebook:{"output":true} -->
 
 ```
-Epoch: 0, Batch: 50, loss: 0.2201974
+Epoch: 0, Iteration: 50, loss: 0.2201974
 stopping loop
 ```
 
@@ -292,7 +292,7 @@ model
 <!-- livebook:{"output":true} -->
 
 ```
-Epoch: 0, Batch: 0, loss: 0.0000000
+Epoch: 0, Iteration: 0, loss: 0.0000000
 stopping epoch
 
 stopping epoch

--- a/guides/training_and_evaluation/writing_custom_metrics.livemd
+++ b/guides/training_and_evaluation/writing_custom_metrics.livemd
@@ -99,7 +99,7 @@ Axon.Loop.run(loop, train_data, %{}, iterations: 1000)
 <!-- livebook:{"output":true} -->
 
 ```
-Epoch: 0, Batch: 950, loss: 0.0681635 my weird metric: -5.2842808
+Epoch: 0, Iteration: 950, loss: 0.0681635 my weird metric: -5.2842808
 ```
 
 <!-- livebook:{"output":true} -->
@@ -229,7 +229,7 @@ Axon.Loop.run(loop, train_data, %{}, iterations: 1000)
 <!-- livebook:{"output":true} -->
 
 ```
-Epoch: 0, Batch: 950, dense_0_kernel_mean: -0.1978206 dense_0_kernel_var: 0.2699870 loss: 0.0605523
+Epoch: 0, Iteration: 950, dense_0_kernel_mean: -0.1978206 dense_0_kernel_var: 0.2699870 loss: 0.0605523
 ```
 
 <!-- livebook:{"output":true} -->
@@ -380,7 +380,7 @@ Axon.Loop.run(loop, train_data, %{}, iterations: 1000)
 <!-- livebook:{"output":true} -->
 
 ```
-Epoch: 0, Batch: 950, dense_0_kernel_ema_mean: -0.0139760 loss: 0.0682910
+Epoch: 0, Iteration: 950, dense_0_kernel_ema_mean: -0.0139760 loss: 0.0682910
 ```
 
 <!-- livebook:{"output":true} -->

--- a/guides/training_and_evaluation/your_first_evaluation_loop.livemd
+++ b/guides/training_and_evaluation/your_first_evaluation_loop.livemd
@@ -47,7 +47,7 @@ data =
 <!-- livebook:{"output":true} -->
 
 ```
-Epoch: 0, Batch: 950, loss: 0.1285532
+Epoch: 0, Iteration: 950, loss: 0.1285532
 ```
 
 <!-- livebook:{"output":true} -->
@@ -174,7 +174,7 @@ metrics
 <!-- livebook:{"output":true} -->
 
 ```
-Batch: 999, mean_absolute_error: 0.0856894
+Iteration: 999, mean_absolute_error: 0.0856894
 ```
 
 <!-- livebook:{"output":true} -->

--- a/guides/training_and_evaluation/your_first_training_loop.livemd
+++ b/guides/training_and_evaluation/your_first_training_loop.livemd
@@ -114,7 +114,7 @@ Axon.Loop.run(loop, train_data, %{}, iterations: 1000)
 <!-- livebook:{"output":true} -->
 
 ```
-Epoch: 0, Batch: 950, loss: 0.0563023
+Epoch: 0, Iteration: 950, loss: 0.0563023
 ```
 
 <!-- livebook:{"output":true} -->
@@ -188,9 +188,9 @@ Axon.Loop.run(loop, train_data, %{}, epochs: 3, iterations: 500)
 <!-- livebook:{"output":true} -->
 
 ```
-Epoch: 0, Batch: 450, loss: 0.0935063
-Epoch: 1, Batch: 450, loss: 0.0576384
-Epoch: 2, Batch: 450, loss: 0.0428323
+Epoch: 0, Iteration: 450, loss: 0.0935063
+Epoch: 1, Iteration: 450, loss: 0.0576384
+Epoch: 2, Iteration: 450, loss: 0.0428323
 ```
 
 <!-- livebook:{"output":true} -->
@@ -257,7 +257,7 @@ model
 <!-- livebook:{"output":true} -->
 
 ```
-Epoch: 0, Batch: 900, loss: 0.1492715
+Epoch: 0, Iteration: 900, loss: 0.1492715
 ```
 
 <!-- livebook:{"output":true} -->

--- a/lib/axon/loop.ex
+++ b/lib/axon/loop.ex
@@ -639,8 +639,10 @@ defmodule Axon.Loop do
 
   ## Options
 
-    * `:log` - training loss and metric log interval. Set to 0 to silence
-      training logs. Defaults to 50
+    * `:log` - training loss and metric log interval, in iterations. Every
+      `:log` iterations the loop writes a line of the form
+      `Epoch: 0, Iteration: 50, loss: 0.1234567` to standard output. Set to 0
+      to silence training logs. Defaults to 50
 
     * `:seed` - seed to use when constructing models. Seed controls random initialization
       of model parameters. Defaults to no seed which constructs a random seed for you at
@@ -710,9 +712,9 @@ defmodule Axon.Loop do
       |> Enum.join(" ")
 
     if log_epochs do
-      "\rEpoch: #{Nx.to_number(epoch)}, Batch: #{Nx.to_number(iter)}, #{metrics}"
+      "\rEpoch: #{Nx.to_number(epoch)}, Iteration: #{Nx.to_number(iter)}, #{metrics}"
     else
-      "\rBatch: #{Nx.to_number(iter)}, #{metrics}"
+      "\rIteration: #{Nx.to_number(iter)}, #{metrics}"
     end
   end
 
@@ -754,6 +756,9 @@ defmodule Axon.Loop do
         model
         |> Axon.Loop.evaluator()
         |> Axon.Loop.run(data, trained_model_state, compiler: EXLA)
+
+  The evaluator logs `Iteration: N, <metrics>` as it runs; an evaluation loop
+  runs a single pass over the data so no epoch is printed.
   """
   def evaluator(model) do
     {init_fn, step_fn} = eval_step(model)
@@ -931,7 +936,7 @@ defmodule Axon.Loop do
 
   In most cases, this is useful for inspecting the contents of
   the loop state at intermediate stages. For example, the default
-  `trainer` loop factory attaches IO logging of epoch, batch, loss
+  `trainer` loop factory attaches IO logging of epoch, iteration, loss
   and metrics.
 
   It's also possible to log loop state to files by changing the

--- a/test/axon/loop_test.exs
+++ b/test/axon/loop_test.exs
@@ -189,7 +189,7 @@ defmodule Axon.LoopTest do
       assert ExUnit.CaptureIO.capture_io(fn ->
                assert %State{metrics: %{0 => %{"mean_absolute_error" => _}}} =
                         Loop.run(loop, data, model_state)
-             end) =~ "Batch"
+             end) =~ "Iteration: 0, mean_absolute_error:"
     end
 
     test "eval_step/1 evaluates model on a single batch" do
@@ -474,6 +474,22 @@ defmodule Axon.LoopTest do
         |> Axon.Loop.trainer(:categorical_cross_entropy, :adam)
         |> Axon.Loop.run(data, %{})
       end
+    end
+
+    test "logs epoch and iteration" do
+      model = Axon.input("input", shape: {nil, 1}) |> Axon.dense(1)
+      data = [{Nx.tensor([[1.0]]), Nx.tensor([[2.0]])}]
+
+      loop = Axon.Loop.trainer(model, :mean_squared_error, :sgd, log: 1)
+
+      output =
+        ExUnit.CaptureIO.capture_io(fn ->
+          Axon.Loop.run(loop, data, Axon.ModelState.empty(), epochs: 2)
+        end)
+
+      assert output =~ "Epoch: 0, Iteration: 0, loss:"
+      assert output =~ "Epoch: 1, Iteration: 0, loss:"
+      refute output =~ "Batch"
     end
   end
 


### PR DESCRIPTION
Closes #609.

`Axon.Loop.trainer/4` and `Axon.Loop.evaluator/1` attach a default log handler whose output labels the loop counter as `Batch`:

```
Epoch: 0, Batch: 950, loss: 0.0563023
```

That label collides with the batch axis of the input tensors, so `Batch: 950` reads as "batch size 950" or "a batch with 950 rows". The number being printed is `%Axon.Loop.State{iteration: ...}`, the same counter the user controls with `Axon.Loop.run(loop, data, state, iterations: 1000)` and the same one behind `:iteration_started` / `:iteration_completed`. This PR labels it as what it is:

```
Epoch: 0, Iteration: 950, loss: 0.0563023
```

The evaluator, which runs a single pass and does not print an epoch, goes from `Batch: 999, mean_absolute_error: ...` to `Iteration: 999, mean_absolute_error: ...`.

## Why `Iteration` rather than `Step`

The issue thread floated both. `Iteration` wins because it is the name the public API already uses for exactly this counter: `State.iteration` and `State.max_iteration`, the `iterations:` option to `run/4`, the `:iteration_started` / `:iteration_completed` events, the `every: N` filter docs, and the default `checkpoint_{epoch}_{iteration}.ckpt` filename. `run(..., iterations: 1000)` printing `Iteration: 950` is immediately legible; `Step: 950` would introduce a third name for the same thing.

Inside `Axon.Loop`, "step" also already means something else: the step *function* and step *state* (`step_fn`, `step_state`, `train_step/4`, `eval_step/1`, `batch_step` in the moduledoc). Reusing it for the count would blur that.

The concern in the thread that "Iteration" alone could be read as either the global or the per-epoch count is handled by context. The trainer always prints `Epoch: E, Iteration: I` together, and the evaluator runs one pass so there is nothing to disambiguate. The only place Axon reports a global, cross-epoch counter is the `kino_vega_lite_plot/4` x-axis, which is already labeled `"step"` and is left alone since it is a different quantity.

No option is added to configure the label. Anyone who wants a different format already passes a custom `message_fn` to `Axon.Loop.log/3`, or builds the trainer with `log: 0` and attaches their own logger.

## What changed

- `supervised_log_message_fn/2` now emits `Iteration:` in both the epoch and epoch-less forms. The leading `\r` and everything else is unchanged, so the in-place progress line still renders the same way.
- The `trainer/4` `:log` option doc now states the interval is in iterations and shows the line format once. The `evaluator/1` doc mentions what it prints, and the `log/3` doc says "epoch, iteration, loss and metrics" instead of "epoch, batch, ...".
- All sample-output blocks in `guides/training_and_evaluation/*.livemd` (38 lines across 7 guides) are updated to match. Prose that genuinely talks about batches (step functions consuming a batch, `batch_step`, the `Logger.debug` "batch step execution" messages) is untouched.

`State.iteration`, the events and the `:iterations` option are not renamed; they were already consistent, and that would be an unrelated breaking change.

## Limitations

This is a cosmetic change to what is written to stdout. It only affects code that scrapes the training log for the literal `Batch:` prefix, which would need to look for `Iteration:` instead. Custom `Axon.Loop.log/3` message functions are unaffected.

## Tests

- The existing evaluator test now asserts the full `Iteration: 0, mean_absolute_error:` prefix rather than just `=~ "Batch"`, so a regression to either `Batch` or `Step` is caught.
- A new trainer test runs two epochs with `log: 1` and asserts `Epoch: 0, Iteration: 0, loss:` and `Epoch: 1, Iteration: 0, loss:` appear, and that `Batch` does not.

Both fail against the previous `supervised_log_message_fn/2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
