### PR TITLE
Add axis names to Axon.input and an Axon.rename layer

### DIFF
--- a/deps
+++ b/deps
@@ -1,0 +1,1 @@
+/Users/sean/projects/axon/deps

--- a/lib/axon.ex
+++ b/lib/axon.ex
@@ -19,6 +19,10 @@ defmodule Axon do
 
   Notice you can specify some dimensions as `nil`, indicating
   that the dimension size will be filled in at model runtime.
+  Inputs may also declare axis names with the `:names` option
+  (as in `Nx.tensor/2`), which are applied to the input tensor
+  when the model runs and propagate through subsequent layers.
+  Axes produced by layers can be named with `Axon.rename/3`.
   You can then compose inputs with other layers:
 
       model =
@@ -616,30 +620,83 @@ defmodule Axon do
     * `:shape` - the expected input shape, use `nil` for dimensions
       of a dynamic size.
 
+    * `:names` - axis names for the input, as in `Nx.tensor/2`. When
+      given, the input tensor is renamed with `Nx.rename/2` when the
+      model runs, so subsequent layers and custom layers can refer to
+      axes by name. Must have one entry (an atom or `nil`) per dimension.
+      If the incoming tensor already carries a different non-nil name
+      for an axis, an error is raised. Only supported for inputs with
+      a tensor shape (not containers).
+
     * `:optional` - if `true`, the input may be omitted when using
       the model. This needs to be handled in one of the subsequent
       layers. See `optional/2` for more details.
+
+  ## Examples
+
+  Axis names declared on an input propagate through the layers
+  built on top of it. Axes produced by a layer can be named with
+  `rename/3`:
+
+      Axon.input("features", shape: {nil, 784}, names: [:batch, :pixels])
+      |> Axon.dense(128)
+      |> Axon.rename([:batch, :hidden])
+
+  Custom layers can then refer to axes by name:
+
+      input = Axon.input("features", shape: {nil, 784}, names: [:batch, :pixels])
+      Axon.layer(fn x, _opts -> Nx.sum(x, axes: [:pixels]) end, [input])
 
   """
   @doc type: :special
   def input(name, opts \\ [])
 
   def input(name, opts) when is_binary(name) and is_list(opts) do
-    opts = Keyword.validate!(opts, [:shape, :meta, optional: false])
+    opts = Keyword.validate!(opts, [:shape, :names, :meta, optional: false])
     optional = opts[:optional]
     meta = opts[:meta]
 
     input_shape = opts[:shape]
 
     output_shape = input_shape && Axon.Shape.input(input_shape)
+    names = validate_input_names!(opts[:names], output_shape)
 
     layer(:input, [],
       name: name,
       shape: output_shape,
+      names: names,
       meta: meta,
       op_name: :input,
       optional: optional
     )
+  end
+
+  defp validate_input_names!(nil, _shape), do: nil
+
+  defp validate_input_names!(names, shape) do
+    validate_names!(names)
+
+    cond do
+      is_nil(shape) ->
+        names
+
+      Axon.Shape.tensor_shape?(shape) ->
+        Nx.Shape.named_axes!(names, shape)
+
+      true ->
+        raise ArgumentError,
+              "the :names option is only supported for inputs with a tensor shape," <>
+                " got shape: #{inspect(shape)}"
+    end
+  end
+
+  defp validate_names!(names) do
+    if is_list(names) and Enum.all?(names, &is_atom/1) do
+      names
+    else
+      raise ArgumentError,
+            "invalid input names #{inspect(names)}, names must be a list of atoms or nil"
+    end
   end
 
   @doc """
@@ -2579,6 +2636,38 @@ defmodule Axon do
       meta: opts[:meta],
       shape: new_shape,
       op_name: :reshape
+    )
+  end
+
+  @doc """
+  Adds a rename layer to the network.
+
+  This layer renames the axes of its input using `Nx.rename/2`.
+  `names` must contain one entry (an atom or `nil`) per input axis.
+  It is useful for naming axes produced by a layer, such as the
+  feature axis of a dense layer:
+
+      Axon.input("features", shape: {nil, 784}, names: [:batch, :pixels])
+      |> Axon.dense(128)
+      |> Axon.rename([:batch, :hidden])
+
+  See the `:names` option of `input/2` for declaring names on inputs.
+
+  ## Options
+
+    * `:name` - layer name.
+
+  """
+  @doc type: :shape
+  def rename(%Axon{} = x, names, opts \\ []) when is_list(names) do
+    opts = Keyword.validate!(opts, [:name, :meta])
+    names = validate_names!(names)
+
+    layer(:rename, [x],
+      name: opts[:name],
+      meta: opts[:meta],
+      names: names,
+      op_name: :rename
     )
   end
 

--- a/lib/axon.ex
+++ b/lib/axon.ex
@@ -625,8 +625,9 @@ defmodule Axon do
       model runs, so subsequent layers and custom layers can refer to
       axes by name. Must have one entry (an atom or `nil`) per dimension.
       If the incoming tensor already carries a different non-nil name
-      for an axis, an error is raised. Only supported for inputs with
-      a tensor shape (not containers).
+      for an axis, an error is raised; where `nil` is declared, the
+      incoming name is kept. Only supported for inputs with a tensor
+      shape (not containers).
 
     * `:optional` - if `true`, the input may be omitted when using
       the model. This needs to be handled in one of the subsequent
@@ -661,13 +662,15 @@ defmodule Axon do
     output_shape = input_shape && Axon.Shape.input(input_shape)
     names = validate_input_names!(opts[:names], output_shape)
 
-    layer(:input, [],
-      name: name,
-      shape: output_shape,
-      names: names,
-      meta: meta,
-      op_name: :input,
-      optional: optional
+    # :names is only stored when given so unnamed inputs keep their
+    # existing node opts (and display output) unchanged
+    input_opts = if names, do: [names: names], else: []
+
+    layer(
+      :input,
+      [],
+      [name: name, shape: output_shape] ++
+        input_opts ++ [meta: meta, op_name: :input, optional: optional]
     )
   end
 
@@ -2659,7 +2662,7 @@ defmodule Axon do
 
   """
   @doc type: :shape
-  def rename(%Axon{} = x, names, opts \\ []) when is_list(names) do
+  def rename(%Axon{} = x, names, opts \\ []) do
     opts = Keyword.validate!(opts, [:name, :meta])
     names = validate_names!(names)
 

--- a/lib/axon/compiler.ex
+++ b/lib/axon/compiler.ex
@@ -484,18 +484,24 @@ defmodule Axon.Compiler do
            op: :input,
            hooks: hooks,
            name: name_fn,
-           opts: [shape: _input_shape, optional: optional?]
+           opts: input_opts
          },
          nodes,
          {cache, op_counts, block_cache, model_state_meta},
          %{mode: mode, print_values: print_values}
        ) do
+    optional? = Keyword.fetch!(input_opts, :optional)
+    # Use Keyword.get so models built before :names existed still compile
+    names = Keyword.get(input_opts, :names)
     name = name_fn.(:input, op_counts)
     op_counts = Map.update(op_counts, :input, 1, fn x -> x + 1 end)
     all_inputs = get_all_inputs(nodes)
 
     predict_fun = fn _params, inputs, state, _cache, result_cache, _fn_stacktrace ->
-      value = get_input(all_inputs, inputs, name, optional?)
+      value =
+        all_inputs
+        |> get_input(inputs, name, optional?)
+        |> rename_input(name, names)
 
       # TODO: Add this back in
       # validate_input_shape!(value, shape)
@@ -510,7 +516,11 @@ defmodule Axon.Compiler do
     end
 
     init_fun = fn template, _cache, result_cache, _fn_stacktrace, _keys ->
-      input = get_input(all_inputs, template, name, optional?)
+      input =
+        all_inputs
+        |> get_input(template, name, optional?)
+        |> rename_input(name, names)
+
       {Nx.to_template(input), {%{}, result_cache}}
     end
 
@@ -961,6 +971,39 @@ defmodule Axon.Compiler do
       name_fn.(:input, %{})
     end)
     |> Enum.uniq()
+  end
+
+  defp rename_input(value, _name, nil), do: value
+  defp rename_input(%Axon.None{} = none, _name, _names), do: none
+
+  defp rename_input(%Nx.Tensor{} = tensor, name, names) do
+    actual = Nx.names(tensor)
+
+    if length(actual) == length(names) do
+      actual
+      |> Enum.zip(names)
+      |> Enum.each(fn
+        {nil, _} ->
+          :ok
+
+        {same, same} ->
+          :ok
+
+        {_, _} ->
+          raise ArgumentError,
+                "input #{inspect(name)} expected axis names #{inspect(names)}," <>
+                  " but received a tensor with names #{inspect(actual)}"
+      end)
+    end
+
+    # raises Nx's rank mismatch error when the lengths differ
+    Nx.rename(tensor, names)
+  end
+
+  defp rename_input(other, name, _names) do
+    raise ArgumentError,
+          "input #{inspect(name)} declares axis names, so it must receive" <>
+            " a tensor, got: #{inspect(other)}"
   end
 
   defp get_input(all_input_names, inputs, name, optional?) do

--- a/lib/axon/compiler.ex
+++ b/lib/axon/compiler.ex
@@ -979,24 +979,30 @@ defmodule Axon.Compiler do
   defp rename_input(%Nx.Tensor{} = tensor, name, names) do
     actual = Nx.names(tensor)
 
-    if length(actual) == length(names) do
-      actual
-      |> Enum.zip(names)
-      |> Enum.each(fn
-        {nil, _} ->
-          :ok
+    names =
+      if length(actual) == length(names) do
+        # declared names win over nil, incoming names are kept where
+        # the input declares nil, and conflicting names are an error
+        Enum.zip_with(actual, names, fn
+          actual_name, nil ->
+            actual_name
 
-        {same, same} ->
-          :ok
+          nil, declared_name ->
+            declared_name
 
-        {_, _} ->
-          raise ArgumentError,
-                "input #{inspect(name)} expected axis names #{inspect(names)}," <>
-                  " but received a tensor with names #{inspect(actual)}"
-      end)
-    end
+          same, same ->
+            same
 
-    # raises Nx's rank mismatch error when the lengths differ
+          _, _ ->
+            raise ArgumentError,
+                  "input #{inspect(name)} expected axis names #{inspect(names)}," <>
+                    " but received a tensor with names #{inspect(actual)}"
+        end)
+      else
+        # let Nx raise its rank mismatch error
+        names
+      end
+
     Nx.rename(tensor, names)
   end
 

--- a/lib/axon/display.ex
+++ b/lib/axon/display.ex
@@ -220,7 +220,7 @@ defmodule Axon.Display do
 
   defp render_output_shape(%Nx.Tensor{} = template) do
     type = type_str(Nx.type(template))
-    shape = shape_string(Nx.shape(template))
+    shape = shape_string(Nx.shape(template), Nx.names(template))
     "#{type}#{shape}"
   end
 
@@ -276,19 +276,32 @@ defmodule Axon.Display do
       %Parameter{name: name, template: %Nx.Tensor{} = template} ->
         type = Nx.type(template)
         shape = Nx.shape(template)
-        "#{name}: #{type_str(type)}#{shape_string(shape)}"
+        "#{name}: #{type_str(type)}#{shape_string(shape, Nx.names(template))}"
 
       %Parameter{name: name, template: shape_fn} when is_function(shape_fn) ->
-        shape = Nx.shape(apply(shape_fn, input_shapes))
-        "#{name}: #{type_str(type)}#{shape_string(shape)}"
+        template = apply(shape_fn, input_shapes)
+        "#{name}: #{type_str(type)}#{template_shape_string(template)}"
     end)
     |> Enum.join("\n")
   end
 
+  defp template_shape_string(%Nx.Tensor{} = template),
+    do: shape_string(Nx.shape(template), Nx.names(template))
+
+  defp template_shape_string(shape) when is_tuple(shape), do: shape_string(shape)
+
   defp shape_string(shape) do
+    shape_string(shape, List.duplicate(nil, tuple_size(shape)))
+  end
+
+  defp shape_string(shape, names) do
     shape
     |> Tuple.to_list()
-    |> Enum.map(fn n -> "[#{n}]" end)
+    |> Enum.zip(names)
+    |> Enum.map(fn
+      {n, nil} -> "[#{n}]"
+      {n, name} -> "[#{name}: #{n}]"
+    end)
     |> Enum.join("")
   end
 

--- a/lib/axon/layers.ex
+++ b/lib/axon/layers.ex
@@ -1942,6 +1942,13 @@ defmodule Axon.Layers do
   end
 
   @doc false
+  # Internal version of Nx.rename for constructing rename layers
+  deftransform rename(x, opts \\ []) do
+    opts = Keyword.validate!(opts, [:names, mode: :inference])
+    Nx.rename(x, opts[:names])
+  end
+
+  @doc false
   # Internal version of Nx.pad for constructing pad layers without
   # worrying about batch or channel dimensions
   defn pad(x, opts \\ []) do

--- a/lib/axon/shape.ex
+++ b/lib/axon/shape.ex
@@ -64,6 +64,31 @@ defmodule Axon.Shape do
   defp is_dim(_), do: false
 
   @doc """
+  Returns `true` if the given input shape is a plain tensor shape,
+  that is a tuple of dimension sizes, as opposed to a container of
+  shapes.
+
+  ## Examples
+
+      iex> Axon.Shape.tensor_shape?({nil, 32})
+      true
+
+      iex> Axon.Shape.tensor_shape?({})
+      true
+
+      iex> Axon.Shape.tensor_shape?({{nil, 32}, {nil, 8}})
+      false
+
+      iex> Axon.Shape.tensor_shape?(%{a: {nil, 32}})
+      false
+  """
+  def tensor_shape?(shape) when is_tuple(shape) do
+    tuple_size(shape) == 0 or is_dim(elem(shape, 0))
+  end
+
+  def tensor_shape?(_shape), do: false
+
+  @doc """
   Determines if two shapes are compatible. Shapes are compatible
   if they are equal, or if all non-nil dimensions are equal.
 

--- a/test/axon/compiler_test.exs
+++ b/test/axon/compiler_test.exs
@@ -195,6 +195,17 @@ defmodule CompilerTest do
       assert Nx.names(predict_fn.(ModelState.empty(), partial)) == [:batch, :features]
     end
 
+    test "keeps incoming names where the input declares nil" do
+      model = Axon.input("x", shape: {nil, 8}, names: [nil, :features])
+      assert {_init_fn, predict_fn} = Axon.build(model)
+
+      named = Nx.iota({2, 8}, type: :f32, names: [:batch, nil])
+      assert Nx.names(predict_fn.(ModelState.empty(), named)) == [:batch, :features]
+
+      unnamed = Nx.iota({2, 8}, type: :f32)
+      assert Nx.names(predict_fn.(ModelState.empty(), unnamed)) == [nil, :features]
+    end
+
     test "raises on input tensors with conflicting names" do
       model = Axon.input("x", shape: {nil, 8}, names: [:batch, :features])
       assert {_init_fn, predict_fn} = Axon.build(model)

--- a/test/axon/compiler_test.exs
+++ b/test/axon/compiler_test.exs
@@ -143,6 +143,118 @@ defmodule CompilerTest do
 
       assert Exception.message(exception) =~ "ambiguous"
     end
+
+    test "applies names to an unnamed input tensor" do
+      model = Axon.input("x", shape: {nil, 8}, names: [:batch, :features])
+      input = Nx.iota({2, 8}, type: :f32)
+
+      assert {init_fn, predict_fn} = Axon.build(model)
+      assert ModelState.empty() == init_fn.(input, ModelState.empty())
+
+      result = predict_fn.(ModelState.empty(), input)
+      assert Nx.names(result) == [:batch, :features]
+      assert_equal(result, input)
+    end
+
+    test "names flow into the init template and downstream layers" do
+      model =
+        Axon.input("x", shape: {nil, 8}, names: [:batch, :features])
+        |> Axon.dense(4)
+
+      template = Nx.template({2, 8}, :f32)
+
+      assert {init_fn, _predict_fn} = Axon.build(model)
+
+      assert %ModelState{data: %{"dense_0" => %{"kernel" => kernel}}} =
+               init_fn.(template, ModelState.empty())
+
+      assert Nx.shape(kernel) == {8, 4}
+      assert Nx.names(Axon.get_output_shape(model, template)) == [:batch, nil]
+    end
+
+    test "names are usable from custom layers" do
+      input = Axon.input("x", shape: {nil, 8}, names: [:batch, :features])
+      model = Axon.layer(fn x, _opts -> Nx.sum(x, axes: [:features]) end, [input])
+      x = Nx.iota({2, 8}, type: :f32)
+
+      assert {_init_fn, predict_fn} = Axon.build(model)
+
+      result = predict_fn.(ModelState.empty(), x)
+      assert Nx.names(result) == [:batch]
+      assert_equal(result, Nx.sum(x, axes: [1]))
+    end
+
+    test "accepts input tensors with matching or partial names" do
+      model = Axon.input("x", shape: {nil, 8}, names: [:batch, :features])
+      assert {_init_fn, predict_fn} = Axon.build(model)
+
+      named = Nx.iota({2, 8}, type: :f32, names: [:batch, :features])
+      assert Nx.names(predict_fn.(ModelState.empty(), named)) == [:batch, :features]
+
+      partial = Nx.iota({2, 8}, type: :f32, names: [nil, :features])
+      assert Nx.names(predict_fn.(ModelState.empty(), partial)) == [:batch, :features]
+    end
+
+    test "raises on input tensors with conflicting names" do
+      model = Axon.input("x", shape: {nil, 8}, names: [:batch, :features])
+      assert {_init_fn, predict_fn} = Axon.build(model)
+
+      assert_raise ArgumentError, ~r/expected axis names \[:batch, :features\]/, fn ->
+        predict_fn.(ModelState.empty(), Nx.iota({2, 8}, type: :f32, names: [:n, :d]))
+      end
+    end
+
+    test "raises on input tensors with a different rank than the names" do
+      model = Axon.input("x", names: [:batch, :features])
+      assert {_init_fn, predict_fn} = Axon.build(model)
+
+      assert_raise ArgumentError, ~r/invalid names for tensor of rank 3/, fn ->
+        predict_fn.(ModelState.empty(), Nx.iota({2, 8, 1}, type: :f32))
+      end
+    end
+
+    test "raises on container values given to a named input" do
+      model = Axon.input("x", names: [:batch, :features])
+      assert {_init_fn, predict_fn} = Axon.build(model)
+
+      assert_raise ArgumentError, ~r/must receive a tensor/, fn ->
+        predict_fn.(ModelState.empty(), {Nx.iota({2, 8}), Nx.iota({2, 8})})
+      end
+    end
+
+    test "names on an omitted optional input resolve to none" do
+      input = Axon.input("mask", optional: true, names: [:batch, :seq])
+
+      model =
+        Axon.layer(
+          fn
+            %Axon.None{}, _ -> Nx.tensor(0)
+            %Nx.Tensor{} = x, _ -> Nx.sum(x, axes: [:seq])
+          end,
+          [Axon.optional(input)]
+        )
+
+      assert {init_fn, predict_fn} = Axon.build(model)
+      assert init_fn.(%{}, ModelState.empty()) == ModelState.empty()
+      assert_equal(predict_fn.(ModelState.empty(), %{}), Nx.tensor(0))
+
+      x = Nx.iota({2, 3}, type: :f32)
+      assert_equal(predict_fn.(ModelState.empty(), %{"mask" => x}), Nx.sum(x, axes: [1]))
+    end
+
+    test "only renames inputs which declare names" do
+      x = Axon.input("x", shape: {nil, 2}, names: [:batch, :features])
+      y = Axon.input("y", shape: {nil, 2})
+      model = Axon.container({x, y})
+
+      assert {_init_fn, predict_fn} = Axon.build(model)
+
+      inputs = %{"x" => Nx.iota({1, 2}, type: :f32), "y" => Nx.iota({1, 2}, type: :f32)}
+      {out_x, out_y} = predict_fn.(ModelState.empty(), inputs)
+
+      assert Nx.names(out_x) == [:batch, :features]
+      assert Nx.names(out_y) == [nil, nil]
+    end
   end
 
   describe "optional" do
@@ -3198,6 +3310,52 @@ defmodule CompilerTest do
 
       assert {init_fn, predict_fn} = Axon.build(mp_model)
       assert Nx.type(predict_fn.(init_fn.(input, ModelState.empty()), input)) == {:bf, 16}
+    end
+  end
+
+  describe "rename" do
+    test "initializes with no params" do
+      model = Axon.input("input", shape: {nil, 8}) |> Axon.rename([:batch, :features])
+      input = random({1, 8})
+
+      assert {init_fn, _predict_fn} = Axon.build(model)
+      assert ModelState.empty() == init_fn.(input, ModelState.empty())
+    end
+
+    test "computes forward pass and names axes" do
+      model = Axon.input("input", shape: {nil, 8}) |> Axon.dense(4)
+      renamed = Axon.rename(model, [:batch, :hidden])
+      input = random({2, 8})
+
+      assert {init_fn, predict_fn} = Axon.build(model)
+      assert {_, renamed_predict_fn} = Axon.build(renamed)
+
+      params = init_fn.(input, ModelState.empty())
+      expected = predict_fn.(params, input)
+      result = renamed_predict_fn.(params, input)
+
+      assert Nx.names(result) == [:batch, :hidden]
+      assert_equal(result, expected)
+    end
+
+    test "names are usable from subsequent custom layers" do
+      renamed = Axon.input("input", shape: {nil, 8}) |> Axon.rename([:batch, :features])
+      model = Axon.layer(fn x, _opts -> Nx.sum(x, axes: [:features]) end, [renamed])
+
+      input = Nx.iota({2, 8}, type: :f32)
+
+      assert {_init_fn, predict_fn} = Axon.build(model)
+      assert_equal(predict_fn.(ModelState.empty(), input), Nx.sum(input, axes: [1]))
+    end
+
+    test "raises on names with wrong rank" do
+      model = Axon.input("input") |> Axon.rename([:batch, :features])
+
+      assert {_init_fn, predict_fn} = Axon.build(model)
+
+      assert_raise Axon.CompileError, ~r/invalid names for tensor of rank 3/, fn ->
+        predict_fn.(ModelState.empty(), random({1, 2, 3}))
+      end
     end
   end
 

--- a/test/axon/display_test.exs
+++ b/test/axon/display_test.exs
@@ -66,6 +66,7 @@ defmodule Axon.DisplayTest do
       assert table =~ ~s|f32[2][8]|
       assert table =~ ~s|f32[2][4]|
       refute table =~ ~s|batch:|
+      refute table =~ ~s|names:|
     end
   end
 

--- a/test/axon/display_test.exs
+++ b/test/axon/display_test.exs
@@ -43,6 +43,30 @@ defmodule Axon.DisplayTest do
 
       assert table =~ ~s|%{maybe: none, out: f32[1][2]}|
     end
+
+    test "renders axis names" do
+      model =
+        Axon.input("x", shape: {nil, 8}, names: [:batch, :features])
+        |> Axon.dense(4)
+        |> Axon.rename([:batch, :hidden])
+
+      table = Axon.Display.as_table(model, Nx.template({2, 8}, :f32))
+
+      assert table =~ ~s|f32[batch: 2][features: 8]|
+      assert table =~ ~s|names: [:batch, :features]|
+      assert table =~ ~s|f32[batch: 2][4]|
+      assert table =~ ~s|f32[batch: 2][hidden: 4]|
+      assert table =~ ~s|kernel: f32[8][4]|
+    end
+
+    test "renders unnamed axes without names" do
+      model = Axon.input("x", shape: {nil, 8}) |> Axon.dense(4)
+      table = Axon.Display.as_table(model, Nx.template({2, 8}, :f32))
+
+      assert table =~ ~s|f32[2][8]|
+      assert table =~ ~s|f32[2][4]|
+      refute table =~ ~s|batch:|
+    end
   end
 
   describe "as_graph/3" do

--- a/test/axon_test.exs
+++ b/test/axon_test.exs
@@ -26,10 +26,9 @@ defmodule AxonTest do
       assert opts[:names] == [:batch, :features]
     end
 
-    test "names default to nil" do
+    test "does not store names when not given" do
       assert %Axon{output: id, nodes: nodes} = Axon.input("x", shape: {nil, 8})
-      assert %Axon.Node{op: :input, opts: opts} = nodes[id]
-      assert opts[:names] == nil
+      assert %Axon.Node{op: :input, opts: [shape: {nil, 8}, optional: false]} = nodes[id]
     end
 
     test "raises on names with wrong rank" do
@@ -839,6 +838,10 @@ defmodule AxonTest do
     test "raises on invalid names" do
       assert_raise ArgumentError, ~r/names must be a list of atoms or nil/, fn ->
         Axon.input("x", shape: {nil, 8}) |> Axon.rename([:batch, "hidden"])
+      end
+
+      assert_raise ArgumentError, ~r/names must be a list of atoms or nil/, fn ->
+        Axon.input("x", shape: {nil, 8}) |> Axon.rename(:batch)
       end
     end
   end

--- a/test/axon_test.exs
+++ b/test/axon_test.exs
@@ -9,6 +9,50 @@ defmodule AxonTest do
       assert %Axon{output: id, nodes: nodes} = Axon.input("input", shape: {32, 1, 28, 28})
       assert %Axon.Node{op: :input, parent: []} = nodes[id]
     end
+
+    test "works with names" do
+      assert %Axon{output: id, nodes: nodes} =
+               Axon.input("x", shape: {nil, 8}, names: [:batch, :features])
+
+      assert %Axon.Node{op: :input, opts: opts} = nodes[id]
+      assert opts[:shape] == {nil, 8}
+      assert opts[:names] == [:batch, :features]
+    end
+
+    test "works with names and no shape" do
+      assert %Axon{output: id, nodes: nodes} = Axon.input("x", names: [:batch, :features])
+      assert %Axon.Node{op: :input, opts: opts} = nodes[id]
+      assert opts[:shape] == nil
+      assert opts[:names] == [:batch, :features]
+    end
+
+    test "names default to nil" do
+      assert %Axon{output: id, nodes: nodes} = Axon.input("x", shape: {nil, 8})
+      assert %Axon.Node{op: :input, opts: opts} = nodes[id]
+      assert opts[:names] == nil
+    end
+
+    test "raises on names with wrong rank" do
+      assert_raise ArgumentError, ~r/invalid names for tensor of rank 2/, fn ->
+        Axon.input("x", shape: {nil, 8}, names: [:batch])
+      end
+    end
+
+    test "raises on invalid names" do
+      assert_raise ArgumentError, ~r/names must be a list of atoms or nil/, fn ->
+        Axon.input("x", shape: {nil, 8}, names: ["batch", :features])
+      end
+
+      assert_raise ArgumentError, ~r/names must be a list of atoms or nil/, fn ->
+        Axon.input("x", shape: {nil, 8}, names: :batch)
+      end
+    end
+
+    test "raises on names with container shape" do
+      assert_raise ArgumentError, ~r/only supported for inputs with a tensor shape/, fn ->
+        Axon.input("x", shape: %{a: {nil, 2}}, names: [:batch, :x])
+      end
+    end
   end
 
   describe "constant" do
@@ -780,6 +824,22 @@ defmodule AxonTest do
                |> Axon.transpose([2, 1, 0])
 
       assert %Axon.Node{} = nodes[id]
+    end
+  end
+
+  describe "rename" do
+    test "works with batch input" do
+      assert %Axon{output: id, nodes: nodes} =
+               Axon.input("x", shape: {nil, 8}) |> Axon.rename([:batch, :hidden])
+
+      assert %Axon.Node{op: :rename, op_name: :rename, opts: [names: [:batch, :hidden]]} =
+               nodes[id]
+    end
+
+    test "raises on invalid names" do
+      assert_raise ArgumentError, ~r/names must be a list of atoms or nil/, fn ->
+        Axon.input("x", shape: {nil, 8}) |> Axon.rename([:batch, "hidden"])
+      end
     end
   end
 


### PR DESCRIPTION
Closes #57.

The issue proposed writing input shapes as keyword lists (`Axon.input(batch: nil, channels: 3, ...)`) so that axes can be referred to by name. The maintainer feedback was that mixing keyword lists and tuples is undesirable and that a separate `:names` option, as in Nx, would be preferable. Nx itself never adopted keyword shapes, and its convention is `names: [...]` on `Nx.tensor/2`, `Nx.template/3` and `Nx.rename/2`, so this PR follows that convention.

## Design

Axon layers are plain Nx ops, so names on an input tensor already flow through the graph today: `dense` keeps the batch name, `layer_norm`, `dropout`, `conv`, pooling and element-wise layers preserve names, and compiled predict functions return named tensors. What was missing was a way to declare names on the model itself, rather than relying on the caller to hand in a named tensor, and a way to name axes produced by layers. This PR adds both.

* `Axon.input(name, names: [...])` declares axis names on an input. Names are validated at graph construction time against `:shape` when one is given (Nx's own rank-mismatch error is raised), and are stored in the node opts alongside `:shape` and `:optional`. When the model runs, the compiler applies them with `Nx.rename/2` to both the predict value and the init template, so every subsequent layer, including custom `Axon.layer` closures, can use `axes: [:features]`, `Nx.axis_index(x, :seq)` and friends. If the incoming tensor already carries a different non-nil name for an axis, an `ArgumentError` is raised; matching names pass through, and where the input declares `nil` for an axis the incoming name is kept (so `nil` behaves like the `nil` dimensions in `:shape`). `:names` is only supported for inputs with a tensor shape, not container shapes.

* `Axon.rename(x, names)` is a new shape layer mirroring `Nx.rename/2`, for naming axes that a layer produced (for example the new feature axis after `Axon.dense`). This serves the issue's "output features as keywords" idea without adding a `:names` option to every layer function.

* `Axon.Display.as_table/2` renders names in the output shape and parameter columns when present, matching `Nx` inspect (`f32[batch: 2][features: 8]`). The input row's options column already lists every entry of the node opts, so `names: [...]` shows up there as well.

Usage:

```elixir
model =
  Axon.input("features", shape: {nil, 784}, names: [:batch, :pixels])
  |> Axon.dense(128)
  |> Axon.rename([:batch, :hidden])

# custom layers can refer to axes by name
input = Axon.input("features", shape: {nil, 784}, names: [:batch, :pixels])
Axon.layer(fn x, _opts -> Nx.sum(x, axes: [:pixels]) end, [input])
```

`:names` is only stored in the input node opts when given, so unnamed inputs keep exactly the same node opts (and `Axon.Display` output) as before. The compiler's input clause previously pattern-matched the exact keyword list `[shape: _, optional: _]`; it now reads the opts with `Keyword.fetch!`/`Keyword.get`, so both named and unnamed inputs compile. A small `Axon.Shape.tensor_shape?/1` helper is exposed so `input/2` can tell tensor shapes from container shapes the same way `Axon.Shape.input/1` does.

## Limitations

* Keyword-list shapes are intentionally not supported, per the maintainer feedback on the issue.
* No per-layer `:names` options are added (e.g. `Axon.dense(128, names: ...)`); `Axon.rename/3` is the escape hatch.
* `Axon.flatten` and the RNN layers still drop names, following `Nx.reshape` and the RNN loop semantics. `Axon.rename/3` can restore them after those layers.
* `:shape` is still not validated at run time (pre-existing `TODO` in the compiler); only `:names` is checked against the actual tensor.
* `Axon.get_inputs/1` is unchanged and still returns `name => shape`, since changing its return type would be breaking.

## Tests

* `test/axon_test.exs`: input nodes carry `:names`, names default to `nil`, rank mismatch against `:shape`, non-atom names, names on container shapes, names without a shape, and `Axon.rename/3` node construction and validation.
* `test/axon/compiler_test.exs`: predict renames an unnamed tensor and preserves values; names flow into the init template and `Axon.get_output_shape/2`; names are usable from custom layers via `axes: [:features]`; matching and partial names on incoming tensors pass through, and incoming names are kept where the input declares `nil`; conflicting names, rank mismatches and container values raise; omitted optional inputs with names still resolve to `%Axon.None{}`; multi-input models only rename the inputs that declare names; `Axon.rename/3` forward pass, downstream use and rank errors.
* `test/axon/display_test.exs`: named and unnamed templates render as `f32[batch: 2][features: 8]` and `f32[2][8]`, and `names: [...]` appears in the input row's options.
* `test/axon/shape_test.exs` picks up the `Axon.Shape.tensor_shape?/1` doctests.

Verified with `mix test` (905 passed, 47 excluded) and `USE_EXLA=1 mix test test/axon/compiler_test.exs test/axon/display_test.exs test/axon_test.exs` (366 passed) to cover the jitted path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

