### PR TITLE
Optionally keep gradients in the training step state

### DIFF
--- a/lib/axon/loop.ex
+++ b/lib/axon/loop.ex
@@ -320,15 +320,39 @@ defmodule Axon.Loop do
     * `:loss_scale` - type of loss-scaling to use, if any. Loss-scaling is necessary when
       doing mixed precision training for numerical stability. Defaults to `:identity` or
       no loss-scaling.
+
+    * `:keep_gradients?` - whether to keep the gradients computed on each
+      iteration in the step state under the `:gradients` key. The gradients
+      have the same structure as `Axon.ModelState.trainable_parameters/1`
+      and are the unscaled gradients passed to the optimizer, before any
+      optimizer transformations such as clipping. Keeping them costs an extra
+      parameter-sized buffer per iteration. Defaults to `false`.
   """
   def train_step(model, loss, optimizer, opts \\ []) do
-    opts = Keyword.validate!(opts, [:seed, loss_scale: :identity])
+    opts = Keyword.validate!(opts, [:seed, loss_scale: :identity, keep_gradients?: false])
     loss_scale = opts[:loss_scale] || :identity
+    keep_gradients? = opts[:keep_gradients?]
 
-    {init_model_fn, forward_model_fn} = build_model_fns(model, :train, opts)
+    {init_model_fn, forward_model_fn} =
+      build_model_fns(model, :train, Keyword.take(opts, [:seed]))
+
     loss_fn = build_loss_fn(loss)
     {init_optimizer_fn, update_optimizer_fn} = build_optimizer_fns(optimizer)
     {init_loss_scale, scale_loss, unscale_grads} = build_loss_scale_fns(loss_scale)
+
+    objective_fn = fn trainable_parameters, model_state, loss_scale_state, inp, tar ->
+      # hack to use trainable parameters as grad
+      model_state =
+        update_in(model_state, [Access.key!(:data)], fn data ->
+          tree_merge(data, trainable_parameters, fn _, _, v -> v end)
+        end)
+
+      model_out = forward_model_fn.(model_state, inp)
+      unscaled_loss = loss_fn.(tar, model_out.prediction)
+      scaled_loss = scale_loss.(unscaled_loss, loss_scale_state)
+
+      {model_out, scaled_loss, unscaled_loss}
+    end
 
     init_fn = fn
       {inp, tar}, %{} = init_model_state ->
@@ -344,7 +368,7 @@ defmodule Axon.Loop do
         # is never referenced by the returned state and never lowered.
         %{prediction: output} = forward_model_fn.(model_state, inp)
 
-        %{
+        step_state = %{
           i: Nx.tensor(0),
           y_true: zeros_like(tar),
           y_pred: zeros_like(output),
@@ -354,22 +378,29 @@ defmodule Axon.Loop do
           loss_scale_state: loss_scale_state
         }
 
+        if keep_gradients? do
+          # Same trick as the prediction above: trace the backward pass to
+          # learn the shape and type of the gradients the step will produce.
+          # The gradient type is not always the parameter type (the backward
+          # pass is seeded with an f32 constant and loss scales unscale with
+          # an f32 scalar), and the template must match the step output
+          # exactly for the loop to compile. Only the template is kept, the
+          # traced expression is never lowered.
+          {_, gradients} =
+            Nx.Defn.value_and_grad(
+              trainable_parameters,
+              &objective_fn.(&1, model_state, loss_scale_state, inp, tar),
+              fn x -> elem(x, 1) end
+            )
+
+          {gradients, _} = unscale_grads.(gradients, loss_scale_state)
+          Map.put(step_state, :gradients, zeros_like(gradients))
+        else
+          step_state
+        end
+
       data, state ->
         raise_bad_training_inputs!(data, state)
-    end
-
-    objective_fn = fn trainable_parameters, model_state, loss_scale_state, inp, tar ->
-      # hack to use trainable parameters as grad
-      model_state =
-        update_in(model_state, [Access.key!(:data)], fn data ->
-          tree_merge(data, trainable_parameters, fn _, _, v -> v end)
-        end)
-
-      model_out = forward_model_fn.(model_state, inp)
-      unscaled_loss = loss_fn.(tar, model_out.prediction)
-      scaled_loss = scale_loss.(unscaled_loss, loss_scale_state)
-
-      {model_out, scaled_loss, unscaled_loss}
     end
 
     step_fn = fn
@@ -409,7 +440,7 @@ defmodule Axon.Loop do
 
         new_model_state = Axon.ModelState.update(model_state, updated_parameters, updated_state)
 
-        %{
+        new_state = %{
           state
           | i: Nx.add(i, 1),
             y_true: tar,
@@ -419,6 +450,12 @@ defmodule Axon.Loop do
             optimizer_state: new_optimizer_state,
             loss_scale_state: new_loss_scale_state
         }
+
+        if keep_gradients? do
+          %{new_state | gradients: gradients}
+        else
+          new_state
+        end
 
       data, state ->
         raise_bad_training_inputs!(data, state)
@@ -591,7 +628,8 @@ defmodule Axon.Loop do
         y_true: tensor() | container(tensor()), # True labels for use in metrics
         loss: tensor(), # Running average of loss over epoch
         model_state: container(tensor()), # Model parameters and state
-        optimizer_state: container(tensor()) # Optimizer state associated with each parameter
+        optimizer_state: container(tensor()), # Optimizer state associated with each parameter
+        gradients: container(tensor()) # Gradients of the last batch, only when keep_gradients?: true
       }
 
   `Axon.Loop.run/4` returns the final `%Axon.Loop.State{}`, so you can extract the
@@ -637,6 +675,28 @@ defmodule Axon.Loop do
       |> Axon.Loop.trainer(loss_weights, :sgd)
       |> Axon.Loop.run(data)
 
+  ### Inspecting gradients
+
+  With `keep_gradients?: true` the gradients of each batch are kept in the
+  step state under `:gradients`, so metrics and event handlers can read them.
+  Note the metric transform is the list `[:gradients]`, which passes the
+  gradient container as the single argument to the metric function:
+
+      grad_norm = fn grads ->
+        grads
+        |> Nx.Defn.Composite.reduce(Nx.tensor(0.0), fn g, acc -> Nx.add(acc, Nx.sum(Nx.pow(g, 2))) end)
+        |> Nx.sqrt()
+      end
+
+      model
+      |> Axon.Loop.trainer(:mean_squared_error, :adam, keep_gradients?: true)
+      |> Axon.Loop.metric(grad_norm, "gradient norm", :running_average, [:gradients])
+      |> Axon.Loop.handle_event(:iteration_completed, fn state ->
+        IO.inspect(state.step_state.gradients["dense_0"]["kernel"], label: "kernel gradient")
+        {:continue, state}
+      end)
+      |> Axon.Loop.run(data, Axon.ModelState.empty(), epochs: 5)
+
   ## Options
 
     * `:log` - training loss and metric log interval. Set to 0 to silence
@@ -649,13 +709,20 @@ defmodule Axon.Loop do
     * `:loss_scale` - type of loss-scaling to use, if any. Loss-scaling is necessary when
       doing mixed precision training for numerical stability. Defaults to `:identity` or
       no loss-scaling.
+
+    * `:keep_gradients?` - whether to keep the gradients computed on each
+      iteration in the step state under the `:gradients` key. The gradients
+      have the same structure as `Axon.ModelState.trainable_parameters/1`
+      and are the unscaled gradients passed to the optimizer, before any
+      optimizer transformations such as clipping. Keeping them costs an extra
+      parameter-sized buffer per iteration. Defaults to `false`.
   """
   def trainer(model, loss, optimizer, opts \\ []) do
-    opts = Keyword.validate!(opts, [:seed, :loss_scale, log: 50])
+    opts = Keyword.validate!(opts, [:seed, :loss_scale, :keep_gradients?, log: 50])
 
     # Build loss now so we can use it as a metric
     loss_fn = build_loss_fn(loss)
-    step_opts = Keyword.take(opts, [:loss_scale, :seed])
+    step_opts = Keyword.take(opts, [:loss_scale, :seed, :keep_gradients?])
     {init_fn, step_fn} = train_step(model, loss_fn, optimizer, step_opts)
 
     log_interval = opts[:log] || 50

--- a/test/axon/loop_test.exs
+++ b/test/axon/loop_test.exs
@@ -291,6 +291,206 @@ defmodule Axon.LoopTest do
     end
   end
 
+  describe "keep_gradients?" do
+    defp gradients_model do
+      Axon.input("input", shape: {nil, 1}) |> Axon.dense(1, name: "dense", use_bias: false)
+    end
+
+    defp gradients_batch do
+      {Nx.tensor([[1.0], [2.0]]), Nx.tensor([[0.0], [0.0]])}
+    end
+
+    # Asserts every leaf of the init template has the shape and type of the
+    # corresponding leaf of the step output. This is what strict compilation
+    # in `Axon.Loop.run/4` requires of the step state.
+    defp assert_same_template(template, output) do
+      template_leaves = Nx.Defn.Composite.flatten_list([template])
+      output_leaves = Nx.Defn.Composite.flatten_list([output])
+      assert length(template_leaves) == length(output_leaves)
+
+      for {leaf, expected} <- Enum.zip(template_leaves, output_leaves) do
+        assert Nx.shape(leaf) == Nx.shape(expected)
+        assert Nx.type(leaf) == Nx.type(expected)
+      end
+    end
+
+    defp grad_norm(grads) do
+      grads
+      |> Nx.Defn.Composite.reduce(Nx.tensor(0.0), fn g, acc ->
+        Nx.add(acc, Nx.sum(Nx.pow(g, 2)))
+      end)
+      |> Nx.sqrt()
+    end
+
+    test "train_step/4 does not add gradients to the step state by default" do
+      model = gradients_model()
+      batch = gradients_batch()
+
+      {init_fn, step_fn} = Axon.Loop.train_step(model, :mean_squared_error, :sgd)
+
+      state = init_fn.(batch, Axon.ModelState.empty())
+      refute Map.has_key?(state, :gradients)
+
+      state = step_fn.(batch, state)
+      refute Map.has_key?(state, :gradients)
+    end
+
+    test "train_step/4 returns the gradients the optimizer received" do
+      model = gradients_model()
+      {x, y} = batch = gradients_batch()
+
+      {init_fn, step_fn} =
+        Axon.Loop.train_step(
+          model,
+          :mean_squared_error,
+          Polaris.Optimizers.sgd(learning_rate: 0.1),
+          keep_gradients?: true
+        )
+
+      state = init_fn.(batch, Axon.ModelState.empty())
+      kernel = state.model_state.data["dense"]["kernel"]
+
+      assert %{"dense" => %{"kernel" => init_grad}} = state.gradients
+      assert map_size(state.gradients) == 1
+      assert_equal(init_grad, Nx.broadcast(0.0, {1, 1}))
+      assert Nx.shape(init_grad) == Nx.shape(kernel)
+      assert Nx.type(init_grad) == Nx.type(kernel)
+
+      new_state = step_fn.(batch, state)
+      new_kernel = new_state.model_state.data["dense"]["kernel"]
+
+      assert %{"dense" => %{"kernel" => grad}} = new_state.gradients
+      assert map_size(new_state.gradients) == 1
+
+      # loss = mean((w * x)^2) with x = [1, 2] is 2.5 * w^2, so the gradient
+      # is 5 * w, and plain SGD applies w - lr * grad.
+      assert_all_close(grad, Nx.multiply(kernel, 5.0))
+      assert_all_close(grad, Nx.divide(Nx.subtract(kernel, new_kernel), 0.1))
+      assert_equal(new_state.y_true, y)
+      assert_equal(Nx.shape(new_state.y_pred), Nx.shape(x))
+
+      assert_same_template(state.gradients, new_state.gradients)
+    end
+
+    test "train_step/4 keeps gradients only for trainable parameters" do
+      model =
+        Axon.input("input", shape: {nil, 1})
+        |> Axon.dense(2, name: "dense_0")
+        |> Axon.dense(1, name: "dense_1")
+
+      batch = gradients_batch()
+
+      # Freeze from within the model's init so the frozen parameters reach
+      # the step through the model state it initializes.
+      {model_init_fn, model_apply_fn} = Axon.build(model, mode: :train)
+
+      frozen_init_fn = fn inp, init_state ->
+        model_init_fn.(inp, init_state)
+        |> Axon.ModelState.freeze(fn [layer | _] -> layer == "dense_0" end)
+      end
+
+      {init_fn, step_fn} =
+        Axon.Loop.train_step({frozen_init_fn, model_apply_fn}, :mean_squared_error, :sgd,
+          keep_gradients?: true
+        )
+
+      state = init_fn.(batch, Axon.ModelState.empty())
+      assert Map.keys(state.gradients) == ["dense_1"]
+      assert Map.keys(state.gradients["dense_1"]) == ["bias", "kernel"]
+
+      new_state = step_fn.(batch, state)
+      assert Map.keys(new_state.gradients) == ["dense_1"]
+      assert Map.keys(new_state.gradients["dense_1"]) == ["bias", "kernel"]
+
+      assert_same_template(state.gradients, new_state.gradients)
+      assert_equal(new_state.model_state.data["dense_0"], state.model_state.data["dense_0"])
+    end
+
+    test "train_step/4 keeps unscaled gradients under loss scaling" do
+      model = gradients_model()
+      {x, _} = batch = gradients_batch()
+
+      {model_init_fn, _} = Axon.build(model)
+      model_state = model_init_fn.(x, Axon.ModelState.empty())
+
+      run = fn loss_scale ->
+        {init_fn, step_fn} =
+          Axon.Loop.train_step(model, :mean_squared_error, :sgd,
+            keep_gradients?: true,
+            loss_scale: loss_scale
+          )
+
+        state = init_fn.(batch, Nx.backend_copy(model_state))
+        new_state = step_fn.(batch, state)
+        assert_same_template(state.gradients, new_state.gradients)
+        new_state.gradients
+      end
+
+      assert_all_close(run.(:identity), run.(:static))
+      assert_all_close(run.(:identity), run.(:dynamic))
+    end
+
+    test "trainer/4 exposes gradients to metrics and handlers" do
+      model = gradients_model()
+      data = List.duplicate(gradients_batch(), 4)
+
+      ExUnit.CaptureIO.capture_io(fn ->
+        result =
+          model
+          |> Axon.Loop.trainer(:mean_squared_error, :sgd, keep_gradients?: true, log: 0)
+          |> Axon.Loop.metric(&grad_norm/1, "gradient norm", :running_average, [:gradients])
+          |> Axon.Loop.handle_event(:iteration_completed, fn state ->
+            send(self(), {:gradients, state.step_state.gradients})
+            {:continue, state}
+          end)
+          |> Axon.Loop.run(data, Axon.ModelState.empty(), epochs: 1)
+
+        send(self(), {:result, result})
+      end)
+
+      assert_receive {:gradients, %{"dense" => %{"kernel" => _}}}
+      assert_receive {:result, %State{} = result}
+
+      assert %{"dense" => %{"kernel" => grad}} = result.step_state.gradients
+      assert Nx.shape(grad) == {1, 1}
+      assert Nx.to_number(result.metrics[0]["gradient norm"]) > 0
+    end
+
+    test "trainer/4 with keep_gradients? works with donate_state?: true" do
+      model = donation_model()
+      data = donation_data()
+      init_state = donation_init_state(model, data)
+
+      run = fn donate? ->
+        ExUnit.CaptureIO.capture_io(fn ->
+          result =
+            model
+            |> Axon.Loop.trainer(
+              :mean_squared_error,
+              Polaris.Optimizers.adam(learning_rate: 0.01),
+              keep_gradients?: true
+            )
+            |> Axon.Loop.run(data, Nx.backend_copy(init_state),
+              epochs: 2,
+              donate_state?: donate?
+            )
+
+          send(self(), {:result, result})
+        end)
+
+        assert_receive {:result, result}
+        result
+      end
+
+      donating = run.(true)
+      not_donating = run.(false)
+
+      assert_equal(donating.step_state.model_state, not_donating.step_state.model_state)
+      assert_equal(donating.step_state.gradients, not_donating.step_state.gradients)
+      assert map_leaves(donating.step_state, &Nx.donatable?/1) |> Enum.uniq() == [false]
+    end
+  end
+
   describe "metrics" do
     test "uses default names with out of the box metrics" do
       step_fn = fn _, _ -> 1 end

--- a/test/axon/loop_test.exs
+++ b/test/axon/loop_test.exs
@@ -430,6 +430,35 @@ defmodule Axon.LoopTest do
       assert_all_close(run.(:identity), run.(:dynamic))
     end
 
+    test "train_step/4 init template matches the gradient type under mixed precision" do
+      # The backward pass yields f32 gradients for bf16 parameters, so the
+      # template cannot simply be zeros of the parameter type.
+      policy =
+        Axon.MixedPrecision.create_policy(
+          params: {:bf, 16},
+          compute: {:bf, 16},
+          output: {:bf, 16}
+        )
+
+      model = Axon.MixedPrecision.apply_policy(gradients_model(), policy)
+      {x, y} = gradients_batch()
+      batch = {Nx.as_type(x, :bf16), Nx.as_type(y, :bf16)}
+
+      for loss_scale <- [:identity, :static, :dynamic] do
+        {init_fn, step_fn} =
+          Axon.Loop.train_step(model, :mean_squared_error, :sgd,
+            keep_gradients?: true,
+            loss_scale: loss_scale
+          )
+
+        state = init_fn.(batch, Axon.ModelState.empty())
+        assert Nx.type(state.model_state.data["dense"]["kernel"]) == {:bf, 16}
+
+        new_state = step_fn.(batch, state)
+        assert_same_template(state.gradients, new_state.gradients)
+      end
+    end
+
     test "trainer/4 exposes gradients to metrics and handlers" do
       model = gradients_model()
       data = List.duplicate(gradients_batch(), 4)


### PR DESCRIPTION
Closes #577.

`Axon.Loop.train_step/4` computes the gradients of every batch and then drops them once the optimizer has consumed them. Nothing downstream of the step can see them, so there is no way for a metric or an event handler to report a gradient norm, spot layers whose gradients have vanished, or log the raw gradients while debugging a model that does not train. The usual workaround is to write a custom step function, which means giving up `trainer/4`, loss scaling, and the rest of the supervised loop.

## Design

`train_step/4` and `trainer/4` gain a `keep_gradients?` option (default `false`). When it is set, the step state carries one extra key, `:gradients`, holding a container with exactly the structure of `Axon.ModelState.trainable_parameters/1`: nested string-keyed maps of tensors, frozen parameters excluded. The value is the gradient of the loss with respect to each trainable parameter for the batch that was just processed, after loss-scale unscaling and before any optimizer transformation, which is exactly what the optimizer's `update_fn` receives. `init_fn` initializes the key to zeros of the same shapes and types.

When the option is off, the step state is byte-for-byte what it was before: the key is absent rather than `nil`, so existing pattern matches, checkpoints, and compiled-function templates are unaffected.

```elixir
grad_norm = fn grads ->
  grads
  |> Nx.Defn.Composite.reduce(Nx.tensor(0.0), fn g, acc -> Nx.add(acc, Nx.sum(Nx.pow(g, 2))) end)
  |> Nx.sqrt()
end

model
|> Axon.Loop.trainer(:mean_squared_error, :adam, keep_gradients?: true)
|> Axon.Loop.metric(grad_norm, "gradient norm", :running_average, [:gradients])
|> Axon.Loop.handle_event(:iteration_completed, fn state ->
  IO.inspect(state.step_state.gradients["dense_0"]["kernel"], label: "kernel gradient")
  {:continue, state}
end)
|> Axon.Loop.run(data, Axon.ModelState.empty(), epochs: 5)
```

The metric transform has to be the list `[:gradients]` rather than the bare atom, because a list of fields is what `metric/5` applies as the argument list of the metric function. The docs call this out.

### Why the init traces the backward pass

`Axon.Loop.run/4` compiles the batch function once, with the step state returned by `init_fn` as the template, and then feeds each step's output back in. Strict compilation requires the `:gradients` entry the init produces to have the same shapes and types as the one the step produces. `zeros_like(trainable_parameters)` is not a safe template: `Nx.Defn.Grad` seeds the backward pass with an f32 constant and never casts back to the parameter type, and the static and dynamic loss scales unscale by multiplying with an f32 scalar, so for bf16 or f16 parameters the gradient type can differ from the parameter type. Instead the init does what it already does for `y_pred`: it traces the computation (here `value_and_grad` plus `unscale_grads`) and reads only shape and type off the result with `zeros_like/1`. The traced expression is never referenced by the returned state, so it is never lowered. The cost is a little extra Elixir-side tracing at init time, only when the option is on.

## Tradeoffs and limitations

- Keeping the gradients costs a parameter-sized buffer between iterations and stops the compiler from fusing the gradients into the optimizer update, which is why the option is opt-in and off by default.
- Checkpoints written by `Axon.Loop.checkpoint/2` serialize the whole step state, so they grow by the size of the trainable parameters when the option is on.
- `:gradients` is not added to the donatable step-state keys: the step never reads the previous gradients back, so donating them would be pointless. `donate_state?: true` keeps working with the option on.
- Gradient accumulation across micro-batches is a different feature and is out of scope. This only exposes the per-iteration gradients.
- Unrelated, but noticed while writing the frozen-parameter test: a `%Axon.ModelState{}` with `frozen_parameters` set by `Axon.ModelState.freeze/2` loses that field when passed back through a model's `init_fn`, because `merge_model_state!/2` in `Axon.Compiler` only merges `:data`. That is pre-existing on `main` and not touched here; the test freezes from inside a `{init_fn, apply_fn}` model tuple so the frozen state actually reaches the step.

## Tests

`test/axon/loop_test.exs` gains a `describe "keep_gradients?"` block:

- the default step state has no `:gradients` key, before and after a step;
- for a single bias-free dense layer with `sgd(learning_rate: 0.1)`, the kept gradient equals both the analytic gradient (`5w` for `mean((w * x)^2)` with `x = [1, 2]`) and `(w - w') / lr`, so it is exactly what the optimizer received; the init template is zeros with the parameter's shape and type, and the init template and step output have identical shapes and types for every leaf;
- with `dense_0` frozen, only `dense_1` gradients are kept and `dense_0` is unchanged by the step;
- the gradients kept under `:static` and `:dynamic` loss scaling match those under `:identity`, and in each case the init template matches the step output;
- under a bf16 mixed-precision policy the parameters are bf16 while the gradients are f32, and the init template still matches the step output for each loss scale, which guards the backward-pass tracing in `init_fn` (zeros of the parameter type would fail this);
- `trainer/4` with the option exposes the gradients to a `[:gradients]` metric and to an `:iteration_completed` handler through a full `Axon.Loop.run/4`, which exercises the strict compilation path;
- `donate_state?: true` with the option on converges to the same model state and gradients as the non-donating run, and the returned state is not donatable.

All six substantive tests fail on `main` without the library change. `mix test` passes on the default backend (883 tests) and `USE_EXLA=1 mix test test/axon/loop_test.exs` passes as well, including the `exla_only` buffer-donation tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

