### PR TITLE
Merge training updates into a single Axon.ModelState.update call

### DIFF
--- a/lib/axon/loop.ex
+++ b/lib/axon/loop.ex
@@ -360,10 +360,7 @@ defmodule Axon.Loop do
 
     objective_fn = fn trainable_parameters, model_state, loss_scale_state, inp, tar ->
       # hack to use trainable parameters as grad
-      model_state =
-        update_in(model_state, [Access.key!(:data)], fn data ->
-          tree_merge(data, trainable_parameters, fn _, _, v -> v end)
-        end)
+      model_state = Axon.ModelState.update(model_state, trainable_parameters)
 
       model_out = forward_model_fn.(model_state, inp)
       unscaled_loss = loss_fn.(tar, model_out.prediction)
@@ -428,27 +425,6 @@ defmodule Axon.Loop do
       Nx.Defn.jit(init_fn, on_conflict: :reuse),
       Nx.Defn.jit(step_fn, on_conflict: :reuse)
     }
-  end
-
-  defp tree_merge(lhs, rhs, fun) do
-    Enum.reduce(lhs, %{}, fn {key, val_lhs}, acc ->
-      case Map.get(rhs, key) do
-        nil ->
-          Map.put(acc, key, val_lhs)
-
-        %Nx.Tensor{} = val_rhs ->
-          new_val = fun.(key, val_lhs, val_rhs)
-          Map.put(acc, key, new_val)
-
-        val_rhs when is_map(val_lhs) and is_map(val_rhs) ->
-          updated_val = tree_merge(val_lhs, val_rhs, fun)
-          Map.put(acc, key, updated_val)
-
-        val_rhs ->
-          new_val = fun.(key, val_lhs, val_rhs)
-          Map.put(acc, key, new_val)
-      end
-    end)
   end
 
   defp raise_bad_training_inputs!(data, state) do

--- a/test/axon/loop_test.exs
+++ b/test/axon/loop_test.exs
@@ -289,6 +289,90 @@ defmodule Axon.LoopTest do
       assert_all_close(state.model_state.data["instance_norm"]["mean"], Nx.broadcast(0.9, {8}))
       assert_all_close(state.model_state.data["instance_norm"]["var"], Nx.broadcast(0.1, {8}))
     end
+
+    test "train_step/3 updates only trainable parameters" do
+      model =
+        Axon.input("input")
+        |> Axon.dense(3, name: "dense_0")
+        |> Axon.tanh()
+        |> Axon.dense(2, name: "dense_1")
+
+      inp = Nx.iota({4, 4}, type: :f32)
+      tar = Nx.iota({4, 2}, type: :f32)
+
+      {init_fn, step_fn} = Axon.Loop.train_step(model, :mean_squared_error, :sgd)
+
+      state = init_fn.({inp, tar}, Axon.ModelState.empty())
+
+      frozen_model_state =
+        Axon.ModelState.freeze(state.model_state, fn
+          ["dense_0" | _] -> true
+          _ -> false
+        end)
+
+      new_state = step_fn.({inp, tar}, %{state | model_state: frozen_model_state})
+
+      # frozen parameters are not in the gradient, so they must come back
+      # untouched from the merge
+      assert_equal(
+        new_state.model_state.data["dense_0"]["kernel"],
+        frozen_model_state.data["dense_0"]["kernel"]
+      )
+
+      assert_equal(
+        new_state.model_state.data["dense_0"]["bias"],
+        frozen_model_state.data["dense_0"]["bias"]
+      )
+
+      assert_not_equal(
+        new_state.model_state.data["dense_1"]["kernel"],
+        frozen_model_state.data["dense_1"]["kernel"]
+      )
+
+      assert_not_equal(
+        new_state.model_state.data["dense_1"]["bias"],
+        frozen_model_state.data["dense_1"]["bias"]
+      )
+
+      # the model state metadata must survive the update
+      assert new_state.model_state.parameters == frozen_model_state.parameters
+      assert new_state.model_state.frozen_parameters == frozen_model_state.frozen_parameters
+    end
+
+    test "train_step/3 updates nested parameters" do
+      block = Axon.block(&Axon.dense(&1, 4, name: "inner"), name: "block")
+
+      model =
+        Axon.input("input")
+        |> block.()
+        |> Axon.tanh()
+        |> block.()
+        |> Axon.batch_norm(name: "norm")
+        |> Axon.dense(2, name: "out")
+
+      inp = Nx.iota({4, 4}, type: :f32)
+      tar = Nx.iota({4, 2}, type: :f32)
+
+      {init_fn, step_fn} = Axon.Loop.train_step(model, :mean_squared_error, :sgd)
+
+      state = init_fn.({inp, tar}, Axon.ModelState.empty())
+      new_state = step_fn.({inp, tar}, state)
+
+      # nested trainable parameters are updated
+      assert_not_equal(
+        new_state.model_state.data["block"]["inner"]["kernel"],
+        state.model_state.data["block"]["inner"]["kernel"]
+      )
+
+      # state is updated alongside the nested parameters
+      assert_not_equal(
+        new_state.model_state.data["norm"]["mean"],
+        state.model_state.data["norm"]["mean"]
+      )
+
+      assert new_state.model_state.parameters == state.model_state.parameters
+      assert new_state.model_state.state == state.model_state.state
+    end
   end
 
   describe "metrics" do


### PR DESCRIPTION
Closes #576.

`Axon.Loop.train_step/4` updated the model state in two different ways. The objective function that runs under `Nx.Defn.value_and_grad` took the differentiated variable (the trainable parameters) and spliced it back into `model_state.data` by hand, using a private `tree_merge/3` that was a copy of the one in `Axon.ModelState`. The step function then applied the optimizer output with the real API, `Axon.ModelState.update/3`. The hand-rolled merge existed because `Axon.ModelState.update/3` used to be a plain `def` and could not be called from the jitted step. Since #656 turned the `Axon.ModelState` API into transforms, that restriction is gone.

This PR makes the objective call `Axon.ModelState.update(model_state, trainable_parameters)` directly and deletes the duplicated `tree_merge/3` from `Axon.Loop`, so both parameter merges in `train_step/4` go through the same function:

```elixir
# before
model_state =
  update_in(model_state, [Access.key!(:data)], fn data ->
    tree_merge(data, trainable_parameters, fn _, _, v -> v end)
  end)

# after
model_state = Axon.ModelState.update(model_state, trainable_parameters)
```

The behaviour is the same. `update/2` replaces the leaves of `data` that exist in `trainable_parameters` and keeps everything else; frozen parameters are never part of the gradient variable (`trainable_parameters/1` diffs against `frozen_parameters`), so they stay untouched, and `Axon.ModelState.SharedParameter` leaves are skipped, so tied weights stay tied. `updated_state` defaults to `%{}`, which makes the state merge a no-op, and the `parameters`, `state` and `frozen_parameters` metadata are `keep:` fields of the container, so they survive the jitted step. Because the merge is a plain replacement, the same `Nx.Defn.Expr` tensors end up in `data` and gradients flow exactly as before. Layer state (batch-norm running statistics, etc.) is still produced by the forward pass and merged in the step function with the three-arity `update/3` call, which is unchanged.

The only difference from the old private copy is that `Axon.ModelState.tree_merge` treats `Axon.Quantization.QTensor` as a leaf instead of recursing into the struct. This cannot change results because `Axon.Quantization` freezes quantized kernels, so they never appear in the trainable parameters.

Two tests were added to `test/axon/loop_test.exs`:

- `train_step/3 updates only trainable parameters` freezes one dense layer, runs a step, and checks that the frozen kernel and bias come back unchanged while the trainable layer's parameters move, and that `parameters` and `frozen_parameters` are preserved.
- `train_step/3 updates nested parameters` uses a reused `Axon.block` with a batch norm and checks that the nested block parameters and the layer state are both updated through the single path, with `parameters` and `state` preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
