### PR TITLE
Add Axon.Pruning with magnitude-based unstructured pruning

### DIFF
--- a/lib/axon/pruning.ex
+++ b/lib/axon/pruning.ex
@@ -287,7 +287,7 @@ defmodule Axon.Pruning do
 
   defp optimizer_fns(optimizer) when is_atom(optimizer) do
     if Code.ensure_loaded?(Polaris.Optimizers) and
-         function_exported?(Polaris.Optimizers, optimizer, 0) do
+         {optimizer, 0} in Polaris.Optimizers.__info__(:functions) do
       apply(Polaris.Optimizers, optimizer, [])
     else
       invalid_optimizer!(optimizer)

--- a/lib/axon/pruning.ex
+++ b/lib/axon/pruning.ex
@@ -1,0 +1,422 @@
+defmodule Axon.Pruning do
+  @moduledoc """
+  Model pruning.
+
+  Pruning removes weights from a trained model by setting them to zero.
+  Most of the parameters in a trained network contribute very little to
+  its output, so a large fraction of them can be removed with a small
+  loss in accuracy, especially when the pruned model is fine-tuned for
+  a few more steps afterwards.
+
+  This module implements **unstructured magnitude pruning** of an
+  `Axon.ModelState`: the parameters with the smallest absolute values
+  are zeroed, either against a single global threshold or per tensor.
+  Pruning produces a *mask* alongside the pruned state. The mask is a
+  nested map that mirrors the model state data, with a `{:u, 8}` tensor
+  (`1` = keep, `0` = pruned) for every pruned parameter. Use it with
+  `masked_optimizer/2` to keep pruned weights at zero while fine-tuning:
+
+      # Prune 90% of the kernel weights
+      {pruned_state, mask} = Axon.Pruning.prune(model_state, 0.9)
+
+      # Report the resulting sparsity
+      Axon.Pruning.global_sparsity(pruned_state)
+      #=> 0.87...
+
+      # Fine-tune the remaining weights; pruned weights stay at zero
+      trained_state =
+        model
+        |> Axon.Loop.trainer(
+          :categorical_cross_entropy,
+          Axon.Pruning.masked_optimizer(:adam, mask)
+        )
+        |> Axon.Loop.run(data, pruned_state, epochs: 2)
+
+  ## Limitations
+
+  Zeroed weights are still stored densely; this module reduces the number
+  of non-zero parameters, not the memory footprint or the latency of the
+  model. Taking advantage of sparsity requires backend support for sparse
+  tensors or structured pruning, neither of which is implemented here. The
+  model graph is never modified, only the model state. Ties between
+  parameters of equal magnitude are broken arbitrarily but deterministically.
+  """
+  import Nx.Defn, only: [deftransform: 1, deftransform: 2]
+
+  alias Axon.ModelState
+
+  @doc """
+  Computes a magnitude-based pruning mask for the given model state.
+
+  `sparsity` is a number between `0` and `1` giving the fraction of the
+  selected parameters to prune. The selected parameters are ranked by
+  absolute value and the smallest ones are marked as pruned. The returned
+  mask is a nested map that mirrors the model state data and contains a
+  `{:u, 8}` tensor (`1` = keep, `0` = pruned) for each selected parameter.
+  Parameters which were not selected are absent from the mask.
+
+  Only parameters are considered, never state such as batch normalization
+  running statistics. Tied parameters (see `Axon.ModelState.tie/4`),
+  quantized parameters and non-float parameters are skipped.
+
+  This function does not modify the model state. See `apply_mask/2` and
+  `prune/3`.
+
+  ## Options
+
+    * `:scope` - `:global` ranks all selected parameters together, so a
+      single threshold is used across the model and some tensors end up
+      sparser than others. `:tensor` prunes each selected tensor to
+      `sparsity` independently. Defaults to `:global`.
+
+    * `:filter` - an arity-1 function which receives the access path of
+      a parameter as a list of strings, such as `["dense_0", "kernel"]`
+      or `["lstm_0", "input_kernel", "wii"]`, and returns whether that
+      parameter should be considered for pruning. The default filter
+      selects every parameter whose path contains a name ending in
+      `"kernel"`, which covers dense, convolution and embedding kernels
+      as well as the input and hidden kernels of recurrent layers, and
+      leaves biases and normalization parameters untouched.
+
+  ## Examples
+
+      iex> model = Axon.input("x", shape: {nil, 2}) |> Axon.dense(4, name: "dense")
+      iex> {init_fn, _} = Axon.build(model)
+      iex> model_state = init_fn.(Nx.template({1, 2}, :f32), Axon.ModelState.empty())
+      iex> kernel = Nx.tensor([[1.0, -8.0, 3.0, 0.5], [2.0, 7.0, -0.1, 4.0]])
+      iex> model_state = put_in(model_state, [Access.key!(:data), "dense", "kernel"], kernel)
+      iex> mask = Axon.Pruning.magnitude_mask(model_state, 0.5)
+      iex> mask["dense"]["kernel"]
+      #Nx.Tensor<
+        u8[2][4]
+        [
+          [0, 1, 1, 0],
+          [0, 1, 0, 1]
+        ]
+      >
+      iex> Map.has_key?(mask["dense"], "bias")
+      false
+
+  """
+  deftransform magnitude_mask(%ModelState{} = model_state, sparsity, opts \\ []) do
+    unless is_number(sparsity) and sparsity >= 0 and sparsity <= 1 do
+      raise ArgumentError,
+            "expected sparsity to be a number between 0 and 1, got: #{inspect(sparsity)}"
+    end
+
+    opts = Keyword.validate!(opts, scope: :global, filter: &default_filter/1)
+    scope = opts[:scope]
+    filter = opts[:filter]
+
+    unless scope in [:global, :tensor] do
+      raise ArgumentError, "expected :scope to be :global or :tensor, got: #{inspect(scope)}"
+    end
+
+    unless is_function(filter, 1) do
+      raise ArgumentError, "expected :filter to be an arity-1 function, got: #{inspect(filter)}"
+    end
+
+    candidates =
+      model_state
+      |> parameter_leaves()
+      |> Enum.filter(fn {path, tensor} ->
+        Nx.Type.float?(Nx.type(tensor)) and filter.(path)
+      end)
+      |> Enum.sort_by(fn {path, _} -> path end)
+
+    masks =
+      case scope do
+        :tensor -> tensor_masks(candidates, sparsity)
+        :global -> global_masks(candidates, sparsity)
+      end
+
+    Enum.reduce(masks, %{}, fn {path, mask}, acc -> put_path(acc, path, mask) end)
+  end
+
+  defp default_filter(path), do: Enum.any?(path, &String.ends_with?(&1, "kernel"))
+
+  defp tensor_masks(candidates, sparsity) do
+    Enum.map(candidates, fn {path, tensor} ->
+      size = Nx.size(tensor)
+      keep = size - round(sparsity * size)
+
+      mask =
+        tensor
+        |> Nx.flatten()
+        |> Nx.abs()
+        |> keep_largest(keep)
+        |> Nx.reshape(Nx.shape(tensor))
+
+      {path, mask}
+    end)
+  end
+
+  defp global_masks([], _sparsity), do: []
+
+  defp global_masks(candidates, sparsity) do
+    magnitudes = Enum.map(candidates, fn {_, tensor} -> Nx.abs(Nx.flatten(tensor)) end)
+    total = Enum.reduce(magnitudes, 0, &(Nx.size(&1) + &2))
+    keep = total - round(sparsity * total)
+    global_mask = magnitudes |> Nx.concatenate() |> keep_largest(keep)
+
+    {masks, _offset} =
+      Enum.map_reduce(candidates, 0, fn {path, tensor}, offset ->
+        size = Nx.size(tensor)
+
+        mask =
+          global_mask
+          |> Nx.slice([offset], [size])
+          |> Nx.reshape(Nx.shape(tensor))
+
+        {{path, mask}, offset + size}
+      end)
+
+    masks
+  end
+
+  # Returns a {:u, 8} mask over a flat vector which keeps the `keep`
+  # largest entries. Ties are broken by position, which keeps the exact
+  # count and makes the result deterministic.
+  defp keep_largest(flat, keep) do
+    size = Nx.size(flat)
+
+    cond do
+      keep >= size ->
+        Nx.broadcast(Nx.tensor(1, type: :u8), {size})
+
+      keep <= 0 ->
+        Nx.broadcast(Nx.tensor(0, type: :u8), {size})
+
+      true ->
+        flat
+        |> Nx.argsort(direction: :desc, stable: true)
+        |> Nx.argsort(stable: true)
+        |> Nx.less(keep)
+    end
+  end
+
+  @doc """
+  Applies a pruning mask to the given model state or parameter map.
+
+  Every leaf which has an entry in `mask` is replaced with the same tensor
+  with zeros wherever the mask is `0`. Leaves without a mask entry and mask
+  entries without a matching leaf are ignored. `mask` is typically produced
+  by `magnitude_mask/3`.
+
+  The first argument may be an `Axon.ModelState` or a nested parameter map
+  such as the one returned by `Axon.ModelState.trainable_parameters/1`.
+
+  ## Examples
+
+      iex> params = %{"dense" => %{"kernel" => Nx.tensor([1.0, 2.0, 3.0]), "bias" => Nx.tensor([1.0])}}
+      iex> mask = %{"dense" => %{"kernel" => Nx.tensor([1, 0, 1], type: :u8)}}
+      iex> Axon.Pruning.apply_mask(params, mask)
+      %{
+        "dense" => %{
+          "bias" => Nx.tensor([1.0]),
+          "kernel" => Nx.tensor([1.0, 0.0, 3.0])
+        }
+      }
+
+  """
+  deftransform apply_mask(model_state_or_params, mask)
+
+  deftransform apply_mask(%ModelState{} = model_state, mask) when is_map(mask) do
+    update_in(model_state, [Access.key!(:data)], &mask_tree(&1, mask))
+  end
+
+  deftransform apply_mask(params, mask) when is_map(params) and is_map(mask) do
+    mask_tree(params, mask)
+  end
+
+  @doc """
+  Prunes the given model state.
+
+  Computes a magnitude-based mask with `magnitude_mask/3` and applies it
+  with `apply_mask/2`. Returns a tuple of the pruned model state and the
+  mask. Accepts the same options as `magnitude_mask/3`.
+
+  ## Examples
+
+      {pruned_state, mask} = Axon.Pruning.prune(model_state, 0.5, scope: :tensor)
+
+  """
+  deftransform prune(%ModelState{} = model_state, sparsity, opts \\ []) do
+    mask = magnitude_mask(model_state, sparsity, opts)
+    {apply_mask(model_state, mask), mask}
+  end
+
+  @doc """
+  Wraps an optimizer so that it never updates pruned parameters.
+
+  `optimizer` is anything accepted by `Axon.Loop.trainer/4`: an atom
+  naming an optimizer in `Polaris.Optimizers` or a tuple of
+  `{init_fn, update_fn}`. `mask` is a pruning mask as returned by
+  `magnitude_mask/3` or `prune/3`. The returned optimizer computes the
+  regular updates and then zeroes them wherever the mask is `0`, so
+  parameters which are zero when training starts stay exactly zero
+  regardless of momentum or weight decay.
+
+  Mask entries for parameters which are not being trained, such as
+  frozen parameters, are ignored. The mask is kept in the optimizer
+  state, so it lives on the same device as the rest of the training
+  state and is included in checkpoints.
+
+  ## Examples
+
+      {pruned_state, mask} = Axon.Pruning.prune(model_state, 0.9)
+
+      model
+      |> Axon.Loop.trainer(:categorical_cross_entropy, Axon.Pruning.masked_optimizer(:adam, mask))
+      |> Axon.Loop.run(data, pruned_state, epochs: 2)
+
+  """
+  def masked_optimizer(optimizer, mask) when is_map(mask) do
+    # The optimizer init function is traced, so the mask is copied to the
+    # binary backend, which can be embedded in the traced expression, and
+    # placed in the optimizer state. From there on it is passed to the
+    # update function as a regular argument.
+    mask = Nx.backend_copy(mask, Nx.BinaryBackend)
+
+    Polaris.Updates.stateful(
+      optimizer_fns(optimizer),
+      fn _params -> %{mask: mask} end,
+      fn updates, %{mask: mask} = state, _params -> {mask_tree(updates, mask), state} end
+    )
+  end
+
+  defp optimizer_fns(optimizer) when is_atom(optimizer) do
+    if Code.ensure_loaded?(Polaris.Optimizers) and
+         function_exported?(Polaris.Optimizers, optimizer, 0) do
+      apply(Polaris.Optimizers, optimizer, [])
+    else
+      invalid_optimizer!(optimizer)
+    end
+  end
+
+  defp optimizer_fns({init_fn, update_fn} = optimizer)
+       when is_function(init_fn, 1) and is_function(update_fn, 3) do
+    optimizer
+  end
+
+  defp optimizer_fns(optimizer), do: invalid_optimizer!(optimizer)
+
+  defp invalid_optimizer!(optimizer) do
+    raise ArgumentError,
+          "invalid optimizer #{inspect(optimizer)}, expected an atom matching the name" <>
+            " of an optimizer in Polaris.Optimizers or a tuple of {init_fn, update_fn}"
+  end
+
+  @doc """
+  Returns the fraction of zero entries in each parameter of the model state.
+
+  The result is a nested map mirroring the parameters of the model state
+  with a float per parameter. Composite parameters such as the kernels of
+  recurrent layers produce nested maps. Tied and quantized parameters are
+  skipped, and state is not included.
+
+  ## Examples
+
+      Axon.Pruning.sparsity(pruned_state)
+      #=> %{"dense_0" => %{"bias" => 0.0, "kernel" => 0.9}}
+
+  """
+  def sparsity(%ModelState{} = model_state) do
+    model_state
+    |> parameter_leaves()
+    |> Enum.reduce(%{}, fn {path, tensor}, acc ->
+      put_path(acc, path, ratio(zero_count(tensor), Nx.size(tensor)))
+    end)
+  end
+
+  @doc """
+  Returns the fraction of zero entries across all parameters of the model state.
+
+  The fraction is computed over the total number of entries, so larger
+  parameters weigh more than smaller ones. Parameters are counted as in
+  `sparsity/1`. Returns `0.0` for a model state without parameters.
+
+  ## Examples
+
+      Axon.Pruning.global_sparsity(pruned_state)
+      #=> 0.8625
+
+  """
+  def global_sparsity(%ModelState{} = model_state) do
+    {zeros, total} =
+      model_state
+      |> parameter_leaves()
+      |> Enum.reduce({0, 0}, fn {_path, tensor}, {zeros, total} ->
+        {zeros + zero_count(tensor), total + Nx.size(tensor)}
+      end)
+
+    ratio(zeros, total)
+  end
+
+  defp zero_count(tensor) do
+    tensor |> Nx.equal(0) |> Nx.sum() |> Nx.to_number()
+  end
+
+  defp ratio(_zeros, 0), do: 0.0
+  defp ratio(zeros, total), do: zeros / total
+
+  ## Tree helpers
+
+  # Returns a list of {path, tensor} pairs for every tensor leaf
+  # reachable from the parameters tree of the model state. Tied and
+  # quantized parameters are skipped.
+  defp parameter_leaves(%ModelState{data: data, parameters: parameters}) do
+    collect_leaves(parameters, data, [])
+  end
+
+  defp collect_leaves(names, data, path) when is_list(names) and is_map(data) do
+    Enum.flat_map(names, fn name -> data_leaves(Map.get(data, name), path ++ [name]) end)
+  end
+
+  defp collect_leaves(tree, data, path) when is_map(tree) and is_map(data) do
+    Enum.flat_map(tree, fn {key, subtree} ->
+      case data do
+        %{^key => subdata} when is_map(subdata) and not is_struct(subdata) ->
+          collect_leaves(subtree, subdata, path ++ [key])
+
+        %{} ->
+          []
+      end
+    end)
+  end
+
+  defp collect_leaves(_names, _data, _path), do: []
+
+  defp data_leaves(%Nx.Tensor{} = tensor, path), do: [{path, tensor}]
+
+  defp data_leaves(%_{}, _path), do: []
+
+  defp data_leaves(map, path) when is_map(map) do
+    Enum.flat_map(map, fn {key, value} -> data_leaves(value, path ++ [key]) end)
+  end
+
+  defp data_leaves(_other, _path), do: []
+
+  defp mask_tree(tree, mask) do
+    Enum.reduce(mask, tree, fn {key, mask_value}, acc ->
+      case Map.fetch(acc, key) do
+        {:ok, value} -> Map.put(acc, key, mask_value(value, mask_value))
+        :error -> acc
+      end
+    end)
+  end
+
+  defp mask_value(%Nx.Tensor{} = tensor, %Nx.Tensor{} = mask), do: Nx.select(mask, tensor, 0)
+  defp mask_value(%_{} = value, _mask), do: value
+
+  defp mask_value(tree, mask) when is_map(tree) and is_map(mask) and not is_struct(mask),
+    do: mask_tree(tree, mask)
+
+  defp mask_value(value, _mask), do: value
+
+  defp put_path(map, [key], value), do: Map.put(map, key, value)
+
+  defp put_path(map, [key | rest], value) do
+    Map.update(map, key, put_path(%{}, rest, value), &put_path(&1, rest, value))
+  end
+end

--- a/test/axon/pruning_test.exs
+++ b/test/axon/pruning_test.exs
@@ -1,0 +1,364 @@
+defmodule Axon.PruningTest do
+  use Axon.Case, async: true
+
+  doctest Axon.Pruning
+
+  alias Axon.ModelState
+  alias Axon.Pruning
+
+  defmodule InDefn do
+    import Nx.Defn
+
+    defn global_mask(model_state), do: Axon.Pruning.magnitude_mask(model_state, 0.5)
+
+    defn dense_mask(model_state), do: Axon.Pruning.magnitude_mask(model_state, 0.0)
+
+    defn tensor_mask(model_state),
+      do: Axon.Pruning.magnitude_mask(model_state, 0.5, scope: :tensor)
+
+    defn apply_mask(model_state, mask), do: Axon.Pruning.apply_mask(model_state, mask)
+
+    defn prune(model_state), do: Axon.Pruning.prune(model_state, 0.5)
+  end
+
+  @kernel Nx.tensor([[1.0, -8.0, 3.0, 0.5], [2.0, 7.0, -0.1, 4.0]])
+  @kernel_mask Nx.tensor([[0, 1, 1, 0], [0, 1, 0, 1]], type: :u8)
+
+  defp init(model, template, opts \\ []) do
+    {init_fn, _} = Axon.build(model, opts)
+    init_fn.(template, ModelState.empty())
+  end
+
+  defp dense_state do
+    Axon.input("x", shape: {nil, 2})
+    |> Axon.dense(4, name: "d")
+    |> init(Nx.template({1, 2}, :f32))
+    |> put_in([Access.key!(:data), "d", "kernel"], @kernel)
+  end
+
+  defp two_dense_state do
+    Axon.input("x", shape: {nil, 4})
+    |> Axon.dense(4, name: "d0")
+    |> Axon.dense(4, name: "d1")
+    |> init(Nx.template({1, 4}, :f32))
+    |> put_in([Access.key!(:data), "d0", "kernel"], Nx.broadcast(0.1, {4, 4}))
+    |> put_in([Access.key!(:data), "d1", "kernel"], Nx.broadcast(5.0, {4, 4}))
+  end
+
+  defp lstm_state do
+    Axon.input("x", shape: {nil, 2, 3})
+    |> Axon.lstm(4, name: "l")
+    |> elem(0)
+    |> init(Nx.template({1, 2, 3}, :f32))
+  end
+
+  describe "magnitude_mask/3" do
+    test "prunes the smallest magnitudes of each tensor with scope: :tensor" do
+      mask = Pruning.magnitude_mask(dense_state(), 0.5, scope: :tensor)
+
+      assert %{"d" => %{"kernel" => kernel_mask}} = mask
+      refute Map.has_key?(mask["d"], "bias")
+      assert Nx.type(kernel_mask) == {:u, 8}
+      assert Nx.shape(kernel_mask) == {2, 4}
+      assert_equal(kernel_mask, @kernel_mask)
+    end
+
+    test "uses a single threshold across tensors with scope: :global" do
+      mask = Pruning.magnitude_mask(two_dense_state(), 0.5, scope: :global)
+
+      assert_equal(mask["d0"]["kernel"], Nx.broadcast(Nx.tensor(0, type: :u8), {4, 4}))
+      assert_equal(mask["d1"]["kernel"], Nx.broadcast(Nx.tensor(1, type: :u8), {4, 4}))
+
+      mask = Pruning.magnitude_mask(two_dense_state(), 0.5, scope: :tensor)
+
+      assert_equal(Nx.sum(mask["d0"]["kernel"]), Nx.tensor(8))
+      assert_equal(Nx.sum(mask["d1"]["kernel"]), Nx.tensor(8))
+    end
+
+    test "defaults to scope: :global" do
+      assert_equal(
+        Pruning.magnitude_mask(two_dense_state(), 0.5)["d0"]["kernel"],
+        Nx.broadcast(Nx.tensor(0, type: :u8), {4, 4})
+      )
+    end
+
+    test "prunes an exact number of entries when magnitudes tie" do
+      state =
+        put_in(dense_state(), [Access.key!(:data), "d", "kernel"], Nx.broadcast(1.0, {2, 4}))
+
+      mask = Pruning.magnitude_mask(state, 0.25, scope: :tensor)
+      assert_equal(Nx.sum(mask["d"]["kernel"]), Nx.tensor(8 - round(0.25 * 8)))
+
+      mask = Pruning.magnitude_mask(state, 0.25, scope: :global)
+      assert_equal(Nx.sum(mask["d"]["kernel"]), Nx.tensor(8 - round(0.25 * 8)))
+    end
+
+    test "keeps everything at sparsity 0 and nothing at sparsity 1" do
+      for scope <- [:global, :tensor] do
+        mask = Pruning.magnitude_mask(dense_state(), 0.0, scope: scope)
+        assert Nx.type(mask["d"]["kernel"]) == {:u, 8}
+        assert_equal(mask["d"]["kernel"], Nx.broadcast(Nx.tensor(1, type: :u8), {2, 4}))
+
+        mask = Pruning.magnitude_mask(dense_state(), 1.0, scope: scope)
+        assert Nx.type(mask["d"]["kernel"]) == {:u, 8}
+        assert_equal(mask["d"]["kernel"], Nx.broadcast(Nx.tensor(0, type: :u8), {2, 4}))
+      end
+    end
+
+    test "default filter selects kernels and skips norm parameters and state" do
+      state =
+        Axon.input("x", shape: {nil, 2})
+        |> Axon.dense(4, name: "d")
+        |> Axon.batch_norm(name: "bn")
+        |> init(Nx.template({1, 2}, :f32), mode: :train)
+
+      mask = Pruning.magnitude_mask(state, 0.5)
+
+      assert Map.keys(mask) == ["d"]
+      assert Map.keys(mask["d"]) == ["kernel"]
+
+      pruned = Pruning.apply_mask(state, mask)
+      assert_equal(pruned.data["bn"]["mean"], state.data["bn"]["mean"])
+      assert_equal(pruned.data["bn"]["var"], state.data["bn"]["var"])
+      assert_equal(pruned.data["bn"]["gamma"], state.data["bn"]["gamma"])
+      assert_equal(pruned.data["d"]["bias"], state.data["d"]["bias"])
+    end
+
+    test "default filter selects composite recurrent kernels" do
+      mask = Pruning.magnitude_mask(lstm_state(), 0.5)
+
+      assert Map.keys(mask) == ["l"]
+      assert Map.keys(mask["l"]) == ["hidden_kernel", "input_kernel"]
+      assert Map.keys(mask["l"]["input_kernel"]) == ["wif", "wig", "wii", "wio"]
+      assert Nx.type(mask["l"]["input_kernel"]["wii"]) == {:u, 8}
+      assert Nx.shape(mask["l"]["input_kernel"]["wii"]) == {3, 4}
+      assert Nx.shape(mask["l"]["hidden_kernel"]["whi"]) == {4, 4}
+    end
+
+    test "accepts a custom :filter" do
+      mask = Pruning.magnitude_mask(dense_state(), 0.5, filter: &match?(["d", "bias"], &1))
+
+      assert Map.keys(mask["d"]) == ["bias"]
+      assert Nx.shape(mask["d"]["bias"]) == {4}
+    end
+
+    test "returns an empty map when nothing matches the filter" do
+      assert Pruning.magnitude_mask(dense_state(), 0.5, filter: fn _ -> false end) == %{}
+      assert Pruning.magnitude_mask(ModelState.empty(), 0.5) == %{}
+    end
+
+    test "skips tied parameters" do
+      state = ModelState.tie(two_dense_state(), ["d1", "kernel"], ["d0", "kernel"])
+
+      mask = Pruning.magnitude_mask(state, 0.5, scope: :tensor, filter: fn _ -> true end)
+
+      assert Map.keys(mask["d0"]) == ["bias", "kernel"]
+      assert Map.keys(mask["d1"]) == ["bias"]
+    end
+
+    test "skips quantized parameters" do
+      model = Axon.input("x", shape: {nil, 2}) |> Axon.dense(4, name: "d")
+
+      state =
+        Axon.Quantization.quantize_model_state(model, init(model, Nx.template({1, 2}, :f32)))
+
+      mask = Pruning.magnitude_mask(state, 0.5, filter: fn _ -> true end)
+
+      assert Map.keys(mask["d"]) == ["bias"]
+    end
+
+    test "skips non-float parameters" do
+      state =
+        put_in(dense_state(), [Access.key!(:data), "d", "kernel"], Nx.iota({2, 4}, type: :s32))
+
+      mask = Pruning.magnitude_mask(state, 0.5, filter: fn _ -> true end)
+
+      assert Map.keys(mask["d"]) == ["bias"]
+    end
+
+    test "raises on invalid sparsity" do
+      assert_raise ArgumentError,
+                   "expected sparsity to be a number between 0 and 1, got: 1.5",
+                   fn -> Pruning.magnitude_mask(dense_state(), 1.5) end
+
+      assert_raise ArgumentError,
+                   "expected sparsity to be a number between 0 and 1, got: -0.1",
+                   fn -> Pruning.magnitude_mask(dense_state(), -0.1) end
+    end
+
+    test "raises on invalid options" do
+      assert_raise ArgumentError,
+                   "expected :scope to be :global or :tensor, got: :layer",
+                   fn -> Pruning.magnitude_mask(dense_state(), 0.5, scope: :layer) end
+
+      assert_raise ArgumentError, ~r/unknown keys \[:method\]/, fn ->
+        Pruning.magnitude_mask(dense_state(), 0.5, method: :random)
+      end
+    end
+  end
+
+  describe "apply_mask/2" do
+    test "zeroes masked entries and leaves everything else untouched" do
+      state = dense_state()
+      mask = %{"d" => %{"kernel" => @kernel_mask}}
+
+      pruned = Pruning.apply_mask(state, mask)
+
+      assert_equal(pruned.data["d"]["kernel"], Nx.select(@kernel_mask, @kernel, 0))
+      assert Nx.type(pruned.data["d"]["kernel"]) == {:f, 32}
+      assert_equal(pruned.data["d"]["bias"], state.data["d"]["bias"])
+      assert pruned.parameters == state.parameters
+      assert pruned.state == state.state
+      assert pruned.frozen_parameters == state.frozen_parameters
+    end
+
+    test "works on a plain parameter map and ignores mask keys missing from it" do
+      state = ModelState.freeze(two_dense_state(), &match?(["d0" | _], &1))
+      mask = Pruning.magnitude_mask(two_dense_state(), 0.5, scope: :tensor)
+      params = ModelState.trainable_parameters(state)
+
+      masked = Pruning.apply_mask(params, mask)
+
+      assert Map.keys(masked) == ["d1"]
+
+      assert_equal(
+        masked["d1"]["kernel"],
+        Nx.select(mask["d1"]["kernel"], params["d1"]["kernel"], 0)
+      )
+
+      assert_equal(masked["d1"]["bias"], params["d1"]["bias"])
+    end
+
+    test "applies masks to composite parameters" do
+      state = lstm_state()
+      {pruned, mask} = Pruning.prune(state, 0.5, scope: :tensor)
+
+      assert_equal(
+        pruned.data["l"]["input_kernel"]["wii"],
+        Nx.select(mask["l"]["input_kernel"]["wii"], state.data["l"]["input_kernel"]["wii"], 0)
+      )
+
+      assert_equal(pruned.data["l"]["bias"]["bi"], state.data["l"]["bias"]["bi"])
+    end
+  end
+
+  describe "prune/3" do
+    test "returns the pruned state and the mask" do
+      state = dense_state()
+
+      {pruned, mask} = Pruning.prune(state, 0.5)
+
+      assert_equal(mask["d"]["kernel"], @kernel_mask)
+      assert_equal(pruned.data["d"]["kernel"], Nx.select(@kernel_mask, @kernel, 0))
+      assert_equal(pruned.data["d"]["bias"], state.data["d"]["bias"])
+      assert pruned.parameters == state.parameters
+    end
+
+    test "works inside defn" do
+      state = dense_state()
+
+      assert_equal(InDefn.global_mask(state), Pruning.magnitude_mask(state, 0.5))
+      assert_equal(InDefn.dense_mask(state), Pruning.magnitude_mask(state, 0.0))
+      assert_equal(InDefn.tensor_mask(state), Pruning.magnitude_mask(state, 0.5, scope: :tensor))
+
+      mask = Pruning.magnitude_mask(state, 0.5)
+      assert_equal(InDefn.apply_mask(state, mask), Pruning.apply_mask(state, mask))
+
+      {pruned, mask} = InDefn.prune(state)
+      {expected_pruned, expected_mask} = Pruning.prune(state, 0.5)
+      assert_equal(pruned, expected_pruned)
+      assert_equal(mask, expected_mask)
+    end
+  end
+
+  describe "sparsity/1 and global_sparsity/1" do
+    test "report zero sparsity for a dense state" do
+      state = dense_state()
+
+      assert Pruning.sparsity(state) == %{"d" => %{"kernel" => 0.0, "bias" => 1.0}}
+      assert Pruning.global_sparsity(state) == 4 / 12
+    end
+
+    test "report the size-weighted fraction of zeros after pruning" do
+      state = put_in(dense_state(), [Access.key!(:data), "d", "bias"], Nx.broadcast(1.0, {4}))
+      {pruned, _mask} = Pruning.prune(state, 0.5, scope: :tensor)
+
+      assert Pruning.sparsity(pruned) == %{"d" => %{"kernel" => 0.5, "bias" => 0.0}}
+      assert Pruning.global_sparsity(pruned) == 4 / 12
+    end
+
+    test "handle composite parameters and empty states" do
+      {pruned, _mask} = Pruning.prune(lstm_state(), 0.5, scope: :tensor)
+
+      assert %{"l" => %{"input_kernel" => %{"wii" => 0.5}, "hidden_kernel" => %{"whi" => 0.5}}} =
+               Pruning.sparsity(pruned)
+
+      assert Pruning.global_sparsity(ModelState.empty()) == 0.0
+    end
+  end
+
+  describe "masked_optimizer/2" do
+    defp train(optimizer, model, state, iterations) do
+      data =
+        Stream.repeatedly(fn -> {Nx.broadcast(1.0, {2, 4}), Nx.broadcast(0.5, {2, 1})} end)
+
+      %Axon.Loop.State{step_state: %{model_state: trained}} =
+        model
+        |> Axon.Loop.trainer(:mean_squared_error, optimizer)
+        |> Axon.Loop.run(data, state, iterations: iterations)
+
+      trained
+    end
+
+    defp pruned_model do
+      model =
+        Axon.input("x", shape: {nil, 4})
+        |> Axon.dense(8, name: "d")
+        |> Axon.dense(1, name: "out")
+
+      state =
+        model
+        |> init(Nx.template({1, 4}, :f32))
+        |> put_in([Access.key!(:data), "d", "kernel"], Nx.iota({4, 8}, type: :f32))
+
+      {pruned, mask} = Pruning.prune(state, 0.5, filter: &match?(["d", "kernel"], &1))
+      {model, pruned, mask}
+    end
+
+    test "keeps pruned parameters at zero while training" do
+      {model, pruned, mask} = pruned_model()
+
+      for optimizer <- [:adam, Polaris.Optimizers.sgd(learning_rate: 0.1)] do
+        trained = train(Pruning.masked_optimizer(optimizer, mask), model, pruned, 5)
+
+        assert_equal(
+          Nx.select(mask["d"]["kernel"], 0, trained.data["d"]["kernel"]),
+          Nx.broadcast(0.0, {4, 8})
+        )
+
+        assert_not_equal(trained.data["d"]["kernel"], pruned.data["d"]["kernel"])
+        assert_not_equal(trained.data["d"]["bias"], pruned.data["d"]["bias"])
+        assert Pruning.sparsity(trained)["d"]["kernel"] == Pruning.sparsity(pruned)["d"]["kernel"]
+      end
+    end
+
+    test "an unmasked optimizer does not keep pruned parameters at zero" do
+      {model, pruned, mask} = pruned_model()
+
+      trained = train(:adam, model, pruned, 5)
+
+      assert_not_equal(
+        Nx.select(mask["d"]["kernel"], 0, trained.data["d"]["kernel"]),
+        Nx.broadcast(0.0, {4, 8})
+      )
+    end
+
+    test "raises on an invalid optimizer" do
+      message =
+        "invalid optimizer :nope, expected an atom matching the name of an optimizer" <>
+          " in Polaris.Optimizers or a tuple of {init_fn, update_fn}"
+
+      assert_raise ArgumentError, message, fn -> Pruning.masked_optimizer(:nope, %{}) end
+    end
+  end
+end

--- a/test/axon/pruning_test.exs
+++ b/test/axon/pruning_test.exs
@@ -359,6 +359,10 @@ defmodule Axon.PruningTest do
           " in Polaris.Optimizers or a tuple of {init_fn, update_fn}"
 
       assert_raise ArgumentError, message, fn -> Pruning.masked_optimizer(:nope, %{}) end
+
+      assert_raise ArgumentError, ~r/invalid optimizer :module_info/, fn ->
+        Pruning.masked_optimizer(:module_info, %{})
+      end
     end
   end
 end


### PR DESCRIPTION
Closes #120.

Pruning is a standard compression step alongside quantization, but Axon had nothing for it: there was no way to zero out low-magnitude weights, no way to keep them at zero while fine-tuning, and no way to report how sparse a model state is. This PR adds `Axon.Pruning`, a sibling of `Axon.Quantization` that works purely on an `Axon.ModelState` and leaves the model graph untouched.

## Design

This is a first, deliberately narrow increment: **unstructured magnitude pruning**. The parameters with the smallest absolute values are set to zero, either against one global threshold (`scope: :global`, the default, so some tensors end up sparser than others) or per tensor (`scope: :tensor`, every selected tensor is pruned to exactly the requested sparsity). Pruning always produces a *mask* alongside the pruned state: a nested map mirroring the model state data with a `{:u, 8}` tensor (`1` = keep, `0` = pruned) for every pruned parameter. Parameters that were not selected are simply absent from the mask.

The public API is:

* `magnitude_mask/3` computes the mask without touching the state. Candidates come from the `parameters` tree only, so batch-norm running statistics (which live in `state`) are never pruned. Tied parameters (`Axon.ModelState.SharedParameter`), quantized parameters (`Axon.Quantization.QTensor`) and non-float tensors are skipped. The `:filter` option receives the same access paths as `Axon.ModelState.freeze/2` (e.g. `["dense_0", "kernel"]` or `["lstm_0", "input_kernel", "wii"]`); the default keeps any path with a name ending in `"kernel"`, which covers dense/conv/embedding kernels and the composite RNN kernels while leaving biases and normalization parameters alone.
* `apply_mask/2` zeroes the masked entries of a model state or a plain parameter map using `Nx.select/3`, so dtypes are preserved and `NaN`/`Inf` don't leak through a multiply.
* `prune/3` is `magnitude_mask/3` + `apply_mask/2` and returns `{pruned_state, mask}`.
* `masked_optimizer/2` wraps anything `Axon.Loop.trainer/4` accepts (a `Polaris.Optimizers` atom or an `{init_fn, update_fn}` tuple) via `Polaris.Updates.stateful/3`. The mask is stored in the optimizer state, and the *final* update is zeroed at pruned positions, so a weight that starts at zero stays exactly zero regardless of momentum or weight decay. This composes with the existing loop and needs no changes to `Axon.Loop`. Mask entries for parameters that are not trained (e.g. frozen ones) are ignored.
* `sparsity/1` and `global_sparsity/1` report the fraction of exactly-zero entries per parameter (nested maps for composite parameters) and size-weighted across the whole state.

The mask computation ranks magnitudes with a double `Nx.argsort` (stable), so exactly `round(sparsity * n)` entries are pruned even when magnitudes tie, and it works inside `defn` on any backend. `magnitude_mask/3`, `apply_mask/2` and `prune/3` are `deftransform`s so they can be called from `defn`; the sparsity reporting functions call `Nx.to_number/1` and are eager only.

## Usage

```elixir
{pruned_state, mask} = Axon.Pruning.prune(model_state, 0.9)

Axon.Pruning.global_sparsity(pruned_state)
#=> 0.87...

trained_state =
  model
  |> Axon.Loop.trainer(:categorical_cross_entropy, Axon.Pruning.masked_optimizer(:adam, mask))
  |> Axon.Loop.run(data, pruned_state, epochs: 2)
```

## Limitations

* Zeroed weights are still stored densely: this reduces the number of non-zero parameters, not memory or latency. Getting a speedup needs sparse tensor support or structured pruning, neither of which exists yet.
* Structured/channel pruning, gradual pruning schedules and rewriting the model graph are out of scope for this increment.
* The default filter is a naming heuristic on `"kernel"`; anything else needs an explicit `:filter`.
* `masked_optimizer/2` copies the mask to the binary backend so it can be embedded in the traced optimizer init; from then on it travels as ordinary optimizer state (and is therefore checkpointed with it).
* Ties between equal magnitudes are broken by position, deterministically but arbitrarily.

## Tests

`test/axon/pruning_test.exs` covers per-tensor and global masks against hand-computed expectations, exact counts under ties, the sparsity `0`/`1` short-circuits, the default filter on dense + batch norm (state untouched) and LSTM (composite kernels masked, biases not), custom filters, skipping of tied, quantized and integer parameters, argument validation, `apply_mask/2` on model states and plain parameter maps (ignoring mask keys that are absent), all three transforms inside `defn`, `sparsity/1`/`global_sparsity/1` including composite parameters and empty states, and `masked_optimizer/2` with both `:adam` and an `{init_fn, update_fn}` tuple through a real `Axon.Loop` run (pruned entries stay exactly zero, unmasked entries train, and a control run without the wrapper does *not* keep them at zero). The suite passes on the default backend and with `USE_EXLA=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
