### PR TITLE
Improve shape mismatch errors in training loops

### DIFF
--- a/lib/axon/loop.ex
+++ b/lib/axon/loop.ex
@@ -367,6 +367,7 @@ defmodule Axon.Loop do
 
       model_out = forward_model_fn.(model_state, inp)
       unscaled_loss = loss_fn.(tar, model_out.prediction)
+      check_loss_output!(unscaled_loss)
       scaled_loss = scale_loss.(unscaled_loss, loss_scale_state)
 
       {model_out, scaled_loss, unscaled_loss}
@@ -574,7 +575,13 @@ defmodule Axon.Loop do
   `loss` must be an atom which matches a function in `Axon.Losses`, a list
   of `{loss, weight}` tuples representing a basic weighted loss function
   for multi-output models, or an arity-2 function representing a custom loss
-  function.
+  function. Built-in losses expect the targets to have exactly the same shape
+  as the model prediction, and every loss function must return a scalar; the
+  training step raises with the offending shapes otherwise. To train
+  `:categorical_cross_entropy` on integer class labels, one-hot encode the
+  targets or pass
+  `&Axon.Losses.categorical_cross_entropy(&1, &2, sparse: true, reduction: :mean)`
+  as a custom loss.
 
   `optimizer` must be an atom matching the name of a valid optimizer in `Polaris.Optimizers`,
   or a `{init_fn, update_fn}` tuple where `init_fn` is an arity-1 function which
@@ -630,7 +637,9 @@ defmodule Axon.Loop do
 
   ### Multiple objectives with multi-output model
 
-      model = {Axon.input("input_0", shape: {nil, 1}), Axon.input("input_1", shape: {nil, 2})}
+      model =
+        Axon.container({Axon.input("input_0", shape: {nil, 1}), Axon.input("input_1", shape: {nil, 2})})
+
       loss_weights = [mean_squared_error: 0.5, mean_absolute_error: 0.5]
 
       model
@@ -1564,9 +1573,11 @@ defmodule Axon.Loop do
     * `:garbage_collect` - whether or not to garbage collect after
       each loop iteration. This may prevent OOMs, but it will slow down training.
 
-    * `:strict?` - whether or not to compile step functions strictly. If this flag
-      is set, the loop will raise on any cache miss during the training loop. Defaults
-      to true.
+    * `:strict?` - whether or not to compile step functions strictly. When set,
+      the step function is compiled once for the shape and type of the first batch
+      and the loop raises if any later batch differs (for example a smaller final
+      batch). Set to `false` to recompile for every new batch shape instead.
+      Defaults to `true`.
 
     * `:force_garbage_collection?` - whether or not to force garbage collection after each
       iteration. This may help avoid OOMs when training large models, but it will slow
@@ -1828,6 +1839,7 @@ defmodule Axon.Loop do
 
         {:continue, state} ->
           %State{
+            epoch: epoch,
             iteration: iters,
             max_iteration: max_iters,
             step_state: step_state,
@@ -1841,22 +1853,26 @@ defmodule Axon.Loop do
           # arguments to agree on what is donated.
           step_state = maybe_donate_step_state(step_state, donate_state?)
 
-          batch_fn =
+          {batch_fn, batch_template} =
             case batch_fn do
               {:non_compiled, batch_fn, jit_compile?, strict?, jit_opts} ->
                 cond do
                   jit_compile? and strict? ->
-                    Nx.Defn.compile(batch_fn, [data, iters, step_state, metrics], jit_opts)
+                    compiled =
+                      Nx.Defn.compile(batch_fn, [data, iters, step_state, metrics], jit_opts)
+
+                    {compiled, Nx.to_template(data)}
 
                   jit_compile? ->
-                    Nx.Defn.jit(batch_fn, jit_opts)
+                    {Nx.Defn.jit(batch_fn, jit_opts), nil}
 
                   true ->
-                    batch_fn
+                    {batch_fn, nil}
                 end
 
-              {:compiled, batch_fn} ->
-                batch_fn
+              {:compiled, batch_fn, batch_template} ->
+                check_batch_compatible!(batch_template, data, epoch, iters)
+                {batch_fn, batch_template}
             end
 
           if debug? do
@@ -1870,7 +1886,7 @@ defmodule Axon.Loop do
             Logger.debug("Axon.Loop finished batch step execution in #{us_to_ms(time)}ms")
           end
 
-          batch_fn = {:compiled, batch_fn}
+          batch_fn = {:compiled, batch_fn, batch_template}
           state = %{state | step_state: new_step_state, metrics: new_metrics}
 
           case fire_event(:iteration_completed, handler_fns, state, debug?) do
@@ -1902,6 +1918,37 @@ defmodule Axon.Loop do
   # state is either overwritten without being read, like `:y_pred`, or too small
   # to be worth donating, like `:i`.
   @donatable_step_state_keys [:model_state, :optimizer_state, :loss_scale_state]
+
+  # The step function is compiled once, for the first batch, when strict?: true.
+  # Nx raises on a later batch of a different shape, but only says which
+  # argument position disagreed with the template; report the batch and the
+  # fix instead. Nx.compatible?/2 is the same per-leaf predicate the compiled
+  # function applies, so this never rejects a batch Nx would have accepted.
+  defp check_batch_compatible!(nil, _data, _epoch, _iteration), do: :ok
+
+  defp check_batch_compatible!(template, data, epoch, iteration) do
+    unless Nx.compatible?(template, data) do
+      raise ArgumentError, """
+      batch #{iteration} of epoch #{epoch} does not have the same shape and type as the batch \
+      the loop was compiled for.
+
+      Compiled for:
+
+      #{inspect(template)}
+
+      Got:
+
+      #{inspect(Nx.to_template(data))}
+
+      Every batch must have the same shape and type when Axon.Loop.run/4 runs with \
+      strict?: true (the default), because the step function is compiled once for the \
+      first batch. This usually happens when the last batch of a dataset is smaller than \
+      the others. Drop the partial batch (for example with Nx.to_batched/3 and \
+      leftover: :discard), pad it to the full batch size, or pass strict?: false to \
+      Axon.Loop.run/4 to recompile the step function for every new batch shape.
+      """
+    end
+  end
 
   defp maybe_donate_step_state(step_state, false), do: step_state
 
@@ -2075,18 +2122,21 @@ defmodule Axon.Loop do
   # joint, multi-objective loss function.
   # TODO(seanmor5): Configurable per-batch reductions
   # TODO(seanmor5): Configurable multi-objective reductions
-  # TODO(seanmor5): Should we trace custom loss functions and provide a
-  # more clear error if the output shape is wrong?
   defp build_loss_fn(loss) do
     case loss do
       loss_name when is_atom(loss_name) and loss_name in @valid_axon_losses ->
-        &apply(Axon.Losses, loss_name, [&1, &2, [reduction: :mean]])
+        fn y_true, y_pred ->
+          check_loss_shapes!(loss_name, y_true, y_pred)
+          apply(Axon.Losses, loss_name, [y_true, y_pred, [reduction: :mean]])
+        end
 
       loss_fn when is_function(loss, 2) ->
         loss_fn
 
       [{_, _} | _] = losses ->
         fn y_true, y_pred ->
+          check_multi_output_shapes!(length(losses), y_true, y_pred)
+
           {_, loss} =
             Enum.reduce(losses, {0, Nx.tensor(0)}, fn {loss, weight}, {i, acc_loss} ->
               loss_fn = build_loss_fn(loss)
@@ -2113,6 +2163,86 @@ defmodule Axon.Loop do
                 " an arity-2 function of the form loss(y_true, y_pred), or a list" <>
                 " of 2-tuples of {loss, weight} for multi-objective models"
     end
+  end
+
+  # The built-in losses all document y_true and y_pred as having identical
+  # shapes and the trainer never passes sparse: true, so anything else would
+  # either fail with a raw Nx broadcast error or silently broadcast into a
+  # meaningless loss (e.g. integer labels against one-hot predictions). These
+  # checks run while the step function is traced, so they must only read
+  # shapes and never inspect an expression tensor directly.
+  defp check_loss_shapes!(loss_name, %Nx.Tensor{} = y_true, %Nx.Tensor{} = y_pred) do
+    true_shape = Nx.shape(y_true)
+    pred_shape = Nx.shape(y_pred)
+
+    if true_shape != pred_shape do
+      raise ArgumentError,
+            "the targets given to Axon.Losses.#{loss_name}/3 have shape #{inspect(true_shape)}" <>
+              " but the model prediction has shape #{inspect(pred_shape)}," <>
+              " Axon.Losses.#{loss_name}/3 expects targets and predictions of the same shape. " <>
+              loss_shape_hint(loss_name, true_shape, pred_shape)
+    end
+  end
+
+  defp check_loss_shapes!(loss_name, y_true, y_pred) do
+    raise ArgumentError,
+          "expected the targets and the model prediction to be tensors when training with" <>
+            " the built-in loss #{inspect(loss_name)}, got targets:" <>
+            " #{inspect(Nx.to_template(y_true))} and prediction:" <>
+            " #{inspect(Nx.to_template(y_pred))}. For models with container outputs pass" <>
+            " a list of {loss, weight} tuples, one per output, or a custom loss function" <>
+            " to Axon.Loop.trainer/4"
+  end
+
+  defp loss_shape_hint(loss_name, true_shape, pred_shape) do
+    cond do
+      tuple_size(true_shape) > 0 and tuple_size(pred_shape) > 0 and
+          elem(true_shape, 0) != elem(pred_shape, 0) ->
+        "The batch axes differ (#{elem(true_shape, 0)} vs #{elem(pred_shape, 0)}), which" <>
+          " usually means the inputs and targets in your dataset are not batched together;" <>
+          " make sure every {input, target} pair given to Axon.Loop.run/4 comes from the" <>
+          " same batch"
+
+      loss_name == :categorical_cross_entropy and
+          (tuple_size(true_shape) < tuple_size(pred_shape) or
+             elem(true_shape, tuple_size(true_shape) - 1) == 1) ->
+        "If your targets are integer class labels, either one-hot encode them, e.g." <>
+          " Nx.equal(Nx.reshape(labels, {:auto, 1}), Nx.iota({1, num_classes})), or use" <>
+          " sparse targets through a custom loss:" <>
+          " &Axon.Losses.categorical_cross_entropy(&1, &2, sparse: true, reduction: :mean)"
+
+      true ->
+        "Check that the output size of the last layer of your model matches your targets"
+    end
+  end
+
+  defp check_multi_output_shapes!(n, y_true, y_pred) do
+    unless is_tuple(y_true) and tuple_size(y_true) == n and
+             is_tuple(y_pred) and tuple_size(y_pred) == n do
+      raise ArgumentError,
+            "a list of #{n} weighted losses expects the model prediction and the targets to" <>
+              " be tuples with #{n} elements, one per output, got targets:" <>
+              " #{inspect(Nx.to_template(y_true))} and prediction:" <>
+              " #{inspect(Nx.to_template(y_pred))}"
+    end
+  end
+
+  # The training step keeps a running average of the loss against a scalar
+  # accumulator, so a non-scalar loss changes the step state template and only
+  # fails on the next batch with an unrelated-looking Nx compile error.
+  defp check_loss_output!(%Nx.Tensor{} = loss) do
+    if Nx.shape(loss) != {} do
+      raise ArgumentError, non_scalar_loss_message(Nx.to_template(loss))
+    end
+  end
+
+  defp check_loss_output!(loss), do: raise(ArgumentError, non_scalar_loss_message(loss))
+
+  defp non_scalar_loss_message(got) do
+    "expected the loss function to return a scalar tensor, got #{inspect(got)}." <>
+      " The training step accumulates a single loss value per batch, so custom loss" <>
+      " functions must reduce the per-example loss to a scalar, for example with Nx.mean/1," <>
+      " and functions from Axon.Losses must be called with reduction: :mean or reduction: :sum"
   end
 
   # Builds model init and forward functions from an Axon struct,

--- a/lib/axon/loop.ex
+++ b/lib/axon/loop.ex
@@ -2236,6 +2236,8 @@ defmodule Axon.Loop do
     end
   end
 
+  defp check_loss_output!(loss) when is_number(loss), do: :ok
+
   defp check_loss_output!(loss), do: raise(ArgumentError, non_scalar_loss_message(loss))
 
   defp non_scalar_loss_message(got) do

--- a/test/axon/loop_test.exs
+++ b/test/axon/loop_test.exs
@@ -638,6 +638,18 @@ defmodule Axon.LoopTest do
                |> Loop.run([{inputs, targets}], Axon.ModelState.empty())
     end
 
+    test "accepts a loss function that returns a number" do
+      data = [{Nx.iota({8, 4}, type: :f32), Nx.iota({8, 3}, type: :f32)}]
+
+      assert %State{epoch: 1, step_state: %{loss: loss}} =
+               Axon.input("input", shape: {nil, 4})
+               |> Axon.dense(3)
+               |> Loop.trainer(fn _y_true, _y_pred -> 1.0 end, :sgd, log: 0)
+               |> Loop.run(data, Axon.ModelState.empty())
+
+      assert Nx.to_number(loss) == 1.0
+    end
+
     test "raises when the loss function does not return a scalar" do
       data = [{Nx.iota({8, 4}, type: :f32), Nx.iota({8, 3}, type: :f32)}]
       loss_fn = fn y_true, y_pred -> Nx.subtract(y_true, y_pred) end

--- a/test/axon/loop_test.exs
+++ b/test/axon/loop_test.exs
@@ -462,6 +462,76 @@ defmodule Axon.LoopTest do
         strict?: false
       )
     end
+
+    test "raises a clear error when a batch changes shape under strict compilation" do
+      data = [
+        {Nx.iota({8, 4}, type: :f32), Nx.iota({8, 3}, type: :f32)},
+        {Nx.iota({4, 4}, type: :f32), Nx.iota({4, 3}, type: :f32)}
+      ]
+
+      message =
+        assert_raise ArgumentError,
+                     ~r/batch 1 of epoch 0 does not have the same shape and type/,
+                     fn ->
+                       Axon.input("input", shape: {nil, 4})
+                       |> Axon.dense(3)
+                       |> Loop.trainer(:mean_squared_error, :sgd, log: 0)
+                       |> Loop.run(data, Axon.ModelState.empty())
+                     end
+
+      assert message.message =~ "f32[8][4]"
+      assert message.message =~ "f32[4][4]"
+      assert message.message =~ "strict?: false"
+    end
+
+    test "raises a clear error when a batch changes type under strict compilation" do
+      data = [
+        {Nx.iota({8, 4}, type: :f32), Nx.iota({8, 3}, type: :f32)},
+        {Nx.iota({8, 4}), Nx.iota({8, 3}, type: :f32)}
+      ]
+
+      assert_raise ArgumentError,
+                   ~r/batch 1 of epoch 0 does not have the same shape and type/,
+                   fn ->
+                     Axon.input("input", shape: {nil, 4})
+                     |> Axon.dense(3)
+                     |> Loop.trainer(:mean_squared_error, :sgd, log: 0)
+                     |> Loop.run(data, Axon.ModelState.empty())
+                   end
+    end
+
+    test "raises a clear error when a batch changes shape in an evaluation loop" do
+      data = [
+        {Nx.iota({8, 4}, type: :f32), Nx.iota({8, 3}, type: :f32)},
+        {Nx.iota({4, 4}, type: :f32), Nx.iota({4, 3}, type: :f32)}
+      ]
+
+      model = Axon.input("input", shape: {nil, 4}) |> Axon.dense(3)
+      {init_fn, _} = Axon.build(model)
+      model_state = init_fn.(Nx.template({8, 4}, :f32), Axon.ModelState.empty())
+
+      assert_raise ArgumentError,
+                   ~r/batch 1 of epoch 0 does not have the same shape and type/,
+                   fn ->
+                     model
+                     |> Loop.evaluator()
+                     |> Loop.metric(:mean_absolute_error)
+                     |> Loop.run(data, model_state)
+                   end
+    end
+
+    test "recompiles for new batch shapes with strict?: false" do
+      data = [
+        {Nx.iota({8, 4}, type: :f32), Nx.iota({8, 3}, type: :f32)},
+        {Nx.iota({4, 4}, type: :f32), Nx.iota({4, 3}, type: :f32)}
+      ]
+
+      assert %State{epoch: 1, event_counts: %{iteration_completed: %{total: 2}}} =
+               Axon.input("input", shape: {nil, 4})
+               |> Axon.dense(3)
+               |> Loop.trainer(:mean_squared_error, :sgd, log: 0)
+               |> Loop.run(data, Axon.ModelState.empty(), strict?: false)
+    end
   end
 
   describe "trainer" do
@@ -474,6 +544,112 @@ defmodule Axon.LoopTest do
         |> Axon.Loop.trainer(:categorical_cross_entropy, :adam)
         |> Axon.Loop.run(data, %{})
       end
+    end
+
+    test "raises a clear error when targets and predictions have different shapes" do
+      data = [{Nx.iota({8, 4}, type: :f32), Nx.iota({8, 2}, type: :f32)}]
+
+      assert_raise ArgumentError,
+                   ~r/targets given to Axon.Losses.mean_squared_error\/3 have shape \{8, 2\} but the model prediction has shape \{8, 3\}/,
+                   fn ->
+                     Axon.input("input", shape: {nil, 4})
+                     |> Axon.dense(3)
+                     |> Loop.trainer(:mean_squared_error, :sgd, log: 0)
+                     |> Loop.run(data, Axon.ModelState.empty())
+                   end
+    end
+
+    test "points at the batch axis when inputs and targets are batched differently" do
+      data = [{Nx.iota({8, 4}, type: :f32), Nx.iota({4, 3}, type: :f32)}]
+
+      assert_raise ArgumentError, ~r/batch axes differ \(4 vs 8\)/, fn ->
+        Axon.input("input", shape: {nil, 4})
+        |> Axon.dense(3)
+        |> Loop.trainer(:mean_squared_error, :sgd, log: 0)
+        |> Loop.run(data, Axon.ModelState.empty())
+      end
+    end
+
+    test "suggests one-hot encoding for categorical_cross_entropy with integer labels" do
+      labels = Nx.tensor([[0], [1], [2], [0], [1], [2], [0], [1]])
+      data = [{Nx.iota({8, 4}, type: :f32), labels}]
+
+      message =
+        assert_raise ArgumentError,
+                     ~r/have shape \{8, 1\} but the model prediction has shape \{8, 3\}/,
+                     fn ->
+                       Axon.input("input", shape: {nil, 4})
+                       |> Axon.dense(3, activation: :softmax)
+                       |> Loop.trainer(:categorical_cross_entropy, :sgd, log: 0)
+                       |> Loop.run(data, Axon.ModelState.empty())
+                     end
+
+      assert message.message =~ "one-hot encode"
+      assert message.message =~ "sparse: true"
+    end
+
+    test "does not check shapes for custom loss functions" do
+      labels = Nx.tensor([[0], [1], [2], [0], [1], [2], [0], [1]])
+      data = [{Nx.iota({8, 4}, type: :f32), labels}]
+
+      loss_fn = &Axon.Losses.categorical_cross_entropy(&1, &2, sparse: true, reduction: :mean)
+
+      assert %State{epoch: 1, event_counts: %{iteration_completed: %{total: 1}}} =
+               Axon.input("input", shape: {nil, 4})
+               |> Axon.dense(3, activation: :softmax)
+               |> Loop.trainer(loss_fn, :sgd, log: 0)
+               |> Loop.run(data, Axon.ModelState.empty())
+    end
+
+    test "raises when a built-in loss is used with a container output" do
+      model =
+        Axon.container({Axon.input("a", shape: {nil, 1}), Axon.input("b", shape: {nil, 2})})
+
+      inputs = %{"a" => Nx.iota({8, 1}, type: :f32), "b" => Nx.iota({8, 2}, type: :f32)}
+      targets = {Nx.iota({8, 1}, type: :f32), Nx.iota({8, 2}, type: :f32)}
+
+      assert_raise ArgumentError,
+                   ~r/expected the targets and the model prediction to be tensors/,
+                   fn ->
+                     model
+                     |> Loop.trainer(:mean_squared_error, :sgd, log: 0)
+                     |> Loop.run([{inputs, targets}], Axon.ModelState.empty())
+                   end
+    end
+
+    test "raises when a multi-output loss list gets non-tuple targets" do
+      model =
+        Axon.container({Axon.input("a", shape: {nil, 1}), Axon.input("b", shape: {nil, 2})})
+
+      inputs = %{"a" => Nx.iota({8, 1}, type: :f32), "b" => Nx.iota({8, 2}, type: :f32)}
+      losses = [mean_squared_error: 0.5, mean_absolute_error: 0.5]
+
+      assert_raise ArgumentError, ~r/tuples with 2 elements/, fn ->
+        model
+        |> Loop.trainer(losses, :sgd, log: 0)
+        |> Loop.run([{inputs, Nx.iota({8, 1}, type: :f32)}], Axon.ModelState.empty())
+      end
+
+      targets = {Nx.iota({8, 1}, type: :f32), Nx.iota({8, 2}, type: :f32)}
+
+      assert %State{epoch: 1, event_counts: %{iteration_completed: %{total: 1}}} =
+               model
+               |> Loop.trainer(losses, :sgd, log: 0)
+               |> Loop.run([{inputs, targets}], Axon.ModelState.empty())
+    end
+
+    test "raises when the loss function does not return a scalar" do
+      data = [{Nx.iota({8, 4}, type: :f32), Nx.iota({8, 3}, type: :f32)}]
+      loss_fn = fn y_true, y_pred -> Nx.subtract(y_true, y_pred) end
+
+      assert_raise ArgumentError,
+                   ~r/expected the loss function to return a scalar tensor, got #Nx.Tensor<\s*f32\[8\]\[3\]/,
+                   fn ->
+                     Axon.input("input", shape: {nil, 4})
+                     |> Axon.dense(3)
+                     |> Loop.trainer(loss_fn, :sgd, log: 0)
+                     |> Loop.run(data, Axon.ModelState.empty())
+                   end
     end
   end
 


### PR DESCRIPTION
Closes #480.

When the targets in a training loop do not line up with the model output, `Axon.Loop.run/4` currently surfaces whatever Nx happens to raise deep inside the traced step function: a `cannot broadcast tensor of dimensions {8, 2} to {8, 3}`, an `argument at position 1 is not compatible with compiled function template` with a template diff and no mention of which batch, or a `FunctionClauseError` in `Nx.Type.type_to_int/1`. Worse, the most common mistake of all, feeding integer class labels of shape `{batch, 1}` to `:categorical_cross_entropy` against `{batch, classes}` predictions, does not raise at all: the labels broadcast against the log-probabilities and the loop trains happily on a meaningless loss.

This PR adds a handful of checks at the trainer and loop boundary that catch these cases before Nx does and explain what went wrong and how to fix it.

## What changes

| Situation | Before | After |
| --- | --- | --- |
| Targets `{8, 2}` vs prediction `{8, 3}` with a built-in loss | raw Nx broadcast error | `ArgumentError` naming the loss, both shapes, and a hint to check the last layer's output size |
| Targets `{4, 3}` vs prediction `{8, 3}` (batch axes differ) | raw Nx broadcast error | same, with a hint that inputs and targets are not batched together |
| Integer labels `{8, 1}` vs `{8, 3}` with `:categorical_cross_entropy` | silently trains, loss stays 0.0 | raises and suggests one-hot encoding or `sparse: true` through a custom loss |
| Built-in atom loss with an `Axon.container` output | `FunctionClauseError` in `Nx.Type.type_to_int/1` | raises, points at `{loss, weight}` lists or a custom loss |
| `[mean_squared_error: 0.5, ...]` with non-tuple targets | `ArgumentError` from `Kernel.elem/2` ("not a tuple") | raises saying targets and prediction must be 2-tuples, one per output |
| Custom loss returning a non-scalar | runs, then fails on the 2nd batch with a template error (or in metric formatting) | raises immediately with the loss's template and the reduction advice |
| Second batch `{4, 4}/{4, 3}` after a first `{8, 4}/{8, 3}` under the default `strict?: true` | Nx "argument at position 1 is not compatible with compiled function template" | raises with the epoch, the iteration, both templates, and three fixes (drop the partial batch, pad it, or `strict?: false`) |

Everything is a plain `ArgumentError` raised from `lib/axon/loop.ex`, so it propagates out of `Axon.Loop.run/4` exactly like the Nx errors did.

## Design

There are four checks.

**Built-in loss shape check.** `build_loss_fn/1` now wraps every atom in `@valid_axon_losses` with a check that `Nx.shape(y_true) == Nx.shape(y_pred)`. Exact equality is the right rule here: all ten built-in losses document `y_true` and `y_pred` as `(d_0, ..., d_n)`, and the trainer calls them with only `reduction: :mean`, never `sparse: true`, so any shape difference either fails inside Nx or silently broadcasts into a wrong loss. The hint appended to the message depends on what mismatched: a differing batch axis points at the dataset zipping, a `{batch, 1}` or lower-rank target with `:categorical_cross_entropy` points at one-hot encoding or `sparse: true`, and anything else points at the last layer's output size. If either side is not a tensor (a container-output model with an atom loss), a separate clause explains that container outputs need a `{loss, weight}` list or a custom loss. Custom `fn/2` losses are deliberately not shape checked, since they may rely on broadcasting or on `sparse: true`.

**Multi-output structure check.** The `[{loss, weight}, ...]` clause checks that both targets and prediction are tuples with one element per loss before it starts indexing into them with `elem/2`.

**Scalar loss check.** `train_step/4`'s objective function now checks that whatever the loss function returned is a rank-0 tensor (a plain Elixir number is accepted as well, as before). The step accumulates `loss * i + batch_loss / (i + 1)` against a scalar accumulator, so a non-scalar loss changes the step-state template and only fails on the next batch with an error that has nothing to do with the loss. This applies to every kind of loss, including custom ones.

**Per-batch template check.** When `run_epoch/7` compiles the step function strictly, it remembers `Nx.to_template(data)` for the batch it compiled on and carries it in the `{:compiled, fn, template}` tuple. Every later batch is checked with `Nx.compatible?/2`, the same per-leaf predicate the compiled function's wrapper uses, so this never rejects a batch Nx would have accepted; it only pre-empts the Nx error with one that names the batch and the fixes. Only the data is checked. Step-state and metric mismatches (a handler swapping a tensor's shape, say) still get the Nx error, which is accurate for those. The check costs one container traversal per batch and is only active under `strict?: true`; with `strict?: false` the template is `nil` and nothing changes.

The first three checks run while the step function is being traced, so they only read shapes and use `Nx.to_template/1` for anything that ends up in a message; an `Nx.Defn.Expr` tensor is never inspected directly.

## Example

```elixir
labels = Nx.tensor([[0], [1], [2], [0], [1], [2], [0], [1]])

Axon.input("input", shape: {nil, 4})
|> Axon.dense(3, activation: :softmax)
|> Axon.Loop.trainer(:categorical_cross_entropy, :sgd)
|> Axon.Loop.run([{Nx.iota({8, 4}, type: :f32), labels}], Axon.ModelState.empty())
```

used to train silently. It now raises:

```
** (ArgumentError) the targets given to Axon.Losses.categorical_cross_entropy/3 have shape {8, 1}
but the model prediction has shape {8, 3}, Axon.Losses.categorical_cross_entropy/3 expects targets
and predictions of the same shape. If your targets are integer class labels, either one-hot encode
them, e.g. Nx.equal(Nx.reshape(labels, {:auto, 1}), Nx.iota({1, num_classes})), or use sparse
targets through a custom loss:
&Axon.Losses.categorical_cross_entropy(&1, &2, sparse: true, reduction: :mean)
```

And a ragged final batch now reports:

```
** (ArgumentError) batch 1 of epoch 0 does not have the same shape and type as the batch the loop
was compiled for.

Compiled for:

{#Nx.Tensor<f32[8][4] Nx.TemplateBackend>, #Nx.Tensor<f32[8][3] Nx.TemplateBackend>}

Got:

{#Nx.Tensor<f32[4][4] Nx.TemplateBackend>, #Nx.Tensor<f32[4][3] Nx.TemplateBackend>}

Every batch must have the same shape and type when Axon.Loop.run/4 runs with strict?: true
(the default), because the step function is compiled once for the first batch. This usually
happens when the last batch of a dataset is smaller than the others. Drop the partial batch
(for example with Nx.to_batched/3 and leftover: :discard), pad it to the full batch size, or
pass strict?: false to Axon.Loop.run/4 to recompile the step function for every new batch shape.
```

## Tradeoffs and limitations

* One behavior change: `:categorical_cross_entropy` (and any other built-in loss) with `{batch, 1}` targets against `{batch, classes}` predictions used to broadcast silently and now raises. That silent case computed a meaningless loss, which is the point, but it is a change for anyone who was unknowingly relying on it. The `sparse: true` path via a custom loss keeps working and is covered by a test.
* Custom loss functions are not shape checked, only checked for returning a scalar.
* Only the data container is checked per batch; step-state/metric template mismatches still surface the Nx error.
* Out of scope: validating input tensors against the shape declared in `Axon.input(name, shape: ...)`. That is a compiler-level TODO (`validate_input_shape!` is commented out at `lib/axon/compiler.ex:501`) that also affects `Axon.predict/4` outside loops and deserves its own issue. Metric shape checks (e.g. `Axon.Metrics.accuracy/2` on mismatched shapes) are also out of scope.
* `Axon.Losses` itself is untouched, so direct callers that rely on broadcasting or `sparse: true` are unaffected; the rule is only enforced at the trainer boundary where the trainer fixes the options.

## Docs

The `trainer/4` docs now state the same-shape and scalar requirements and show the `sparse: true` custom loss for integer labels, and the `:strict?` option in `run/4` explains that the step function is compiled once for the first batch. The "Multiple objectives with multi-output model" example in `trainer/4` was also fixed: it built the model as a bare tuple of `Axon` structs, which `trainer/4` rejects with "Invalid model", and now uses `Axon.container/1`.

## Tests

`test/axon/loop_test.exs`:

* different target/prediction shapes name both shapes and the loss
* differing batch axes get the "not batched together" hint
* integer labels with `:categorical_cross_entropy` get the one-hot / `sparse: true` hint
* the same integer labels with `&Axon.Losses.categorical_cross_entropy(&1, &2, sparse: true, reduction: :mean)` still train (custom losses are not shape checked)
* a built-in loss with an `Axon.container` output raises the container message
* a `{loss, weight}` list with non-tuple targets raises, and with tuple targets still trains
* a custom loss that returns `{8, 3}` raises the scalar message
* a second batch with a different shape, or a different type, raises the per-batch message under the default `strict?: true`, in both a trainer and an evaluator loop
* the same ragged batches train through with `strict?: false`

All nine error-path tests fail on `main` and pass here; `mix test` passes in full.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

