### PR TITLE
Diagnose partial initial model states and document Axon.build

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ model =
 
 {init_fn, predict_fn} = Axon.build(model, compiler: EXLA)
 
-params = init_fn.(Nx.template({1, 784}, :f32), %{})
+params = init_fn.(Nx.template({1, 784}, :f32), Axon.ModelState.empty())
 predict_fn.(params, input)
 ```
 

--- a/guides/cheatsheets/axon_pytorch.cheatmd
+++ b/guides/cheatsheets/axon_pytorch.cheatmd
@@ -317,7 +317,7 @@ model = Axon.input("input", shape: {nil, 784})
 # 3. Initialize parameters using an input shape template and a map with optional values for the parameters.
 #    The second argument is useful when loading saved parameters.
 input_template = Nx.template({1, 784}, :f32)
-params = init_fn.(input_template, %{})
+params = init_fn.(input_template, Axon.ModelState.empty())
 # `params` now holds the initialized parameters (e.g., a nested map)
 ```
 

--- a/guides/model_creation/complex_models.livemd
+++ b/guides/model_creation/complex_models.livemd
@@ -81,7 +81,7 @@ And you can use `Axon.build/2` on `out` as you would any other Axon model:
 ```
 
 ```elixir
-params = init_fn.(template, %{})
+params = init_fn.(template, Axon.ModelState.empty())
 predict_fn.(params, Nx.iota({2, 8}, type: :f32))
 ```
 

--- a/guides/model_creation/custom_layers.livemd
+++ b/guides/model_creation/custom_layers.livemd
@@ -121,7 +121,7 @@ graph TD;
 
 ```elixir
 {init_fn, predict_fn} = Axon.build(out)
-params = init_fn.(template, %{})
+params = init_fn.(template, Axon.ModelState.empty())
 ```
 
 <!-- livebook:{"output":true} -->
@@ -186,7 +186,7 @@ out = Axon.layer(&CustomLayers1.my_layer/3, [input, alpha], op_name: :my_layer)
 
 ```elixir
 {init_fn, predict_fn} = Axon.build(out)
-params = init_fn.(template, %{})
+params = init_fn.(template, Axon.ModelState.empty())
 ```
 
 <!-- livebook:{"output":true} -->

--- a/guides/model_creation/model_hooks.livemd
+++ b/guides/model_creation/model_hooks.livemd
@@ -32,7 +32,7 @@ model =
 {init_fn, predict_fn} = Axon.build(model)
 
 input = Nx.iota({2, 4}, type: :f32)
-params = init_fn.(input, %{})
+params = init_fn.(input, Axon.ModelState.empty())
 ```
 
 <!-- livebook:{"output":true} -->
@@ -118,7 +118,7 @@ model =
   |> Axon.relu()
 
 {init_fn, predict_fn} = Axon.build(model)
-params = init_fn.(input, %{})
+params = init_fn.(input, Axon.ModelState.empty())
 
 predict_fn.(params, input)
 ```
@@ -172,7 +172,7 @@ model =
 On initialization:
 
 ```elixir
-params = init_fn.(input, %{})
+params = init_fn.(input, Axon.ModelState.empty())
 ```
 
 <!-- livebook:{"output":true} -->
@@ -363,7 +363,7 @@ model =
   |> Axon.relu()
 
 {init_fn, predict_fn} = Axon.build(model, mode: :train)
-params = init_fn.(input, %{})
+params = init_fn.(input, Axon.ModelState.empty())
 ```
 
 <!-- livebook:{"output":true} -->
@@ -423,7 +423,7 @@ predict_fn.(params, input)
 
 ```elixir
 {init_fn, predict_fn} = Axon.build(model, mode: :inference)
-params = init_fn.(input, %{})
+params = init_fn.(input, Axon.ModelState.empty())
 ```
 
 <!-- livebook:{"output":true} -->

--- a/guides/model_creation/multi_input_multi_output_models.livemd
+++ b/guides/model_creation/multi_input_multi_output_models.livemd
@@ -72,7 +72,7 @@ graph TD;
 
 ```elixir
 {init_fn, predict_fn} = Axon.build(out)
-params = init_fn.(inputs, %{})
+params = init_fn.(inputs, Axon.ModelState.empty())
 ```
 
 <!-- livebook:{"output":true} -->
@@ -158,7 +158,7 @@ When executed, containers will return a data structure which matches their input
 
 ```elixir
 {init_fn, predict_fn} = Axon.build(out)
-params = init_fn.(template, %{})
+params = init_fn.(template, Axon.ModelState.empty())
 predict_fn.(params, Nx.iota({2, 8}, type: :f32))
 ```
 
@@ -199,7 +199,7 @@ out = Axon.container(%{x1: x1, x2: x2})
 
 ```elixir
 {init_fn, predict_fn} = Axon.build(out)
-params = init_fn.(template, %{})
+params = init_fn.(template, Axon.ModelState.empty())
 predict_fn.(params, Nx.iota({2, 8}, type: :f32))
 ```
 
@@ -242,7 +242,7 @@ out = Axon.container({%{x1: {x1, x2}, x2: %{x1: x1, x2: {x2}}}})
 
 ```elixir
 {init_fn, predict_fn} = Axon.build(out)
-params = init_fn.(template, %{})
+params = init_fn.(template, Axon.ModelState.empty())
 predict_fn.(params, Nx.iota({2, 8}, type: :f32))
 ```
 

--- a/guides/model_creation/sequential_models.livemd
+++ b/guides/model_creation/sequential_models.livemd
@@ -90,7 +90,7 @@ Your model is more involved and as a result so is the execution graph! Now, usin
 ```
 
 ```elixir
-params = init_fn.(template, %{})
+params = init_fn.(template, Axon.ModelState.empty())
 ```
 
 <!-- livebook:{"output":true} -->

--- a/guides/model_creation/your_first_axon_model.livemd
+++ b/guides/model_creation/your_first_axon_model.livemd
@@ -68,16 +68,16 @@ You can see this in action by actually executing your model. You can build the `
 Notice that `Axon.build/2` returns a tuple of `{init_fn, predict_fn}`. `init_fn` has the signature:
 
 ```
-init_fn.(template :: map(tensor) | tensor, initial_params :: map) :: map(tensor)
+init_fn.(template :: map(tensor) | tensor, initial_state :: Axon.ModelState.t()) :: Axon.ModelState.t()
 ```
 
 while `predict_fn` has the signature:
 
 ```
-predict_fn.(params :: map(tensor), input :: map(tensor) | tensor)
+predict_fn.(model_state :: Axon.ModelState.t(), input :: map(tensor) | tensor)
 ```
 
-`init_fn` returns all of your model's trainable parameters and state. You need to pass a template of the expected inputs because the shape of certain model parameters often depend on the shape of model inputs. You also need to pass any initial parameters you want your model to start with. This is useful for things like transfer learning, which you can read about in another guide.
+`init_fn` returns all of your model's trainable parameters and state. You need to pass a template of the expected inputs because the shape of certain model parameters often depend on the shape of model inputs. You also need to pass any initial parameters you want your model to start with. This is useful for things like transfer learning, which you can read about in another guide. Parameters missing from the initial state are initialized from scratch (and logged at `:debug` level when the initial state is not empty), while keys in the initial state that do not correspond to any model parameter are ignored with a warning.
 
 `predict_fn` returns transformed inputs from your model's trainable parameters and the given inputs.
 

--- a/guides/model_execution/accelerating_axon.livemd
+++ b/guides/model_execution/accelerating_axon.livemd
@@ -66,7 +66,7 @@ Now all tensors and operations on them will run on the configured backend:
   |> Nx.Random.uniform(shape: {2, 128})
 
 {init_fn, predict_fn} = Axon.build(model)
-params = init_fn.(inputs, %{})
+params = init_fn.(inputs, Axon.ModelState.empty())
 predict_fn.(params, inputs)
 ```
 
@@ -105,7 +105,7 @@ And now let's build another model, this time passing the EXLA compiler as an opt
   |> Nx.Random.uniform(shape: {2, 128})
 
 {init_fn, predict_fn} = Axon.build(model, compiler: EXLA)
-params = init_fn.(inputs, %{})
+params = init_fn.(inputs, Axon.ModelState.empty())
 predict_fn.(params, inputs)
 ```
 
@@ -159,8 +159,8 @@ exla_predict_fn = EXLA.jit(predict_fn)
 ```elixir
 Benchee.run(
   %{
-    "elixir init" => fn -> init_fn.(inputs, %{}) end,
-    "exla init" => fn -> exla_init_fn.(inputs, %{}) end
+    "elixir init" => fn -> init_fn.(inputs, Axon.ModelState.empty()) end,
+    "exla init" => fn -> exla_init_fn.(inputs, Axon.ModelState.empty()) end
   },
   time: 10,
   memory_time: 5,

--- a/guides/model_execution/training_and_inference_mode.livemd
+++ b/guides/model_execution/training_and_inference_mode.livemd
@@ -27,7 +27,7 @@ model =
   |> Axon.dense(1)
 
 {init_fn, predict_fn} = Axon.build(model)
-params = init_fn.(inputs, %{})
+params = init_fn.(inputs, Axon.ModelState.empty())
 predict_fn.(params, inputs)
 ```
 
@@ -47,7 +47,7 @@ You can also explicitly specify the mode:
 
 ```elixir
 {init_fn, predict_fn} = Axon.build(model, mode: :inference)
-params = init_fn.(inputs, %{})
+params = init_fn.(inputs, Axon.ModelState.empty())
 predict_fn.(params, inputs)
 ```
 
@@ -71,7 +71,7 @@ By specifying `mode: :train`, you tell your models to execute in training mode. 
 
 ```elixir
 {init_fn, predict_fn} = Axon.build(model, mode: :train)
-params = init_fn.(inputs, %{})
+params = init_fn.(inputs, Axon.ModelState.empty())
 predict_fn.(params, inputs)
 ```
 
@@ -108,7 +108,7 @@ model =
   |> Axon.dense(1)
 
 {init_fn, predict_fn} = Axon.build(model, mode: :train)
-params = init_fn.(inputs, %{})
+params = init_fn.(inputs, Axon.ModelState.empty())
 predict_fn.(params, inputs)
 ```
 

--- a/lib/axon.ex
+++ b/lib/axon.ex
@@ -106,7 +106,7 @@ defmodule Axon do
 
       {init_fn, predict_fn} = Axon.build(model1)
 
-      params1 = init_fn.(Nx.template({1, 1}, {:f, 32}), %{})
+      params1 = init_fn.(Nx.template({1, 1}, {:f, 32}), Axon.ModelState.empty())
       # Inputs are referenced by name
       predict_fn.(params1, %{"input_0" => x, "input_1" => y})
 
@@ -175,7 +175,7 @@ defmodule Axon do
 
       {init_fn, predict_fn} = Axon.build(model)
 
-      params = init_fn.(Nx.template({1, 1}, {:f, 32}), %{})
+      params = init_fn.(Nx.template({1, 1}, {:f, 32}), Axon.ModelState.empty())
       predict_fn.(params, inputs)
 
   You may either set the default JIT compiler or backend globally, or
@@ -185,7 +185,7 @@ defmodule Axon do
 
       {init_fn, predict_fn} = Axon.build(model, compiler: EXLA, mode: :train)
 
-      params = init_fn.(Nx.template({1, 1}, {:f, 32}), %{})
+      params = init_fn.(Nx.template({1, 1}, {:f, 32}), Axon.ModelState.empty())
       predict_fn.(params, inputs)
 
   `predict_fn` by default runs in inference mode, which performs certain

--- a/lib/axon.ex
+++ b/lib/axon.ex
@@ -4377,19 +4377,67 @@ defmodule Axon do
 
   ## `init_fn`
 
-  The `init_fn` receives two arguments, the input template and
-  an optional map with initial parameters for layers:
+  The `init_fn` receives two arguments, an input template (a tensor,
+  an `Nx.template/2`, or a container/map of them matching the model
+  inputs) and an `Axon.ModelState` with initial parameters. It returns
+  a new `Axon.ModelState` holding every parameter and state entry the
+  model declares:
 
       {init_fn, predict_fn} = Axon.build(model)
-      init_fn.(Nx.template({1, 1}, {:f, 32}), %{"dense_0" => dense_params})
+
+      # initialize everything from the layers' initializers
+      model_state = init_fn.(Nx.template({1, 1}, :f32), Axon.ModelState.empty())
+
+      # start from pre-trained parameters for some layers
+      model_state =
+        init_fn.(
+          Nx.template({1, 1}, :f32),
+          Axon.ModelState.new(%{"dense_0" => dense_params})
+        )
+
+  Initialization is a pure function: the model (`%Axon{}`) never carries
+  parameters, nothing is allocated or cached on the backend, and calling
+  `init_fn` again returns an equivalent state. The template is needed
+  only because parameter shapes depend on input shapes; no computation
+  is run on the template values.
+
+  Given an initial state, `init_fn`:
+
+    * uses the tensors found in the initial state for the parameters
+      they name, casting them to the model's precision policy when the
+      types differ (a warning is logged when a cast happens);
+
+    * initializes every parameter that is not present in the initial
+      state from the layer's initializer. When the initial state is not
+      empty, the initialized parameters are logged at `:debug` level so
+      you can verify that a set of loaded parameters covered the whole
+      model;
+
+    * ignores keys in the initial state that do not correspond to any
+      parameter of the model and logs them in a warning, which is useful
+      for tracking down naming mismatches when porting parameters from
+      other frameworks.
+
+  Because of this, running `init_fn` with your loaded parameters is the
+  recommended way to validate them before inference.
 
   ## `predict_fn`
 
-  The `predict_fn` receives two arguments, the trained parameters
-  and the actual inputs:
+  The `predict_fn` receives two arguments, a model state (typically the
+  one returned by `init_fn` or a trained one) and the actual inputs:
 
       {_init_fn, predict_fn} = Axon.build(model, opts)
-      predict_fn.(params, input)
+      predict_fn.(model_state, input)
+
+  `predict_fn` is also a pure function of its arguments: it does not
+  mutate the model state or keep hidden state on the backend, so the
+  same state and inputs always produce the same output. In `:inference`
+  mode (the default) it returns the model output. In `:train` mode it
+  returns `%{prediction: output, state: updated_state}`, where
+  `updated_state` contains the layer state (such as batch normalization
+  statistics) computed during the forward pass; it is up to the caller
+  to merge it back with `Axon.ModelState.update/3`, which is what
+  `Axon.Loop` does.
 
   ## Options
 
@@ -4398,8 +4446,9 @@ defmodule Axon do
       passed, it uses the default compiler configured in `Nx.Defn`;
 
     * `:debug` - if `true`, will log graph traversal and generation
-      metrics. Also forwarded to JIT if debug mode is available
-      for your chosen compiler or backend. Defaults to `false`
+      timing metrics with `Logger.debug/1`. Also forwarded to JIT if
+      debug mode is available for your chosen compiler or backend.
+      Defaults to `false`
 
     * `:print_values` - if `true`, will print intermediate layer
       values to the screen for inspection. This is useful if you need

--- a/lib/axon/compiler.ex
+++ b/lib/axon/compiler.ex
@@ -178,10 +178,9 @@ defmodule Axon.Compiler do
           params
         end)
 
-      out =
-        params
-        |> normalize_blocks(model_state_meta)
-        |> merge_model_state!(init_model_state)
+      initialized = normalize_blocks(params, model_state_meta)
+      log_initialized_parameters(initialized.data, init_model_state.data)
+      out = merge_model_state!(initialized, init_model_state)
 
       if debug? do
         Logger.debug("Axon finished init expression generation in #{us_to_ms(time)}ms")
@@ -295,22 +294,75 @@ defmodule Axon.Compiler do
     end
   end
 
-  defp merge_model_state!(state, init_state) do
-    %{state | data: merge_params!(state.data, init_state.data)}
+  defp log_initialized_parameters(_data, init_data) when init_data == %{}, do: :ok
+
+  defp log_initialized_parameters(data, init_data) do
+    case missing_paths(data, init_data, []) do
+      [] ->
+        :ok
+
+      paths ->
+        Logger.debug(
+          "the following parameters were not present in the initial model state" <>
+            " and were initialized from scratch: " <> format_paths(paths)
+        )
+    end
   end
 
-  defp merge_params!(params, init_params) do
-    Enum.reduce(init_params, params, fn {key, value}, params ->
+  # Leaves in `data` (the freshly initialized state) that have no
+  # counterpart in `init_data`. Paths are accumulated in reverse.
+  defp missing_paths(data, init_data, path) do
+    Enum.flat_map(data, fn
+      {key, %{} = nested} when not is_struct(nested) ->
+        case init_data do
+          %{^key => %{} = init_nested} when not is_struct(init_nested) ->
+            missing_paths(nested, init_nested, [key | path])
+
+          %{^key => _} ->
+            []
+
+          _ ->
+            missing_paths(nested, %{}, [key | path])
+        end
+
+      {key, _leaf} ->
+        if Map.has_key?(init_data, key), do: [], else: [[key | path]]
+    end)
+  end
+
+  defp format_paths(paths) do
+    paths
+    |> Enum.map(&Enum.join(Enum.reverse(&1), "."))
+    |> Enum.sort()
+    |> Enum.map_join(", ", &inspect/1)
+  end
+
+  defp merge_model_state!(state, init_state) do
+    {data, unexpected} = merge_params!(state.data, init_state.data, [])
+
+    if unexpected != [] do
+      Logger.warning(
+        "the following keys in the initial model state do not correspond to any" <>
+          " parameter of the model and were ignored: " <> format_paths(unexpected)
+      )
+    end
+
+    %{state | data: data}
+  end
+
+  defp merge_params!(params, init_params, path) do
+    Enum.reduce(init_params, {params, []}, fn {key, value}, {params, unexpected} ->
       case params do
         %{^key => %{} = nested} when not is_struct(nested) ->
-          %{params | key => merge_params!(nested, value)}
+          {merged, nested_unexpected} = merge_params!(nested, value, [key | path])
+          {%{params | key => merged}, nested_unexpected ++ unexpected}
 
         %{^key => template} ->
-          %{params | key => merge_type(key, template, value)}
+          name = Enum.join(Enum.reverse([key | path]), ".")
+          {%{params | key => merge_type(name, template, value)}, unexpected}
 
         _ ->
-          Logger.warning("found unexpected key in the initial parameters map: #{inspect(key)}")
-          params
+          {params, [[key | path] | unexpected]}
       end
     end)
   end

--- a/test/axon/compiler_test.exs
+++ b/test/axon/compiler_test.exs
@@ -5781,6 +5781,123 @@ defmodule CompilerTest do
     end
   end
 
+  describe "initial state diagnostics" do
+    @describetag :capture_log
+
+    test "logs parameters initialized from scratch when initial state is partial" do
+      model =
+        Axon.input("input", shape: {nil, 1})
+        |> Axon.dense(2, name: "dense_0")
+        |> Axon.dense(2, name: "dense_1")
+
+      {init_fn, _} = Axon.build(model)
+      template = Nx.template({1, 1}, :f32)
+
+      %ModelState{data: %{"dense_0" => dense_0}} = init_fn.(template, ModelState.empty())
+
+      log =
+        capture_log(fn ->
+          init_fn.(template, ModelState.new(%{"dense_0" => dense_0}))
+        end)
+
+      assert log =~
+               "were initialized from scratch: \"dense_1.bias\", \"dense_1.kernel\""
+
+      refute log =~ "dense_0.kernel"
+      refute log =~ "were ignored"
+    end
+
+    test "does not log initialized parameters for an empty initial state" do
+      model = Axon.input("input", shape: {nil, 1}) |> Axon.dense(2)
+      {init_fn, _} = Axon.build(model)
+
+      refute capture_log(fn -> init_fn.(Nx.template({1, 1}, :f32), ModelState.empty()) end) =~
+               "initialized from scratch"
+    end
+
+    test "warns once with full paths for unexpected keys" do
+      model = Axon.input("input", shape: {nil, 1}) |> Axon.dense(2, name: "dense_0")
+      {init_fn, _} = Axon.build(model)
+      template = Nx.template({1, 1}, :f32)
+      %ModelState{data: %{"dense_0" => dense_0}} = init_fn.(template, ModelState.empty())
+
+      init_state =
+        ModelState.new(%{
+          "dense_0" => Map.put(dense_0, "foo", Nx.tensor(1.0)),
+          "dense_9" => %{"kernel" => Nx.tensor(1.0)}
+        })
+
+      log = capture_log(fn -> init_fn.(template, init_state) end)
+
+      # an entirely unknown subtree is reported by its root
+      assert log =~ "were ignored: \"dense_0.foo\", \"dense_9\""
+      # one aggregated warning, not one line per key
+      assert length(String.split(log, "were ignored")) == 2
+      refute log =~ "initialized from scratch"
+    end
+
+    test "uses nested paths for block parameters" do
+      block = Axon.block(&Axon.dense(&1, 2, name: "dense_0"))
+      model = Axon.input("input", shape: {nil, 1}) |> block.()
+
+      {init_fn, _} = Axon.build(model)
+      template = Nx.template({1, 1}, :f32)
+
+      %ModelState{data: %{"block_0" => %{"dense_0" => dense_0}}} =
+        init_fn.(template, ModelState.empty())
+
+      init_state =
+        ModelState.new(%{
+          "block_0" => %{"dense_0" => Map.delete(dense_0, "bias"), "extra" => Nx.tensor(1.0)}
+        })
+
+      log = capture_log(fn -> init_fn.(template, init_state) end)
+
+      assert log =~ "initialized from scratch: \"block_0.dense_0.bias\""
+      assert log =~ "were ignored: \"block_0.extra\""
+    end
+
+    test "uses nested paths for composite parameters" do
+      {model, _} = Axon.input("input", shape: {nil, 2, 1}) |> Axon.lstm(2, name: "lstm")
+
+      {init_fn, _} = Axon.build(model)
+      template = Nx.template({1, 2, 1}, :f32)
+
+      %ModelState{data: %{"lstm" => lstm}} = init_fn.(template, ModelState.empty())
+
+      init_state =
+        ModelState.new(%{
+          "lstm" => Map.update!(lstm, "input_kernel", &Map.delete(&1, "wii"))
+        })
+
+      log = capture_log(fn -> init_fn.(template, init_state) end)
+
+      assert log =~ "initialized from scratch: \"lstm.input_kernel.wii\""
+    end
+
+    test "names the full path when casting initial parameters to the policy" do
+      block = Axon.block(&Axon.dense(&1, 2, name: "dense_0"))
+      model = Axon.input("input", shape: {nil, 1}) |> block.()
+
+      {init_fn, _} = Axon.build(model)
+      template = Nx.template({1, 1}, :f32)
+
+      %ModelState{data: %{"block_0" => %{"dense_0" => dense_0}}} =
+        init_fn.(template, ModelState.empty())
+
+      init_state =
+        ModelState.new(%{
+          "block_0" => %{
+            "dense_0" => Map.update!(dense_0, "kernel", &Nx.as_type(&1, :f16))
+          }
+        })
+
+      log = capture_log(fn -> init_fn.(template, init_state) end)
+
+      assert log =~ "initial type for parameter block_0.dense_0.kernel does not match policy"
+    end
+  end
+
   describe "instrumentation" do
     @describetag :capture_log
 


### PR DESCRIPTION
Closes #475.

Most of the concrete asks in that thread have already landed: the `Axon.CompileError` message now points at `debug: true` for the "layer was defined at" section, `Axon.block` and `Axon.namespace/2,3` give parameter maps grouping/nesting, and `Axon.elem/3` / `Axon.fetch/3` destructure containers. The Livebook table truncation and the unpickler location were answered in the thread as not being Axon changes. Two asks were still open, and this PR resolves them.

## Initial-state diagnostics in `init_fn`

The reporter asked for stricter modes that flag parameters that were missing from the supplied parameter map (and therefore silently initialized) and extra unused data in the map. The maintainer position in the thread was not to raise, because partially initializing a model is a normal training / transfer-learning workflow, but to do what Bumblebee's loader does and log the missing parameters at debug level, and to log unused parameters as well.

`init_fn` now does both, and always names parameters by their full dotted path:

* When the initial state is not empty, every parameter that was absent from it and had to be initialized from the layer's initializer is listed in one `Logger.debug` line. With `Axon.ModelState.empty()` nothing is logged, since every parameter is "missing" and the line would be noise.
* Keys in the initial state that do not correspond to any model parameter are collected into one `Logger.warning` line with their full paths. Previously this was one warning per key with only the leaf name, so a naming mismatch in a large model produced hundreds of `found unexpected key ...: "kernel"` lines that did not say which layer was affected. An entirely unknown subtree is reported by its root (`"dense_9"`) rather than by every leaf under it.
* The existing "initial type for parameter ... does not match policy" warning now also names the full path.

Paths follow the structure of `Axon.ModelState.data`, so `Axon.block` sub-states appear as `"block_0.dense_0.kernel"` and composite parameters as `"lstm.input_kernel.wii"`. Quantized tensors and shared parameters are structs and are treated as leaves.

For example, loading a state that misspells one key and covers only the first layer:

```elixir
model =
  Axon.input("input", shape: {nil, 1})
  |> Axon.dense(2, name: "dense_0")
  |> Axon.dense(2, name: "dense_1")

{init_fn, _} = Axon.build(model)
init_fn.(Nx.template({1, 1}, :f32), Axon.ModelState.new(%{"dense_0" => %{"kernel" => k, "bais" => b}}))
```

logs

```
[debug] the following parameters were not present in the initial model state and were initialized from scratch: "dense_0.bias", "dense_1.bias", "dense_1.kernel"
[warning] the following keys in the initial model state do not correspond to any parameter of the model and were ignored: "dense_0.bais"
```

Tradeoffs: the missing-parameter report is at `:debug` rather than `:warning` or an exception, following the maintainer's comment; users validating a ported checkpoint can raise their log level. The check lives in `init_fn` (the natural point where the supplied state meets the model's declared parameters) rather than in `predict_fn`, and the `Axon.build` docs now recommend running `init_fn` with loaded parameters as the way to validate them. No new `Axon.build` option was added. Because `init_fn` is JIT-compiled and cached by argument signature, a repeated call with an identical signature may not re-trace and therefore may not re-log; this was already true of the existing warnings. Merge semantics are unchanged: this only changes what is logged.

## `Axon.build/2` docs and guides

The reporter also asked whether `predict_fn` mutates backend state or whether `init_fn` copies parameters to the backend, and proposed wording for the docs. The `init_fn` / `predict_fn` sections of `Axon.build/2` now explain that both are pure functions of their arguments, that the model never carries parameters and nothing is cached on the backend, why a template is needed, what `init_fn` does with an initial state (use, cast, initialize, ignore-with-warning), and what `predict_fn` returns in `:inference` versus `:train` mode. The old example passed a bare map to `init_fn`, which now triggers a deprecation warning; it uses `Axon.ModelState.new/1` and `Axon.ModelState.empty/0` instead. The 22 `init_fn.(x, %{})` call sites in the guides, the three in the `Axon` moduledoc and the one in the README were updated the same way, and the signature description in the "Your first Axon model" guide now uses `Axon.ModelState.t()`. Livebook output blocks were left untouched.

## Out of scope

A scale-factor form of `Axon.resize` for inputs with `nil` spatial dimensions was raised late in the thread and never answered by the maintainers; it is a separate layer feature and not addressed here. A predict-time unused-key check is also not added, since `init_fn` is where the supplied state is reconciled with the model.

## Tests

`test/axon/compiler_test.exs` gains an "initial state diagnostics" describe block covering: the debug line for a partial state (and that present parameters are not listed), no debug line for an empty state, a single aggregated warning with full paths for unexpected keys (including an unknown subtree reported by its root), nested paths through `Axon.block`, nested paths through a composite LSTM parameter, and the full path in the type-cast warning. Five of the six fail on `main`. `mix test`: 883 passed (200 doctests, 683 tests), 47 excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

