### PR TITLE
Add parameter constraints

### DIFF
--- a/lib/axon.ex
+++ b/lib/axon.ex
@@ -283,6 +283,8 @@ defmodule Axon do
 
   @type t :: %__MODULE__{}
 
+  @valid_constraints [:max_norm, :min_max_norm, :non_neg, :unit_norm]
+
   defstruct [
     :nodes,
     :output
@@ -413,6 +415,12 @@ defmodule Axon do
     * `:initializer` - parameter initializer. Defaults to `:glorot_uniform`.
     * `:type` - parameter type. Defaults to `{:f, 32}`.
     * `:kind` - parameter kind. Defaults to `:parameter`.
+    * `:constraint` - parameter constraint applied after each optimizer
+      update. Either one of `#{inspect(@valid_constraints)}` (a function
+      in `Axon.Constraints` with default options) or an arity-1 function
+      receiving the parameter tensor and returning the projected tensor.
+      Defaults to `nil` (no constraint). Constraints only apply to
+      trainable (`kind: :parameter`) parameters that are not frozen.
 
   ## Examples
 
@@ -434,12 +442,23 @@ defmodule Axon do
 
       parameter("kernel", {32, 64}, type: {:bf, 16}, initializer: :lecun_normal)
 
+  With a constraint:
+
+      parameter("kernel", {32, 64}, constraint: Axon.Constraints.max_norm(max: 2.0))
+
   """
   @doc type: :special
   def parameter(name, template, opts \\ [])
 
   def parameter(name, shape, opts) when is_tuple(shape) do
-    opts = Keyword.validate!(opts, initializer: :glorot_uniform, type: {:f, 32}, kind: :parameter)
+    opts =
+      Keyword.validate!(opts,
+        initializer: :glorot_uniform,
+        type: {:f, 32},
+        kind: :parameter,
+        constraint: nil
+      )
+
     {type, opts} = Keyword.pop!(opts, :type)
 
     template = Nx.template(shape, type)
@@ -447,8 +466,11 @@ defmodule Axon do
   end
 
   def parameter(name, %Nx.Tensor{} = template, opts) do
-    opts = Keyword.validate!(opts, initializer: :glorot_uniform, kind: :parameter)
+    opts =
+      Keyword.validate!(opts, initializer: :glorot_uniform, kind: :parameter, constraint: nil)
+
     initializer = validate_initializer!(opts[:initializer])
+    constraint = validate_constraint!(opts[:constraint])
     kind = opts[:kind] || :parameter
 
     template = Nx.to_template(template)
@@ -457,6 +479,7 @@ defmodule Axon do
       name: name,
       template: template,
       initializer: initializer,
+      constraint: constraint,
       kind: kind,
       # Legacy
       type: Nx.type(template),
@@ -465,9 +488,17 @@ defmodule Axon do
   end
 
   def parameter(name, function, opts) when is_function(function) do
-    opts = Keyword.validate!(opts, initializer: :glorot_uniform, type: nil, kind: :parameter)
+    opts =
+      Keyword.validate!(opts,
+        initializer: :glorot_uniform,
+        type: nil,
+        kind: :parameter,
+        constraint: nil
+      )
+
     {type, opts} = Keyword.pop!(opts, :type)
     initializer = validate_initializer!(opts[:initializer])
+    constraint = validate_constraint!(opts[:constraint])
     kind = opts[:kind] || :parameter
 
     template =
@@ -486,12 +517,20 @@ defmodule Axon do
       name: name,
       template: template,
       initializer: initializer,
+      constraint: constraint,
       kind: kind
     }
   end
 
   def parameter(name, shape_dsl, opts) when is_list(shape_dsl) do
-    opts = Keyword.validate!(opts, initializer: :glorot_uniform, type: {:f, 32}, kind: :parameter)
+    opts =
+      Keyword.validate!(opts,
+        initializer: :glorot_uniform,
+        type: {:f, 32},
+        kind: :parameter,
+        constraint: nil
+      )
+
     {type, opts} = Keyword.pop!(opts, :type)
 
     if Enum.all?(shape_dsl, &is_integer/1) do
@@ -547,18 +586,40 @@ defmodule Axon do
 
   You may specify the parameter shape as either a static shape or
   as function of the inputs to the given layer. If you specify the
-  parameter shape as a function, it will be given the
+  parameter shape as a function, it will be given the shapes of the
+  layer inputs and must return the parameter shape.
 
   ## Options
 
     * `:initializer` - parameter initializer. Defaults to `:glorot_uniform`.
+    * `:type` - parameter type. Defaults to `{:f, 32}`.
+    * `:kind` - parameter kind. Defaults to `:parameter`.
+    * `:constraint` - parameter constraint applied after each optimizer
+      update. Either one of `#{inspect(@valid_constraints)}` (a function
+      in `Axon.Constraints` with default options) or an arity-1 function
+      receiving the parameter tensor and returning the projected tensor.
+      Defaults to `nil` (no constraint). Constraints only apply to
+      trainable (`kind: :parameter`) parameters that are not frozen.
+
+  ## Examples
+
+      param("kernel", {32, 64})
+      param("kernel", fn input_shape -> {elem(input_shape, 1), 64} end)
+      param("kernel", {32, 64}, constraint: :non_neg)
 
   """
   @doc type: :special
   def param(name, shape, opts \\ [])
 
   def param(name, shape, opts) when is_binary(name) and is_tuple(shape) do
-    opts = Keyword.validate!(opts, initializer: :glorot_uniform, type: {:f, 32}, kind: :parameter)
+    opts =
+      Keyword.validate!(opts,
+        initializer: :glorot_uniform,
+        type: {:f, 32},
+        kind: :parameter,
+        constraint: nil
+      )
+
     {type, opts} = Keyword.pop(opts, :type, {:f, 32})
 
     template = Nx.template(shape, type)
@@ -566,7 +627,14 @@ defmodule Axon do
   end
 
   def param(name, shape, opts) when is_binary(name) and is_function(shape) do
-    opts = Keyword.validate!(opts, initializer: :glorot_uniform, type: {:f, 32}, kind: :parameter)
+    opts =
+      Keyword.validate!(opts,
+        initializer: :glorot_uniform,
+        type: {:f, 32},
+        kind: :parameter,
+        constraint: nil
+      )
+
     {type, opts} = Keyword.pop(opts, :type, {:f, 32})
 
     {:arity, arity} = Function.info(shape, :arity)
@@ -582,7 +650,14 @@ defmodule Axon do
   end
 
   def param(name, shape_dsl, opts) when is_binary(name) and is_list(shape_dsl) do
-    opts = Keyword.validate!(opts, initializer: :glorot_uniform, type: {:f, 32}, kind: :parameter)
+    opts =
+      Keyword.validate!(opts,
+        initializer: :glorot_uniform,
+        type: {:f, 32},
+        kind: :parameter,
+        constraint: nil
+      )
+
     {type, opts} = Keyword.pop(opts, :type, {:f, 32})
 
     if Enum.all?(shape_dsl, &is_integer/1) do
@@ -4677,6 +4752,24 @@ defmodule Axon do
           "initializer must be one of #{inspect(@valid_initializers)}," <>
             " or an arity-3 function accepting initializer shape, type, and key" <>
             " got #{inspect(initializer)}"
+  end
+
+  defp validate_constraint!(nil), do: nil
+
+  defp validate_constraint!(constraint)
+       when is_atom(constraint) and constraint in @valid_constraints do
+    apply(Axon.Constraints, constraint, [])
+  end
+
+  defp validate_constraint!(constraint) when is_function(constraint, 1) do
+    constraint
+  end
+
+  defp validate_constraint!(constraint) do
+    raise ArgumentError,
+          "constraint must be one of #{inspect(@valid_constraints)}," <>
+            " or an arity-1 function accepting a parameter tensor," <>
+            " got #{inspect(constraint)}"
   end
 
   # Names are generated lazily at inspect, initialization, and compile

--- a/lib/axon/compiler.ex
+++ b/lib/axon/compiler.ex
@@ -65,7 +65,8 @@ defmodule Axon.Compiler do
         to_model_funs(
           id,
           nodes,
-          {%{}, %{}, %{}, %{parameters: %{}, state: %{}, frozen_parameters: %{}}},
+          {%{}, %{}, %{},
+           %{parameters: %{}, state: %{}, frozen_parameters: %{}, constraints: %{}}},
           config
         )
       end)
@@ -161,7 +162,8 @@ defmodule Axon.Compiler do
               data: init_params,
               parameters: parameters,
               state: %{},
-              frozen_parameters: %{}
+              frozen_parameters: %{},
+              constraints: %{}
             }
         end
 
@@ -296,7 +298,21 @@ defmodule Axon.Compiler do
   end
 
   defp merge_model_state!(state, init_state) do
-    %{state | data: merge_params!(state.data, init_state.data)}
+    %{
+      state
+      | data: merge_params!(state.data, init_state.data),
+        constraints: merge_constraints(state.constraints, init_state.constraints)
+    }
+  end
+
+  defp merge_constraints(compiled, given) do
+    Map.merge(compiled, given, fn
+      _key, compiled_val, given_val when is_map(compiled_val) and is_map(given_val) ->
+        merge_constraints(compiled_val, given_val)
+
+      _key, _compiled_val, given_val ->
+        given_val
+    end)
   end
 
   defp merge_params!(params, init_params) do
@@ -331,13 +347,15 @@ defmodule Axon.Compiler do
   defp normalize_blocks(params, %{
          state: meta_state,
          parameters: meta_params,
-         frozen_parameters: frozen
+         frozen_parameters: frozen,
+         constraints: constraints
        }) do
     model_state = %Axon.ModelState{
       data: %{},
       state: meta_state,
       parameters: meta_params,
-      frozen_parameters: frozen
+      frozen_parameters: frozen,
+      constraints: constraints
     }
 
     # Blocks are kinda hacky and produce a model state,
@@ -355,6 +373,11 @@ defmodule Axon.Compiler do
           if model_state.state == %{},
             do: state,
             else: Map.put(state, key, model_state.state)
+        end)
+        |> update_in([Access.key!(:constraints)], fn constraints ->
+          if model_state.constraints == %{},
+            do: constraints,
+            else: Map.put(constraints, key, model_state.constraints)
         end)
         |> update_in([Access.key!(:data)], fn state ->
           Map.put(state, key, model_state.data)
@@ -886,15 +909,29 @@ defmodule Axon.Compiler do
     # Get parameter metadata for the layer
     model_state_meta =
       Enum.reduce(layer_params, model_state_meta, fn
-        %{kind: :parameter, frozen: frozen?, name: param_name}, acc ->
+        %{kind: :parameter, frozen: frozen?, name: param_name, constraint: constraint}, acc ->
           meta =
             Map.update!(acc, :parameters, fn layer_meta ->
               Map.update(layer_meta, name, [param_name], &[param_name | &1])
             end)
 
-          if frozen? do
-            Map.update!(meta, :frozen_parameters, fn layer_meta ->
-              Map.update(layer_meta, name, [param_name], &[param_name | &1])
+          meta =
+            if frozen? do
+              Map.update!(meta, :frozen_parameters, fn layer_meta ->
+                Map.update(layer_meta, name, [param_name], &[param_name | &1])
+              end)
+            else
+              meta
+            end
+
+          if constraint do
+            Map.update!(meta, :constraints, fn layer_meta ->
+              Map.update(
+                layer_meta,
+                name,
+                %{param_name => constraint},
+                &Map.put(&1, param_name, constraint)
+              )
             end)
           else
             meta

--- a/lib/axon/constraints.ex
+++ b/lib/axon/constraints.ex
@@ -1,0 +1,165 @@
+defmodule Axon.Constraints do
+  @moduledoc """
+  Parameter constraints.
+
+  Constraints are projections applied to trainable parameters after
+  each optimizer update, keeping them inside a feasible region such as
+  a maximum norm or non-negativity. They are declared per parameter
+  with the `:constraint` option of `Axon.param/3`, or attached to an
+  existing model state with `Axon.ModelState.constrain/3`, and applied
+  by `Axon.Loop.train_step/4` after every update.
+
+  Constraints are never applied at initialization, to frozen parameters,
+  or to layer state such as batch normalization statistics.
+
+  The functions in this module return arity-1 functions which take a
+  parameter tensor and return the projected tensor:
+
+      constraint = Axon.Constraints.max_norm(max: 2.0)
+      constraint.(kernel)
+
+  Norm-based constraints compute the norm over the given `:axes` and
+  rescale the vectors along the remaining axes. For a dense kernel of
+  shape `{in, out}`, `axes: [0]` (the default) constrains the incoming
+  weight vector of every output unit.
+
+  You may use these functions from within `defn` or outside.
+  """
+  import Nx.Defn
+
+  @epsilon 1.0e-7
+
+  @doc """
+  Constrains the norm of the parameter to be at most `:max`.
+
+  Vectors whose norm exceeds `:max` are rescaled to have norm
+  `:max`; all other vectors are left unchanged.
+
+  ## Options
+
+    * `:max` - maximum norm. Defaults to `2.0`.
+
+    * `:axes` - axes to compute the norm over. Defaults to `[0]`.
+
+  ## Examples
+
+      iex> constraint = Axon.Constraints.max_norm(max: 1.0)
+      iex> constraint.(Nx.tensor([[0.0, 0.0], [3.0, 4.0]]))
+      #Nx.Tensor<
+        f32[2][2]
+        [
+          [0.0, 0.0],
+          [1.0, 1.0]
+        ]
+      >
+  """
+  def max_norm(opts \\ []) do
+    fn x -> max_norm_impl(x, opts) end
+  end
+
+  defnp max_norm_impl(x, opts \\ []) do
+    opts = keyword!(opts, max: 2.0, axes: [0])
+    norms = norm(x, opts[:axes])
+    desired = Nx.clip(norms, 0, opts[:max])
+    x * (desired / (norms + @epsilon))
+  end
+
+  @doc """
+  Constrains the parameter to be non-negative.
+
+  ## Examples
+
+      iex> constraint = Axon.Constraints.non_neg()
+      iex> constraint.(Nx.tensor([[-1.0, 2.0], [3.0, -4.0]]))
+      #Nx.Tensor<
+        f32[2][2]
+        [
+          [0.0, 2.0],
+          [3.0, 0.0]
+        ]
+      >
+  """
+  def non_neg() do
+    &non_neg_impl/1
+  end
+
+  defnp non_neg_impl(x) do
+    Nx.max(x, 0)
+  end
+
+  @doc """
+  Constrains the parameter to have unit norm.
+
+  ## Options
+
+    * `:axes` - axes to compute the norm over. Defaults to `[0]`.
+
+  ## Examples
+
+      iex> constraint = Axon.Constraints.unit_norm()
+      iex> constraint.(Nx.tensor([[0.0, 0.0], [2.0, 4.0]]))
+      #Nx.Tensor<
+        f32[2][2]
+        [
+          [0.0, 0.0],
+          [1.0, 1.0]
+        ]
+      >
+  """
+  def unit_norm(opts \\ []) do
+    fn x -> unit_norm_impl(x, opts) end
+  end
+
+  defnp unit_norm_impl(x, opts \\ []) do
+    opts = keyword!(opts, axes: [0])
+    x / (norm(x, opts[:axes]) + @epsilon)
+  end
+
+  @doc """
+  Constrains the norm of the parameter to be between `:min` and `:max`.
+
+  Vectors whose norm lies outside `[min, max]` are rescaled toward the
+  nearest bound. `:rate` controls how strictly the constraint is
+  enforced on each application: with `rate: 1.0` norms are clipped
+  exactly, while smaller rates only move the norm part of the way
+  toward the feasible region.
+
+  ## Options
+
+    * `:min` - minimum norm. Defaults to `0.0`.
+
+    * `:max` - maximum norm. Defaults to `1.0`.
+
+    * `:rate` - rate at which to enforce the constraint. Defaults to `1.0`.
+
+    * `:axes` - axes to compute the norm over. Defaults to `[0]`.
+
+  ## Examples
+
+      iex> constraint = Axon.Constraints.min_max_norm(min: 8.0, max: 16.0)
+      iex> constraint.(Nx.tensor([[4.0, 32.0]]))
+      #Nx.Tensor<
+        f32[1][2]
+        [
+          [8.0, 16.0]
+        ]
+      >
+  """
+  def min_max_norm(opts \\ []) do
+    fn x -> min_max_norm_impl(x, opts) end
+  end
+
+  defnp min_max_norm_impl(x, opts \\ []) do
+    opts = keyword!(opts, min: 0.0, max: 1.0, rate: 1.0, axes: [0])
+    norms = norm(x, opts[:axes])
+
+    desired =
+      opts[:rate] * Nx.clip(norms, opts[:min], opts[:max]) + (1 - opts[:rate]) * norms
+
+    x * (desired / (norms + @epsilon))
+  end
+
+  defnp norm(x, axes) do
+    Nx.sqrt(Nx.sum(x * x, axes: axes, keep_axes: true))
+  end
+end

--- a/lib/axon/loop.ex
+++ b/lib/axon/loop.ex
@@ -311,6 +311,10 @@ defmodule Axon.Loop do
   the model through `model_parameters = Axon.Update.apply_updates(model_parameters, scaled_updates)`.
   See `Polaris.Updates` for more information on building optimizers.
 
+  Parameter constraints declared with the `:constraint` option of `Axon.param/3`
+  or attached with `Axon.ModelState.constrain/3` are applied after every
+  optimizer update via `Axon.ModelState.apply_constraints/1`.
+
   ## Options
 
     * `:seed` - seed to use when constructing models. Seed controls random initialization
@@ -407,7 +411,10 @@ defmodule Axon.Loop do
           |> Nx.add(batch_loss)
           |> Nx.divide(Nx.add(i, 1))
 
-        new_model_state = Axon.ModelState.update(model_state, updated_parameters, updated_state)
+        new_model_state =
+          model_state
+          |> Axon.ModelState.update(updated_parameters, updated_state)
+          |> Axon.ModelState.apply_constraints()
 
         %{
           state
@@ -636,6 +643,26 @@ defmodule Axon.Loop do
       model
       |> Axon.Loop.trainer(loss_weights, :sgd)
       |> Axon.Loop.run(data)
+
+  ### Parameter constraints
+
+  Constraints declared with the `:constraint` option of `Axon.param/3`, or
+  attached to the initial model state with `Axon.ModelState.constrain/3`, are
+  applied after every optimizer update:
+
+      {init_fn, _} = Axon.build(model)
+      model_state = init_fn.(template, Axon.ModelState.empty())
+
+      model_state =
+        Axon.ModelState.constrain(
+          model_state,
+          &match?([_, "kernel"], &1),
+          Axon.Constraints.max_norm(max: 2.0)
+        )
+
+      model
+      |> Axon.Loop.trainer(:mean_squared_error, :sgd)
+      |> Axon.Loop.run(data, model_state)
 
   ## Options
 

--- a/lib/axon/model_state.ex
+++ b/lib/axon/model_state.ex
@@ -12,9 +12,9 @@ defmodule Axon.ModelState do
 
   @derive {
     Nx.Container,
-    keep: [:parameters, :state, :frozen_parameters], containers: [:data]
+    keep: [:parameters, :state, :frozen_parameters, :constraints], containers: [:data]
   }
-  defstruct [:data, :parameters, :state, :frozen_parameters]
+  defstruct [:data, :parameters, :state, :frozen_parameters, constraints: %{}]
 
   alias __MODULE__
 
@@ -134,6 +134,67 @@ defmodule Axon.ModelState do
   end
 
   @doc """
+  Constrains parameters in the given model state using the given mask.
+
+  The mask is an arity 1 function which takes the access path to the
+  leaf parameter and returns `true` if `constraint` should be applied
+  to it or `false` otherwise. `constraint` is an arity 1 function which
+  receives a parameter tensor and returns the projected tensor, such as
+  the functions in `Axon.Constraints`:
+
+      Axon.ModelState.constrain(
+        model_state,
+        &match?([_, "kernel"], &1),
+        Axon.Constraints.max_norm(max: 2.0)
+      )
+
+  Constraints are applied by `apply_constraints/1`, which
+  `Axon.Loop.train_step/4` calls after every optimizer update. Only
+  trainable, non-frozen parameters are constrained.
+
+  Constraints are stored as functions in the model state metadata, so
+  they are serialized along with the model state and can only be
+  deserialized when the module defining the constraint is available.
+  """
+  deftransform constrain(
+                 %ModelState{data: data, constraints: constraints} = model_state,
+                 mask,
+                 constraint
+               )
+               when is_function(mask, 1) and is_function(constraint, 1) do
+    constraints =
+      data
+      |> get_paths()
+      |> Enum.filter(mask)
+      |> Enum.reduce(constraints, &put_path(&2, &1, constraint))
+
+    %{model_state | constraints: constraints}
+  end
+
+  @doc """
+  Applies the constraints in the given model state to its
+  trainable parameters.
+
+  Parameters without a constraint, frozen parameters, and state
+  are left untouched.
+  """
+  deftransform apply_constraints(
+                 %ModelState{
+                   data: data,
+                   parameters: parameters,
+                   frozen_parameters: frozen,
+                   constraints: constraints
+                 } = model_state
+               ) do
+    active =
+      parameters
+      |> tree_diff(frozen)
+      |> then(&tree_get(constraints, &1))
+
+    %{model_state | data: constrain_tree(data, active)}
+  end
+
+  @doc """
   Returns the trainable parameters in the given model state.
   """
   deftransform trainable_parameters(%ModelState{
@@ -197,7 +258,8 @@ defmodule Axon.ModelState do
       data: data,
       parameters: transform_to_parameters(data),
       state: %{},
-      frozen_parameters: %{}
+      frozen_parameters: %{},
+      constraints: %{}
     }
   end
 
@@ -278,6 +340,31 @@ defmodule Axon.ModelState do
   defp traverse(map, acc) do
     Enum.flat_map(map, fn {k, value} ->
       traverse(value, [k | acc])
+    end)
+  end
+
+  defp put_path(map, [key], value), do: Map.put(map, key, value)
+
+  defp put_path(map, [key | rest], value) do
+    Map.update(map, key, put_path(%{}, rest, value), &put_path(&1, rest, value))
+  end
+
+  defp constrain_tree(data, constraints) do
+    Enum.reduce(constraints, data, fn
+      {key, fun}, acc when is_function(fun, 1) ->
+        case acc do
+          %{^key => %Nx.Tensor{} = tensor} -> Map.put(acc, key, fun.(tensor))
+          %{} -> acc
+        end
+
+      {key, inner}, acc when is_map(inner) ->
+        case acc do
+          %{^key => %{} = nested} when not is_struct(nested) ->
+            Map.put(acc, key, constrain_tree(nested, inner))
+
+          %{} ->
+            acc
+        end
     end)
   end
 

--- a/lib/axon/parameter.ex
+++ b/lib/axon/parameter.ex
@@ -5,6 +5,7 @@ defmodule Axon.Parameter do
     :template,
     :shape,
     :initializer,
+    :constraint,
     :children,
     type: {:f, 32},
     frozen: false,

--- a/mix.exs
+++ b/mix.exs
@@ -170,13 +170,15 @@ defmodule Axon.MixProject do
           Axon.MixedPrecision,
           Axon.None,
           Axon.StatefulOutput,
-          Axon.Initializers
+          Axon.Initializers,
+          Axon.Constraints
         ],
         Summary: [
           Axon.Display
         ],
         Functional: [
           Axon.Activations,
+          Axon.Constraints,
           Axon.Initializers,
           Axon.Layers,
           Axon.Losses,

--- a/test/axon/compiler_test.exs
+++ b/test/axon/compiler_test.exs
@@ -5097,6 +5097,22 @@ defmodule CompilerTest do
   end
 
   describe "block" do
+    test "nests constraints of layers inside the block" do
+      block =
+        Axon.block(fn x ->
+          a = Axon.param("a", {1, 1}, constraint: :non_neg)
+          Axon.layer(fn x, a, _opts -> Nx.add(x, a) end, [x, a], name: "custom_0")
+        end)
+
+      model = block.(Axon.input("features"))
+      {init_fn, _} = Axon.build(model)
+
+      assert %ModelState{constraints: %{"block_0" => %{"custom_0" => %{"a" => f}}}} =
+               init_fn.(Nx.template({1, 1}, :f32), ModelState.empty())
+
+      assert is_function(f, 1)
+    end
+
     test "initializes correctly with single dense layer, used once" do
       block = Axon.block(&Axon.dense(&1, 32))
       model = block.(Axon.input("features"))
@@ -5874,6 +5890,47 @@ defmodule CompilerTest do
   end
 
   describe "parameters" do
+    test "collects constraints into model state metadata" do
+      a = Axon.param("a", {2, 2}, constraint: :non_neg)
+      input = Axon.input("input")
+
+      model =
+        Axon.layer(fn x, a, _opts -> Nx.add(x, a) end, [input, a], name: "custom")
+
+      {init_fn, _} = Axon.build(model)
+
+      assert %ModelState{constraints: %{"custom" => %{"a" => f}}} =
+               init_fn.(Nx.template({1, 2}, :f32), ModelState.empty())
+
+      assert is_function(f, 1)
+    end
+
+    test "has no constraints when none are declared" do
+      a = Axon.param("a", {2, 2})
+      input = Axon.input("input")
+
+      model =
+        Axon.layer(fn x, a, _opts -> Nx.add(x, a) end, [input, a], name: "custom")
+
+      {init_fn, _} = Axon.build(model)
+
+      assert %ModelState{constraints: %{}} =
+               init_fn.(Nx.template({1, 2}, :f32), ModelState.empty())
+    end
+
+    test "preserves constraints of the initial model state" do
+      model = Axon.input("input", shape: {nil, 2}) |> Axon.dense(4, name: "dense_0")
+      {init_fn, _} = Axon.build(model)
+      constraint = Axon.Constraints.max_norm(max: 1.0)
+
+      model_state =
+        init_fn.(Nx.template({1, 2}, :f32), ModelState.empty())
+        |> ModelState.constrain(&match?(["dense_0", "kernel"], &1), constraint)
+
+      assert %ModelState{constraints: %{"dense_0" => %{"kernel" => ^constraint}}} =
+               init_fn.(Nx.template({1, 2}, :f32), model_state)
+    end
+
     test "supports passing a template instead of a function as the shape" do
       a = Axon.param("a", {1, 1})
       input = Axon.input("input")

--- a/test/axon/constraints_test.exs
+++ b/test/axon/constraints_test.exs
@@ -1,0 +1,92 @@
+defmodule Axon.ConstraintsTest do
+  use Axon.Case, async: true
+
+  doctest Axon.Constraints
+
+  defmodule InDefn do
+    import Nx.Defn
+
+    defn apply_constraint(constraint, x), do: constraint.(x)
+  end
+
+  # Column norms are 5 and 1
+  @x Nx.tensor([[3.0, 0.0], [4.0, 1.0]])
+
+  describe "max_norm/1" do
+    test "rescales vectors whose norm exceeds max" do
+      expected = Nx.tensor([[0.6, 0.0], [0.8, 1.0]])
+      assert_all_close(Axon.Constraints.max_norm(max: 1.0).(@x), expected, atol: 1.0e-5)
+    end
+
+    test "leaves vectors within max alone" do
+      assert_all_close(Axon.Constraints.max_norm(max: 10.0).(@x), @x, atol: 1.0e-5)
+    end
+
+    test "computes norms over the given axes" do
+      s = :math.sqrt(17.0)
+
+      assert_all_close(
+        Axon.Constraints.max_norm(max: 1.0, axes: [1]).(@x),
+        Nx.tensor([[1.0, 0.0], [4.0 / s, 1.0 / s]]),
+        atol: 1.0e-5
+      )
+    end
+  end
+
+  describe "unit_norm/1" do
+    test "rescales every vector to unit norm" do
+      assert_all_close(Axon.Constraints.unit_norm().(@x), Nx.tensor([[0.6, 0.0], [0.8, 1.0]]),
+        atol: 1.0e-5
+      )
+    end
+  end
+
+  describe "non_neg/0" do
+    test "clips negative entries to zero" do
+      x = Nx.tensor([[-1.0, 2.0], [3.0, -4.0]])
+      assert_equal(Axon.Constraints.non_neg().(x), Nx.tensor([[0.0, 2.0], [3.0, 0.0]]))
+    end
+
+    test "preserves the parameter type" do
+      x = Nx.tensor([[-1.0, 2.0], [3.0, -4.0]], type: {:bf, 16})
+      out = Axon.Constraints.non_neg().(x)
+      assert Nx.type(out) == {:bf, 16}
+      assert_equal(out, Nx.tensor([[0.0, 2.0], [3.0, 0.0]], type: {:bf, 16}))
+    end
+  end
+
+  describe "min_max_norm/1" do
+    test "rescales vectors outside of [min, max]" do
+      assert_all_close(
+        Axon.Constraints.min_max_norm(min: 2.0, max: 4.0).(@x),
+        Nx.tensor([[2.4, 0.0], [3.2, 2.0]]),
+        atol: 1.0e-5
+      )
+    end
+
+    test "moves norms toward the feasible region according to rate" do
+      assert_all_close(
+        Axon.Constraints.min_max_norm(min: 2.0, max: 4.0, rate: 0.5).(@x),
+        Nx.tensor([[2.7, 0.0], [3.6, 1.5]]),
+        atol: 1.0e-5
+      )
+    end
+  end
+
+  describe "inside defn" do
+    test "constraints are callable from defn" do
+      x = Nx.tensor([[-1.0, 2.0], [3.0, -4.0]])
+
+      assert_equal(
+        InDefn.apply_constraint(Axon.Constraints.non_neg(), x),
+        Nx.tensor([[0.0, 2.0], [3.0, 0.0]])
+      )
+
+      assert_all_close(
+        InDefn.apply_constraint(Axon.Constraints.max_norm(max: 1.0), @x),
+        Nx.tensor([[0.6, 0.0], [0.8, 1.0]]),
+        atol: 1.0e-5
+      )
+    end
+  end
+end

--- a/test/axon/loop_test.exs
+++ b/test/axon/loop_test.exs
@@ -289,6 +289,54 @@ defmodule Axon.LoopTest do
       assert_all_close(state.model_state.data["instance_norm"]["mean"], Nx.broadcast(0.9, {8}))
       assert_all_close(state.model_state.data["instance_norm"]["var"], Nx.broadcast(0.1, {8}))
     end
+
+    test "train_step/3 applies parameter constraints after the update" do
+      input = Axon.input("input", shape: {nil, 4})
+
+      w =
+        Axon.param("w", {1, 4},
+          initializer: fn shape, type -> Nx.broadcast(Nx.tensor(-1.0, type: type), shape) end,
+          constraint: :non_neg
+        )
+
+      model = Axon.layer(fn x, w, _opts -> Nx.multiply(x, w) end, [input, w], name: "custom")
+      {init_fn, step_fn} = Axon.Loop.train_step(model, :mean_squared_error, :sgd)
+
+      x = Nx.broadcast(1.0, {2, 4})
+      y = Nx.broadcast(-2.0, {2, 4})
+
+      state = init_fn.({x, y}, Axon.ModelState.empty())
+      assert_equal(state.model_state.data["custom"]["w"], Nx.broadcast(-1.0, {1, 4}))
+      assert %{"custom" => %{"w" => constraint}} = state.model_state.constraints
+
+      state = step_fn.({x, y}, state)
+
+      # SGD alone would keep the parameter negative
+      assert_equal(state.model_state.data["custom"]["w"], Nx.broadcast(0.0, {1, 4}))
+      assert %{"custom" => %{"w" => ^constraint}} = state.model_state.constraints
+    end
+
+    test "train_step/3 does not constrain frozen parameters" do
+      input = Axon.input("input", shape: {nil, 4})
+
+      w =
+        Axon.param("w", {1, 4},
+          initializer: fn shape, type -> Nx.broadcast(Nx.tensor(-1.0, type: type), shape) end,
+          constraint: :non_neg
+        )
+
+      model = Axon.layer(fn x, w, _opts -> Nx.multiply(x, w) end, [input, w], name: "custom")
+      {init_fn, step_fn} = Axon.Loop.train_step(model, :mean_squared_error, :sgd)
+
+      x = Nx.broadcast(1.0, {2, 4})
+      y = Nx.broadcast(-2.0, {2, 4})
+
+      state = init_fn.({x, y}, Axon.ModelState.empty())
+      state = %{state | model_state: Axon.ModelState.freeze(state.model_state)}
+      state = step_fn.({x, y}, state)
+
+      assert_equal(state.model_state.data["custom"]["w"], Nx.broadcast(-1.0, {1, 4}))
+    end
   end
 
   describe "metrics" do
@@ -461,6 +509,30 @@ defmodule Axon.LoopTest do
         epochs: 5,
         strict?: false
       )
+    end
+  end
+
+  describe "constraints" do
+    test "run/4 applies constraints attached to the initial model state" do
+      model = Axon.input("input", shape: {nil, 4}) |> Axon.dense(8, name: "dense_0")
+      {init_fn, _} = Axon.build(model)
+      constraint = Axon.Constraints.max_norm(max: 0.1)
+
+      model_state =
+        init_fn.(Nx.template({1, 4}, :f32), Axon.ModelState.empty())
+        |> Axon.ModelState.constrain(&match?(["dense_0", "kernel"], &1), constraint)
+
+      data = [{Nx.broadcast(1.0, {2, 4}), Nx.broadcast(5.0, {2, 8})}]
+
+      %State{step_state: %{model_state: trained}} =
+        model
+        |> Axon.Loop.trainer(:mean_squared_error, :sgd, log: 0)
+        |> Axon.Loop.run(data, model_state, epochs: 1)
+
+      kernel = trained.data["dense_0"]["kernel"]
+      column_norms = Nx.sqrt(Nx.sum(Nx.multiply(kernel, kernel), axes: [0]))
+      assert Nx.to_number(Nx.all(Nx.less_equal(column_norms, 0.1 + 1.0e-5))) == 1
+      assert %{"dense_0" => %{"kernel" => ^constraint}} = trained.constraints
     end
   end
 
@@ -852,6 +924,35 @@ defmodule Axon.LoopTest do
       %State{step_state: deserialized_step_state} = Axon.Loop.deserialize_state(serialized)
 
       assert_equal(step_state, deserialized_step_state)
+    end
+
+    test "serialize_state/deserialize_state preserve parameter constraints" do
+      model = Axon.input("input", shape: {nil, 1}) |> Axon.dense(2, name: "dense_0")
+      {init_fn, _} = Axon.Loop.train_step(model, :mean_squared_error, :sgd)
+
+      step_state =
+        init_fn.({Nx.tensor([[1.0]]), Nx.tensor([[1.0, 1.0]])}, Axon.ModelState.empty())
+
+      model_state =
+        Axon.ModelState.constrain(
+          step_state.model_state,
+          &match?(["dense_0", "kernel"], &1),
+          Axon.Constraints.non_neg()
+        )
+
+      negative = Nx.broadcast(-1.0, {1, 2})
+      model_state = put_in(model_state, [Access.key!(:data), "dense_0", "kernel"], negative)
+      state = %State{step_state: %{step_state | model_state: model_state}}
+
+      serialized = Axon.Loop.serialize_state(state)
+      %State{step_state: deserialized_step_state} = Axon.Loop.deserialize_state(serialized)
+
+      assert_equal(state.step_state, deserialized_step_state)
+      assert %{"dense_0" => %{"kernel" => f}} = deserialized_step_state.model_state.constraints
+      assert is_function(f, 1)
+
+      applied = Axon.ModelState.apply_constraints(deserialized_step_state.model_state)
+      assert_equal(applied.data["dense_0"]["kernel"], Nx.broadcast(0.0, {1, 2}))
     end
 
     test "serialize_state/deserialize_state preserve loop state with step state serialization" do

--- a/test/axon/model_state_test.exs
+++ b/test/axon/model_state_test.exs
@@ -37,6 +37,106 @@ defmodule Axon.ModelStateTest do
 
     defn tie(model_state, destination, source),
       do: Axon.ModelState.tie(model_state, destination, source)
+
+    defn constrain(model_state, mask, constraint),
+      do: Axon.ModelState.constrain(model_state, mask, constraint)
+
+    defn apply_constraints(model_state), do: Axon.ModelState.apply_constraints(model_state)
+  end
+
+  describe "constrain/3 and apply_constraints/1" do
+    setup do
+      model =
+        Axon.input("input", shape: {nil, 2})
+        |> Axon.dense(4, name: "dense_0")
+        |> Axon.dense(4, name: "dense_1")
+
+      {init_fn, _} = Axon.build(model)
+      model_state = init_fn.(Nx.template({1, 2}, :f32), ModelState.empty())
+
+      negative = Nx.broadcast(Nx.tensor(-1.0), {2, 4})
+
+      model_state =
+        model_state
+        |> put_in([Access.key!(:data), "dense_0", "kernel"], negative)
+        |> put_in([Access.key!(:data), "dense_1", "kernel"], negative)
+
+      %{model_state: model_state, negative: negative}
+    end
+
+    test "new/1 and empty/0 have no constraints" do
+      assert %ModelState{constraints: %{}} = ModelState.empty()
+      assert %ModelState{constraints: %{}} = ModelState.new(%{"a" => %{"b" => Nx.tensor(1)}})
+    end
+
+    test "constrain/3 puts the constraint at the masked paths", %{model_state: model_state} do
+      constraint = Axon.Constraints.non_neg()
+      mask = &match?([_, "kernel"], &1)
+
+      assert %ModelState{constraints: constraints} =
+               constrained = ModelState.constrain(model_state, mask, constraint)
+
+      assert constraints == %{
+               "dense_0" => %{"kernel" => constraint},
+               "dense_1" => %{"kernel" => constraint}
+             }
+
+      assert InDefn.constrain(model_state, mask, constraint).constraints == constraints
+
+      # data is left untouched until constraints are applied
+      assert_equal(constrained.data["dense_0"]["kernel"], model_state.data["dense_0"]["kernel"])
+    end
+
+    test "constrain/3 composes with existing constraints", %{model_state: model_state} do
+      non_neg = Axon.Constraints.non_neg()
+      unit_norm = Axon.Constraints.unit_norm()
+
+      constraints =
+        model_state
+        |> ModelState.constrain(&match?(["dense_0", "kernel"], &1), non_neg)
+        |> ModelState.constrain(&match?(["dense_0", "bias"], &1), unit_norm)
+        |> Map.fetch!(:constraints)
+
+      assert constraints == %{"dense_0" => %{"kernel" => non_neg, "bias" => unit_norm}}
+    end
+
+    test "apply_constraints/1 projects constrained parameters only",
+         %{model_state: model_state, negative: negative} do
+      constrained =
+        ModelState.constrain(
+          model_state,
+          &match?(["dense_0", "kernel"], &1),
+          Axon.Constraints.non_neg()
+        )
+
+      applied = ModelState.apply_constraints(constrained)
+
+      assert_equal(applied.data["dense_0"]["kernel"], Nx.broadcast(0.0, {2, 4}))
+      assert_equal(applied.data["dense_0"]["bias"], model_state.data["dense_0"]["bias"])
+      assert_equal(applied.data["dense_1"]["kernel"], negative)
+      assert applied.constraints == constrained.constraints
+
+      assert_equal(
+        InDefn.apply_constraints(constrained).data["dense_0"]["kernel"],
+        Nx.broadcast(0.0, {2, 4})
+      )
+    end
+
+    test "apply_constraints/1 skips frozen parameters",
+         %{model_state: model_state, negative: negative} do
+      applied =
+        model_state
+        |> ModelState.constrain(&match?([_, "kernel"], &1), Axon.Constraints.non_neg())
+        |> ModelState.freeze(&match?(["dense_0" | _], &1))
+        |> ModelState.apply_constraints()
+
+      assert_equal(applied.data["dense_0"]["kernel"], negative)
+      assert_equal(applied.data["dense_1"]["kernel"], Nx.broadcast(0.0, {2, 4}))
+    end
+
+    test "apply_constraints/1 is a no-op without constraints", %{model_state: model_state} do
+      assert_equal(ModelState.apply_constraints(model_state), model_state)
+    end
   end
 
   describe "tie/4" do

--- a/test/axon_test.exs
+++ b/test/axon_test.exs
@@ -11,6 +11,45 @@ defmodule AxonTest do
     end
   end
 
+  describe "param" do
+    test "defaults to no constraint" do
+      assert %Axon.Parameter{constraint: nil} = Axon.param("k", {1, 1})
+      assert %Axon.Parameter{constraint: nil} = Axon.parameter("k", {1, 1})
+    end
+
+    test "stores a named constraint as a function" do
+      assert %Axon.Parameter{constraint: f} = Axon.param("k", {1, 1}, constraint: :non_neg)
+      assert is_function(f, 1)
+      assert Nx.to_number(f.(Nx.tensor(-1.0))) == 0.0
+
+      assert %Axon.Parameter{constraint: f} =
+               Axon.parameter("k", fn x -> x end, constraint: :unit_norm)
+
+      assert is_function(f, 1)
+    end
+
+    test "stores a custom constraint function" do
+      constraint = fn x -> Nx.multiply(x, 2) end
+
+      assert %Axon.Parameter{constraint: ^constraint} =
+               Axon.param("k", {1, 1}, constraint: constraint)
+    end
+
+    test "fails on bad constraints" do
+      assert_raise ArgumentError, ~r/constraint must be one of/, fn ->
+        Axon.param("k", {1, 1}, constraint: :bad)
+      end
+
+      assert_raise ArgumentError, ~r/constraint must be one of/, fn ->
+        Axon.param("k", {1, 1}, constraint: fn a, _b -> a end)
+      end
+
+      assert_raise ArgumentError, ~r/constraint must be one of/, fn ->
+        Axon.parameter("k", Nx.template({1, 1}, :f32), constraint: :bad)
+      end
+    end
+  end
+
   describe "constant" do
     test "works with defaults" do
       assert %Axon{output: id, nodes: nodes} = Axon.constant(Nx.tensor(1.0))


### PR DESCRIPTION
Closes #111.

Axon had no way to keep a trainable parameter inside a feasible region during training. Keras offers this as *constraints*: projections such as `max_norm` or `non_neg` that run on a weight right after every optimizer update. This PR adds the same mechanism to Axon, following the Keras (post-update projection) semantics rather than PyTorch-style parametrizations that reparameterize the forward pass.

## Design

Constraints mirror how frozen parameters already work: they are metadata on `%Axon.ModelState{}` that the compiler collects from the graph and that the training step consumes through `Axon.ModelState` transforms.

* `Axon.Constraints` is a new module shaped like `Axon.Initializers`. `max_norm/1`, `non_neg/0`, `unit_norm/1` and `min_max_norm/1` return arity-1 functions that take a parameter tensor and return the projected tensor. Norm-based constraints take `:axes` (default `[0]`, the incoming weight vector of each output unit for a dense kernel). Their implementations are `defnp`s so they trace into the training step.
* `Axon.param/3` and `Axon.parameter/3` accept a `:constraint` option: one of the atoms above (resolved to the `Axon.Constraints` function with default options) or an arity-1 function. It is validated like `:initializer` and stored on `%Axon.Parameter{}`.
* `%Axon.ModelState{}` gains a `constraints` field (a `keep` field, nested `%{layer => %{param => fun}}` like `data`). The compiler collects it next to `frozen_parameters`, nests it for blocks, and `merge_model_state!` carries constraints from a user-supplied initial model state so they compose with `Axon.Loop.run/4`.
* `Axon.ModelState.constrain/3` attaches a constraint to every parameter matched by a path mask (same mask style as `freeze/2`), which is how you constrain built-in layers such as `Axon.dense`. `Axon.ModelState.apply_constraints/1` projects every constrained, trainable, non-frozen parameter.
* `Axon.Loop.train_step/4` calls `apply_constraints/1` right after `Axon.ModelState.update/3`, so every optimizer update is followed by the projection.

## Usage

On a custom layer parameter:

```elixir
w = Axon.param("w", {32, 64}, constraint: Axon.Constraints.max_norm(max: 2.0))
Axon.layer(fn x, w, _opts -> Nx.dot(x, w) end, [input, w])
```

On the parameters of built-in layers, by path:

```elixir
{init_fn, _} = Axon.build(model)
model_state = init_fn.(template, Axon.ModelState.empty())

model_state =
  Axon.ModelState.constrain(
    model_state,
    &match?([_, "kernel"], &1),
    Axon.Constraints.unit_norm()
  )

model
|> Axon.Loop.trainer(:mean_squared_error, :sgd)
|> Axon.Loop.run(data, model_state)
```

## Tradeoffs and limitations

* Constraints are projections applied after each update (Keras semantics). They are not applied at initialization, never to frozen parameters, and never to layer state such as batch norm statistics.
* Constraint functions live in model state metadata, so they are part of the jit cache key and travel with checkpoints. `Axon.Loop.serialize_state/2` serializes them with `term_to_binary`; anonymous constraints only deserialize when the module that defined them is available (the `Axon.Constraints` functions are fine).
* No graph-level `Axon.constrain/3` is added since the graph-level `Axon.freeze/2` is deprecated in favor of the `Axon.ModelState` API, and no per-layer `kernel_constraint`/`bias_constraint` options are added.
* Pre-existing gap, not changed here: `merge_model_state!` still drops the `frozen_parameters` of a user-supplied initial model state at init time. This PR only carries `constraints` across; carrying `frozen_parameters` the same way is a candidate follow-up.

## Tests

* `test/axon/constraints_test.exs`: doctests plus numeric checks for all four constraints (including custom `:axes`, `:rate`, type preservation for `bf16`, and use inside `defn`).
* `test/axon_test.exs`: `:constraint` validation and storage on `Axon.param/3` and `Axon.parameter/3`.
* `test/axon/model_state_test.exs`: `constrain/3` path masking and composition, `apply_constraints/1` projecting only constrained parameters, skipping frozen ones, and both working inside `defn`.
* `test/axon/compiler_test.exs`: constraint metadata is collected for custom layers, nested for blocks, and preserved from an initial model state.
* `test/axon/loop_test.exs`: `train_step` projects a parameter after SGD (and leaves it alone when frozen), `Axon.Loop.run/4` honors constraints attached to the initial model state, and constraints survive `serialize_state`/`deserialize_state`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
