### PR TITLE
Initialize training step state in the types the step produces

### DIFF
--- a/lib/axon/loop.ex
+++ b/lib/axon/loop.ex
@@ -311,6 +311,13 @@ defmodule Axon.Loop do
   the model through `model_parameters = Axon.Update.apply_updates(model_parameters, scaled_updates)`.
   See `Polaris.Updates` for more information on building optimizers.
 
+  The step state is initialized in the types a step produces from it: the loss
+  accumulator takes the type of the loss, and optimizer state which an optimizer
+  initializes in f32 but updates in a wider type (for example Adam moments with
+  f64 parameters) starts in that wider type. This keeps the step state a fixed
+  point in shape and type, which `run/4` relies on when it compiles the step
+  function.
+
   ## Options
 
     * `:seed` - seed to use when constructing models. Seed controls random initialization
@@ -330,34 +337,6 @@ defmodule Axon.Loop do
     {init_optimizer_fn, update_optimizer_fn} = build_optimizer_fns(optimizer)
     {init_loss_scale, scale_loss, unscale_grads} = build_loss_scale_fns(loss_scale)
 
-    init_fn = fn
-      {inp, tar}, %{} = init_model_state ->
-        model_state = init_model_fn.(inp, init_model_state)
-        trainable_parameters = Axon.ModelState.trainable_parameters(model_state)
-
-        optimizer_state = init_optimizer_fn.(trainable_parameters)
-        loss_scale_state = init_loss_scale.()
-
-        # This traces the forward pass to learn the shape and type of the
-        # prediction, it does not compute it. zeros_like/1 reads only the
-        # shape and type off the traced tensors, so the forward expression
-        # is never referenced by the returned state and never lowered.
-        %{prediction: output} = forward_model_fn.(model_state, inp)
-
-        %{
-          i: Nx.tensor(0),
-          y_true: zeros_like(tar),
-          y_pred: zeros_like(output),
-          loss: Nx.tensor(0.0),
-          model_state: model_state,
-          optimizer_state: optimizer_state,
-          loss_scale_state: loss_scale_state
-        }
-
-      data, state ->
-        raise_bad_training_inputs!(data, state)
-    end
-
     objective_fn = fn trainable_parameters, model_state, loss_scale_state, inp, tar ->
       # hack to use trainable parameters as grad
       model_state =
@@ -372,62 +351,116 @@ defmodule Axon.Loop do
       {model_out, scaled_loss, unscaled_loss}
     end
 
-    step_fn = fn
-      {inp, tar}, %{} = state ->
-        %{
-          i: i,
-          loss_scale_state: loss_scale_state,
-          model_state: model_state,
-          optimizer_state: optimizer_state,
-          loss: loss
-        } = state
+    step_body = fn {inp, tar}, state ->
+      %{
+        i: i,
+        loss_scale_state: loss_scale_state,
+        model_state: model_state,
+        optimizer_state: optimizer_state,
+        loss: loss
+      } = state
 
+      trainable_parameters = Axon.ModelState.trainable_parameters(model_state)
+
+      {{model_out, _batch_scaled_loss, batch_loss}, gradients} =
+        Nx.Defn.value_and_grad(
+          trainable_parameters,
+          &objective_fn.(&1, model_state, loss_scale_state, inp, tar),
+          fn x -> elem(x, 1) end
+        )
+
+      {gradients, new_loss_scale_state} =
+        unscale_grads.(gradients, loss_scale_state)
+
+      {updates, new_optimizer_state} =
+        update_optimizer_fn.(gradients, optimizer_state, trainable_parameters)
+
+      updated_parameters = Polaris.Updates.apply_updates(trainable_parameters, updates)
+
+      %{prediction: preds, state: updated_state} = model_out
+
+      new_loss =
+        loss
+        |> Nx.multiply(i)
+        |> Nx.add(batch_loss)
+        |> Nx.divide(Nx.add(i, 1))
+
+      new_model_state = Axon.ModelState.update(model_state, updated_parameters, updated_state)
+
+      %{
+        state
+        | i: Nx.add(i, 1),
+          y_true: tar,
+          y_pred: preds,
+          loss: new_loss,
+          model_state: new_model_state,
+          optimizer_state: new_optimizer_state,
+          loss_scale_state: new_loss_scale_state
+      }
+    end
+
+    init_fn = fn
+      {inp, tar}, %{} = init_model_state ->
+        model_state = init_model_fn.(inp, init_model_state)
         trainable_parameters = Axon.ModelState.trainable_parameters(model_state)
 
-        {{model_out, _batch_scaled_loss, batch_loss}, gradients} =
-          Nx.Defn.value_and_grad(
-            trainable_parameters,
-            &objective_fn.(&1, model_state, loss_scale_state, inp, tar),
-            fn x -> elem(x, 1) end
-          )
+        optimizer_state = init_optimizer_fn.(trainable_parameters)
+        loss_scale_state = init_loss_scale.()
 
-        {gradients, new_loss_scale_state} =
-          unscale_grads.(gradients, loss_scale_state)
+        # This traces the forward pass to learn the shape and type of the
+        # prediction, it does not compute it. zeros_like/1 reads only the
+        # shape and type off the traced tensors, so the forward expression
+        # is never referenced by the returned state and never lowered.
+        %{prediction: output} = forward_model_fn.(model_state, inp)
 
-        {updates, new_optimizer_state} =
-          update_optimizer_fn.(gradients, optimizer_state, trainable_parameters)
-
-        updated_parameters = Polaris.Updates.apply_updates(trainable_parameters, updates)
-
-        %{prediction: preds, state: updated_state} = model_out
-
-        new_loss =
-          loss
-          |> Nx.multiply(i)
-          |> Nx.add(batch_loss)
-          |> Nx.divide(Nx.add(i, 1))
-
-        new_model_state = Axon.ModelState.update(model_state, updated_parameters, updated_state)
-
-        %{
-          state
-          | i: Nx.add(i, 1),
-            y_true: tar,
-            y_pred: preds,
-            loss: new_loss,
-            model_state: new_model_state,
-            optimizer_state: new_optimizer_state,
-            loss_scale_state: new_loss_scale_state
+        state = %{
+          i: Nx.tensor(0),
+          y_true: zeros_like(tar),
+          y_pred: zeros_like(output),
+          loss: Nx.tensor(0.0),
+          model_state: model_state,
+          optimizer_state: optimizer_state,
+          loss_scale_state: loss_scale_state
         }
+
+        # The loop compiles the step against this state as a template, so the
+        # step must return it with the same shapes and types. Nothing here can
+        # know those types up front: the loss takes the type of the model
+        # output and targets, and optimizers initialize their state in f32
+        # whatever the parameter type (Polaris does), which then promotes on
+        # the first update with f64 gradients. Tracing one step reads the
+        # types the step actually produces; like the forward pass above, the
+        # traced step is never referenced by the returned state and never
+        # lowered.
+        cast_like(state, step_body.({inp, tar}, state))
 
       data, state ->
         raise_bad_training_inputs!(data, state)
+    end
+
+    step_fn = fn
+      {inp, tar}, %{} = state -> step_body.({inp, tar}, state)
+      data, state -> raise_bad_training_inputs!(data, state)
     end
 
     {
       Nx.Defn.jit(init_fn, on_conflict: :reuse),
       Nx.Defn.jit(step_fn, on_conflict: :reuse)
     }
+  end
+
+  # Casts every tensor in `container` to the type of the corresponding tensor
+  # in `like`, which must have the same structure. Only the types of `like`
+  # are read, so a traced `like` is never lowered.
+  defp cast_like(container, like) do
+    leaves = Nx.Defn.Composite.flatten_list([like])
+
+    {container, []} =
+      Nx.Defn.Composite.traverse(container, leaves, fn tensor, [leaf | rest] ->
+        {Nx.as_type(tensor, Nx.type(leaf)), rest}
+      end)
+
+    container
   end
 
   defp tree_merge(lhs, rhs, fun) do
@@ -802,7 +835,9 @@ defmodule Axon.Loop do
       |> Axon.Loop.metric(:true_negatives, "tn", :running_sum)
 
   Accumulation function can be one of the accumulation combinators in Axon.Metrics
-  or an arity-3 function of the form: `accumulate(acc, obs, i) :: new_acc`.
+  or an arity-3 function of the form: `accumulate(acc, obs, i) :: new_acc`. The
+  accumulator starts from zero in the type of the accumulated value, so a metric
+  over f64 tensors accumulates in f64.
   """
   def metric(
         %Loop{metrics: metric_fns} = loop,
@@ -1679,8 +1714,7 @@ defmodule Axon.Loop do
       Logger.debug("Axon.Loop finished initializing loop state in #{us_to_ms(time)}ms")
     end
 
-    # TODO: Can we infer here?
-    zero_metrics = Map.new(metric_fns, fn {k, _} -> {k, Nx.tensor(0, type: :f32)} end)
+    zero_metrics = init_metrics(metric_fns, loop_state.step_state, jit_compile?, jit_opts)
     final_metrics_map = loop_state.metrics
     loop_state = %{loop_state | metrics: zero_metrics}
 
@@ -2047,25 +2081,46 @@ defmodule Axon.Loop do
 
       new_metrics =
         metrics
-        |> Enum.zip_with(metric_fns, fn {k, avg}, {k, {v, _}} ->
-          # In some instances the metric is actually present in the
-          # step state e.g. in a supervised training loop when we
-          # are computing loss but it's already computed as a part
-          # of the step state, so we need to check here
-          metric = String.to_atom(k)
-
-          case pstate do
-            %{^metric => value} ->
-              {k, value}
-
-            %{} ->
-              {k, v.(avg, List.wrap(new_step_state), iter)}
-          end
+        |> Enum.zip_with(metric_fns, fn {k, acc}, {k, {v, _}} ->
+          {k, accumulate_metric(k, v, acc, pstate, new_step_state, iter)}
         end)
         |> Map.new()
 
       {new_step_state, new_metrics}
     end
+  end
+
+  # In some instances the metric is actually present in the step state,
+  # e.g. the loss in a supervised training loop, so it is read from there
+  # instead of being accumulated.
+  defp accumulate_metric(name, metric_fn, acc, pstate, new_step_state, iter) do
+    key = String.to_atom(name)
+
+    case pstate do
+      %{^key => value} -> value
+      %{} -> metric_fn.(acc, List.wrap(new_step_state), iter)
+    end
+  end
+
+  # A metric accumulates in the type of its accumulator merged with the type
+  # of the value it observes, and a metric read straight from the step state
+  # has whatever type the step gives it. The zero each accumulator starts
+  # from must already have that type or the metrics change type after the
+  # first batch and no longer match the template the batch function was
+  # compiled against. Tracing one accumulation from an f32 zero over the
+  # initial step state gives the type without computing the metric.
+  defp init_metrics(metric_fns, _step_state, _jit_compile?, _jit_opts) when metric_fns == %{},
+    do: %{}
+
+  defp init_metrics(metric_fns, step_state, jit_compile?, jit_opts) do
+    infer = fn step_state ->
+      Map.new(metric_fns, fn {name, {metric_fn, _}} ->
+        value = accumulate_metric(name, metric_fn, Nx.tensor(0.0), step_state, step_state, 0)
+        {name, zeros_like(value)}
+      end)
+    end
+
+    maybe_jit(infer, [step_state], jit_compile?, jit_opts)
   end
 
   # Builds a loss function from an atom, function, or list of. Valid loss

--- a/test/axon/loop_test.exs
+++ b/test/axon/loop_test.exs
@@ -117,7 +117,8 @@ defmodule Axon.LoopTest do
       assert %{model_state: %{}} =
                pstate =
                init_fn.(
-                 {%{"input_0" => Nx.tensor([[2]]), "input_1" => Nx.tensor([[2]])}, Nx.tensor(0)},
+                 {%{"input_0" => Nx.tensor([[2]]), "input_1" => Nx.tensor([[2]])},
+                  {Nx.tensor([[2]]), Nx.tensor([[2]])}},
                  Axon.ModelState.empty()
                )
 
@@ -289,6 +290,39 @@ defmodule Axon.LoopTest do
       assert_all_close(state.model_state.data["instance_norm"]["mean"], Nx.broadcast(0.9, {8}))
       assert_all_close(state.model_state.data["instance_norm"]["var"], Nx.broadcast(0.1, {8}))
     end
+
+    test "train_step/3 initializes the step state in the types the step produces" do
+      model = precision_model({:f, 64})
+      batch = precision_batch()
+
+      for loss_scale <- [:identity, :dynamic, :static] do
+        {init_fn, step_fn} =
+          Loop.train_step(model, :mean_squared_error, :adam, loss_scale: loss_scale)
+
+        state = init_fn.(batch, Axon.ModelState.empty())
+        next = step_fn.(batch, state)
+
+        assert Nx.type(state.loss) == {:f, 64}
+        assert Nx.type(elem(state.optimizer_state, 1).mu["dense_0"]["kernel"]) == {:f, 64}
+        assert Nx.type(state.model_state.data["dense_0"]["kernel"]) == {:f, 64}
+        assert leaf_types(state) == leaf_types(next)
+      end
+    end
+
+    test "train_step/3 keeps f32 state under an f16 policy" do
+      model = precision_model({:f, 16})
+      batch = precision_batch()
+
+      {init_fn, step_fn} = Loop.train_step(model, :mean_squared_error, :adam)
+
+      state = init_fn.(batch, Axon.ModelState.empty())
+      next = step_fn.(batch, state)
+
+      assert Nx.type(state.loss) == {:f, 32}
+      assert Nx.type(elem(state.optimizer_state, 1).mu["dense_0"]["kernel"]) == {:f, 32}
+      assert Nx.type(state.model_state.data["dense_0"]["kernel"]) == {:f, 16}
+      assert leaf_types(state) == leaf_types(next)
+    end
   end
 
   describe "metrics" do
@@ -370,6 +404,67 @@ defmodule Axon.LoopTest do
       i = 10
 
       assert_equal(sum_tp_fun.(cur_sum, List.wrap(output), i), Nx.tensor(26))
+    end
+  end
+
+  # A dense model with every parameter, computation and output in `type`.
+  defp precision_model(type) do
+    policy = Axon.MixedPrecision.create_policy(params: type, compute: type, output: type)
+
+    Axon.input("input", shape: {nil, 4})
+    |> Axon.dense(8, activation: :relu)
+    |> Axon.dense(1)
+    |> Axon.MixedPrecision.apply_policy(policy)
+  end
+
+  defp precision_batch(target_type \\ {:f, 32}) do
+    {Nx.iota({2, 4}, type: :f32), Nx.tensor([[1.0], [0.0]], type: target_type)}
+  end
+
+  defp leaf_types(container) do
+    container
+    |> List.wrap()
+    |> Nx.Defn.Composite.flatten_list()
+    |> Enum.map(&Nx.type/1)
+  end
+
+  describe "step state types" do
+    test "runs a strict loop with an f64 mixed precision policy" do
+      model = precision_model({:f, 64})
+      data = List.duplicate(precision_batch(), 3)
+
+      ExUnit.CaptureIO.capture_io(fn ->
+        state =
+          model
+          |> Loop.trainer(:mean_squared_error, :adam)
+          |> Loop.metric(:mean_absolute_error)
+          |> Loop.run(data, Axon.ModelState.empty(), epochs: 2)
+
+        assert %State{epoch: 2, metrics: metrics, step_state: step_state} = state
+        assert Nx.type(step_state.loss) == {:f, 64}
+        assert Nx.type(step_state.model_state.data["dense_0"]["kernel"]) == {:f, 64}
+        assert Nx.type(metrics[1]["loss"]) == {:f, 64}
+        assert Nx.type(metrics[1]["mean_absolute_error"]) == {:f, 64}
+      end)
+    end
+
+    test "runs a strict loop with f64 targets and an f32 model" do
+      model = Axon.input("input", shape: {nil, 4}) |> Axon.dense(8) |> Axon.dense(1)
+      data = List.duplicate(precision_batch({:f, 64}), 3)
+
+      for optimizer <- [:sgd, :adam] do
+        ExUnit.CaptureIO.capture_io(fn ->
+          state =
+            model
+            |> Loop.trainer(:mean_squared_error, optimizer)
+            |> Loop.run(data, Axon.ModelState.empty(), epochs: 1)
+
+          assert %State{epoch: 1, metrics: metrics, step_state: step_state} = state
+          assert Nx.type(step_state.loss) == {:f, 64}
+          assert Nx.type(step_state.model_state.data["dense_0"]["kernel"]) == {:f, 32}
+          assert Nx.type(metrics[0]["loss"]) == {:f, 64}
+        end)
+      end
     end
   end
 
@@ -845,7 +940,7 @@ defmodule Axon.LoopTest do
       loss = :binary_cross_entropy
 
       {init_fn, _} = Axon.Loop.train_step(model, loss, optimizer)
-      step_state = init_fn.({Nx.tensor([[1]]), Nx.tensor(1)}, Axon.ModelState.empty())
+      step_state = init_fn.({Nx.tensor([[1]]), Nx.tensor([[1, 0]])}, Axon.ModelState.empty())
       state = %State{step_state: step_state}
 
       serialized = Axon.Loop.serialize_state(state)


### PR DESCRIPTION
Closes #568.

## The problem

`Axon.Loop.run/4` compiles the batch function once, against the initial step state and metrics as templates, and calls that compiled function on every following batch. That only works if the step state is a fixed point of the step in shape and type. On main it is not as soon as anything in the pipeline is wider than f32. The `Nx.while` error from the original report is gone (that code no longer exists), but the same defect now surfaces on the second batch of any f64 run:

```
** (ArgumentError) argument at position 3 is not compatible with compiled function template.
%{i: s32, loss: <<<<< Expected f32 ==== Argument f64 >>>>>, ...
```

Three places hardcoded f32 where the step produces something else:

1. `train_step/4` seeded `loss` with `Nx.tensor(0.0)`; the step computes `loss * i + batch_loss / (i + 1)`, so with an f64 loss it turns f64 after one step.
2. Polaris initializes optimizer moments in f32 regardless of the parameter type; with f64 gradients Adam's `mu`/`nu` promote to f64 on the first update. Every optimizer with moments (adam, adamw, lamb, radam, rmsprop, yogi, adabelief, sgd with momentum) does this.
3. `run/4` started every metric accumulator from `Nx.tensor(0, type: :f32)` (next to a `# TODO: Can we infer here?`), so a `"loss"` metric copied from an f64 step state, or `mean_absolute_error` over f64 predictions, changed type after the first batch too.

The existing integration test "f64 input test" (f64 inputs against an f32 model) fails on main for the same reason and passes with this change.

## The design

Rather than special-casing each entry, the step state is initialized in the types the step produces, learned by tracing one step, not computing it. `train_step/4`'s init already traces the forward pass only to read the prediction's shape and type; this extends the same idea to the whole step. The step body is split out of `step_fn` so init can call it, and init casts its seed state to the traced result:

```elixir
cast_like(state, step_body.({inp, tar}, state))
```

`cast_like/2` only reads `Nx.type/1` off the traced leaves, so nothing of the gradient expression is referenced by the returned state or lowered; the cost is one extra trace at init. One trace is enough because Nx type promotion is monotone: after one step every accumulator has already merged with the types of everything it merges with. `Nx.as_type/2` is a no-op where the type already matches, so `i`, the loss-scale state and every already-correct tensor are untouched.

Metrics get the same treatment: `init_metrics/4` traces one accumulation from an f32 zero over the initial step state and starts each accumulator from `zeros_like` of that value. Metrics that are read straight from the step state (the trainer's `"loss"`) take the step state's type.

Nothing is guessed by hand: the loss type is whatever the loss function returns for the model's output and targets, and optimizer state is whatever the optimizer's update produces. That is what makes this hold for custom losses, custom optimizers and every loss-scale mode without per-case code.

## Usage

```elixir
policy = Axon.MixedPrecision.create_policy(params: {:f, 64}, compute: {:f, 64}, output: {:f, 64})

model =
  Axon.input("input", shape: {nil, 4})
  |> Axon.dense(8, activation: :relu)
  |> Axon.dense(1)
  |> Axon.MixedPrecision.apply_policy(policy)

model
|> Axon.Loop.trainer(:mean_squared_error, :adam)
|> Axon.Loop.metric(:mean_absolute_error)
|> Axon.Loop.run(data, Axon.ModelState.empty(), epochs: 5)
```

This now runs to completion with the default `strict?: true`; the loss, the Adam moments and both metrics are f64.

## Tradeoffs and limitations

- f16/bf16 behaviour is unchanged. With f16 parameters the gradients and loss are f32 and Polaris keeps its f32 master state, so the state was already a fixed point; the cast finds the same types and downcasts nothing. A test pins this.
- Metrics still start from an f32 zero, so for f32 models nothing changes: integer-valued metrics accumulated with `:running_sum` keep accumulating in f32 as they do today. Only metrics whose values are wider than f32 widen.
- Init now traces the loss and optimizer update, so the targets given to `init_fn` must be valid for the loss. `run/4` always initializes from a real batch so this is transparent there; two tests that called `init_fn` directly with placeholder targets of the wrong shape have been updated to pass real ones.
- Polaris's f32 moment initialization is left alone; working around it explicitly would break the f16 master-state case and would still leave custom optimizers unhandled.

## Tests

- `train_step/3` with an f64 policy: `loss` and Adam moments are f64 at init, and the leaf types of the init state equal those of the state after one step, for `:identity`, `:dynamic` and `:static` loss scales. Fails on main with `loss` and eight Adam tensors differing.
- `train_step/3` with an f16 policy keeps f32 loss and moments, f16 parameters, and is a type fixed point (guards against downcasting).
- A strict `Axon.Loop.run` of an f64 policy model with `:adam` and a `mean_absolute_error` metric completes two epochs with f64 loss, parameters and metrics. Raises the template error on main.
- A strict run with f64 targets against an f32 model completes with `:sgd` and `:adam` and reports an f64 loss (the same failure mode as the existing "f64 input test" integration test, which now passes).

The full suite passes, `test/axon/loop_test.exs` passes on EXLA, and `test/axon/integration_test.exs --include integration` passes apart from "image classification test", which times out at 60s on main as well on the default backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
