### PR TITLE
Build train steps from objective functions

### DIFF
--- a/guides/training_and_evaluation/custom_models_loss_optimizers.livemd
+++ b/guides/training_and_evaluation/custom_models_loss_optimizers.livemd
@@ -341,6 +341,70 @@ Epoch: 0, Batch: 1000, loss: 0.1098235
 }
 ```
 
+## Using custom objectives in training loops
+
+A loss function only ever sees the targets and the prediction of a single forward pass. Some training objectives need more than that: contrastive and metric-learning objectives run the model on several inputs and compare the embeddings, regularized objectives add a penalty computed from the parameters, and some objectives are only meaningful when you can see the whole model state. Rather than re-implementing the training step for these cases, `Axon.Loop.trainer/3` and `Axon.Loop.train_step/3` accept an objective function anywhere they accept a loss. An objective is an arity-4 function which matches the following spec:
+
+<!-- livebook:{"force_markdown":true} -->
+
+```elixir
+objective(
+  forward_fn :: (model_state, inputs -> %{prediction: term, state: term}),
+  model_state :: Axon.ModelState.t(),
+  inputs :: tensor | container(tensor),
+  targets :: tensor | container(tensor)
+) :: {loss :: scalar, %{prediction: term, state: term}}
+```
+
+`forward_fn` is the model's forward function in training mode, so you never have to build the model yourself or remember to pass `mode: :train`. `model_state` is the state being trained; the training step differentiates the returned loss with respect to it, which means any parameter you read from `model_state.data` inside the objective is differentiated too. The objective returns the unscaled loss along with the forward output to use as the prediction. The output must be a map with `:prediction` and `:state` keys, which is exactly what `forward_fn` returns, so the common case is `{loss, forward_fn.(model_state, inputs)}`. `:prediction` becomes `y_pred` in the step state for metrics and `:state` is the updated state of stateful layers such as batch normalization. When the objective runs the model more than once, return whichever output you want to treat as the prediction.
+
+For example, the following objective adds an L2 penalty on the kernel of the first layer to a mean squared error loss:
+
+```elixir
+train_data =
+  Stream.repeatedly(fn ->
+    xs = Nx.random_normal({8, 1})
+    ys = Nx.sin(xs)
+    {xs, ys}
+  end)
+
+model =
+  Axon.input("data")
+  |> Axon.dense(8, name: "dense_0")
+  |> Axon.relu()
+  |> Axon.dense(1, name: "dense_1")
+
+objective = fn forward_fn, model_state, inputs, targets ->
+  %{prediction: y_pred} = output = forward_fn.(model_state, inputs)
+
+  penalty = model_state.data["dense_0"]["kernel"] |> Nx.pow(2) |> Nx.sum()
+  loss = Axon.Losses.mean_squared_error(targets, y_pred, reduction: :mean)
+
+  {Nx.add(loss, Nx.multiply(1.0e-3, penalty)), output}
+end
+
+model
+|> Axon.Loop.trainer(objective, :sgd)
+|> Axon.Loop.run(train_data, %{}, iterations: 1000)
+```
+
+Objectives run inside the compiled training step, so an anonymous objective must use `Nx` functions on tensors (`Nx.add/2` rather than `+`), or you can write it as a `defn` and pass `&MyModule.objective/4`. Here is an objective which runs the model twice and pulls the embeddings of two views of the same input together:
+
+<!-- livebook:{"force_markdown":true} -->
+
+```elixir
+objective = fn forward_fn, model_state, {anchor, positive}, _targets ->
+  %{prediction: anchor_embedding} = output = forward_fn.(model_state, anchor)
+  %{prediction: positive_embedding} = forward_fn.(model_state, positive)
+
+  loss = Nx.mean(Nx.pow(Nx.subtract(anchor_embedding, positive_embedding), 2))
+
+  {loss, output}
+end
+```
+
+The `loss` reported by a loop built from an objective is the running average of the objective's loss kept by the training step. Because it cannot be recomputed from `y_true` and `y_pred` alone, `Axon.Loop.validate/4` does not report a `validation_loss` for these loops; metrics given as an atom or an arity-2 function, such as `:mean_absolute_error`, are still validated as usual.
+
 ## Using custom optimizers in training loops
 
 As you might expect, it's also possible to customize the optimizer passed to `Axon.Loop.trainer/3`. If you read the `Polaris.Updates` documentation, you'll learn that optimizers are actually represented as the tuple `{init_fn, update_fn}` where `init_fn` initializes optimizer state from model state and `update_fn` scales gradients from optimizer state, gradients, and model state.

--- a/lib/axon/loop.ex
+++ b/lib/axon/loop.ex
@@ -299,8 +299,9 @@ defmodule Axon.Loop do
 
   `loss` must be an atom which matches a function in `Axon.Losses`, a list
   of `{loss, weight}` tuples representing a basic weighted loss function
-  for multi-output models, or an arity-2 function representing a custom loss
-  function.
+  for multi-output models, an arity-2 function representing a custom loss
+  function, or an arity-4 objective function. See the section on objective
+  functions below.
 
   `optimizer` must be an atom matching the name of a valid optimizer in `Polaris.Optimizers`,
   or a `{init_fn, update_fn}` tuple where `init_fn` is an arity-1 function which
@@ -310,6 +311,65 @@ defmodule Axon.Loop do
   The `update_fn` returns `{scaled_updates, optimizer_state}`, which can then be applied to
   the model through `model_parameters = Axon.Update.apply_updates(model_parameters, scaled_updates)`.
   See `Polaris.Updates` for more information on building optimizers.
+
+  ## Objective functions
+
+  A loss function only sees the targets and the prediction of a single forward
+  pass. When the quantity you want to minimize needs more than that, such as
+  several forward passes of the same model, a penalty on the parameters, or a
+  contrastive objective, pass an objective function instead of a loss. An
+  objective is an arity-4 function of the form:
+
+      objective(forward_fn, model_state, inputs, targets) :: {loss, output}
+
+  where:
+
+    * `forward_fn` is the model's forward function in training mode, the
+      same function `Axon.build/2` returns with `mode: :train` (or the
+      `apply_fn` of a `{init_fn, apply_fn}` model). You never need to build
+      the model yourself.
+
+    * `model_state` is the `%Axon.ModelState{}` being trained. The step
+      differentiates `loss` with respect to it, so any parameter you read
+      from `model_state.data` inside the objective is differentiated too.
+      Frozen parameters are excluded from the update.
+
+    * `inputs` and `targets` are the current batch.
+
+    * `loss` must be a scalar tensor. It is the unscaled loss; the step
+      applies loss scaling around the objective.
+
+    * `output` must be a map with `:prediction` and `:state` keys, exactly
+      what `forward_fn` returns in training mode. `:prediction` becomes
+      `y_pred` in the step state for metrics and `:state` is the updated
+      state of stateful layers such as batch normalization. When the
+      objective runs the model more than once, return whichever output you
+      want to be treated as the prediction.
+
+  The common case is therefore `{loss, forward_fn.(model_state, inputs)}`.
+  For example, an objective which adds an L2 penalty on a kernel to the loss:
+
+      objective = fn forward_fn, model_state, inputs, targets ->
+        %{prediction: y_pred} = output = forward_fn.(model_state, inputs)
+        penalty = model_state.data["dense_0"]["kernel"] |> Nx.pow(2) |> Nx.sum()
+        loss = Axon.Losses.mean_squared_error(targets, y_pred, reduction: :mean)
+        {Nx.add(loss, Nx.multiply(1.0e-3, penalty)), output}
+      end
+
+      {init_fn, step_fn} = Axon.Loop.train_step(model, objective, :sgd)
+
+  Or one which runs the model twice and compares the two predictions:
+
+      objective = fn forward_fn, model_state, {anchor, positive}, _targets ->
+        %{prediction: anchor_embedding} = output = forward_fn.(model_state, anchor)
+        %{prediction: positive_embedding} = forward_fn.(model_state, positive)
+        loss = Nx.mean(Nx.pow(Nx.subtract(anchor_embedding, positive_embedding), 2))
+        {loss, output}
+      end
+
+  Objectives run inside the compiled step, so anonymous objectives must use
+  `Nx` functions on tensors (`Nx.add/2` rather than `+`), or be written as
+  `defn` functions.
 
   ## Options
 
@@ -326,7 +386,7 @@ defmodule Axon.Loop do
     loss_scale = opts[:loss_scale] || :identity
 
     {init_model_fn, forward_model_fn} = build_model_fns(model, :train, opts)
-    loss_fn = build_loss_fn(loss)
+    objective_fn = build_objective_fn(loss)
     {init_optimizer_fn, update_optimizer_fn} = build_optimizer_fns(optimizer)
     {init_loss_scale, scale_loss, unscale_grads} = build_loss_scale_fns(loss_scale)
 
@@ -338,11 +398,12 @@ defmodule Axon.Loop do
         optimizer_state = init_optimizer_fn.(trainable_parameters)
         loss_scale_state = init_loss_scale.()
 
-        # This traces the forward pass to learn the shape and type of the
+        # This traces the objective to learn the shape and type of the
         # prediction, it does not compute it. zeros_like/1 reads only the
-        # shape and type off the traced tensors, so the forward expression
+        # shape and type off the traced tensors, so the objective expression
         # is never referenced by the returned state and never lowered.
-        %{prediction: output} = forward_model_fn.(model_state, inp)
+        {_loss, %{prediction: output}} =
+          run_objective!(objective_fn, forward_model_fn, model_state, inp, tar)
 
         %{
           i: Nx.tensor(0),
@@ -358,20 +419,6 @@ defmodule Axon.Loop do
         raise_bad_training_inputs!(data, state)
     end
 
-    objective_fn = fn trainable_parameters, model_state, loss_scale_state, inp, tar ->
-      # hack to use trainable parameters as grad
-      model_state =
-        update_in(model_state, [Access.key!(:data)], fn data ->
-          tree_merge(data, trainable_parameters, fn _, _, v -> v end)
-        end)
-
-      model_out = forward_model_fn.(model_state, inp)
-      unscaled_loss = loss_fn.(tar, model_out.prediction)
-      scaled_loss = scale_loss.(unscaled_loss, loss_scale_state)
-
-      {model_out, scaled_loss, unscaled_loss}
-    end
-
     step_fn = fn
       {inp, tar}, %{} = state ->
         %{
@@ -382,14 +429,24 @@ defmodule Axon.Loop do
           loss: loss
         } = state
 
-        trainable_parameters = Axon.ModelState.trainable_parameters(model_state)
-
-        {{model_out, _batch_scaled_loss, batch_loss}, gradients} =
+        # The loss is differentiated with respect to the whole model state,
+        # so the objective can read any parameter straight from it. The
+        # gradients of frozen parameters and layer state are never used and
+        # are eliminated by the compiler.
+        {{_batch_scaled_loss, batch_loss, model_out}, gradients} =
           Nx.Defn.value_and_grad(
-            trainable_parameters,
-            &objective_fn.(&1, model_state, loss_scale_state, inp, tar),
-            fn x -> elem(x, 1) end
+            model_state,
+            fn model_state ->
+              {loss, output} =
+                run_objective!(objective_fn, forward_model_fn, model_state, inp, tar)
+
+              {scale_loss.(loss, loss_scale_state), loss, output}
+            end,
+            &elem(&1, 0)
           )
+
+        trainable_parameters = Axon.ModelState.trainable_parameters(model_state)
+        gradients = Axon.ModelState.trainable_parameters(gradients)
 
         {gradients, new_loss_scale_state} =
           unscale_grads.(gradients, loss_scale_state)
@@ -430,25 +487,20 @@ defmodule Axon.Loop do
     }
   end
 
-  defp tree_merge(lhs, rhs, fun) do
-    Enum.reduce(lhs, %{}, fn {key, val_lhs}, acc ->
-      case Map.get(rhs, key) do
-        nil ->
-          Map.put(acc, key, val_lhs)
+  # Runs the objective and checks its return value. This runs while the
+  # step is traced, so a bad objective raises once, before compilation.
+  defp run_objective!(objective_fn, forward_fn, model_state, inputs, targets) do
+    case objective_fn.(forward_fn, model_state, inputs, targets) do
+      {loss, %{prediction: _, state: _} = output} ->
+        {loss, output}
 
-        %Nx.Tensor{} = val_rhs ->
-          new_val = fun.(key, val_lhs, val_rhs)
-          Map.put(acc, key, new_val)
-
-        val_rhs when is_map(val_lhs) and is_map(val_rhs) ->
-          updated_val = tree_merge(val_lhs, val_rhs, fun)
-          Map.put(acc, key, updated_val)
-
-        val_rhs ->
-          new_val = fun.(key, val_lhs, val_rhs)
-          Map.put(acc, key, new_val)
-      end
-    end)
+      other ->
+        raise ArgumentError,
+              "objective function must return a 2-tuple of {loss, output} where" <>
+                " output is a map with :prediction and :state keys, such as the map" <>
+                " returned by the model's forward function in training mode, got: " <>
+                inspect(other)
+    end
   end
 
   defp raise_bad_training_inputs!(data, state) do
@@ -573,8 +625,10 @@ defmodule Axon.Loop do
 
   `loss` must be an atom which matches a function in `Axon.Losses`, a list
   of `{loss, weight}` tuples representing a basic weighted loss function
-  for multi-output models, or an arity-2 function representing a custom loss
-  function.
+  for multi-output models, an arity-2 function representing a custom loss
+  function, or an arity-4 objective function of the form
+  `objective(forward_fn, model_state, inputs, targets) :: {loss, output}`.
+  See `train_step/4` for the objective function contract.
 
   `optimizer` must be an atom matching the name of a valid optimizer in `Polaris.Optimizers`,
   or a `{init_fn, update_fn}` tuple where `init_fn` is an arity-1 function which
@@ -637,6 +691,29 @@ defmodule Axon.Loop do
       |> Axon.Loop.trainer(loss_weights, :sgd)
       |> Axon.Loop.run(data)
 
+  ### Custom objective
+
+  When the loss depends on more than the targets and a single prediction,
+  pass an objective function. It receives the training-mode forward
+  function and the model state and returns the loss along with the forward
+  output to use as the prediction:
+
+      objective = fn forward_fn, model_state, inputs, targets ->
+        %{prediction: y_pred} = output = forward_fn.(model_state, inputs)
+        penalty = model_state.data["dense_0"]["kernel"] |> Nx.pow(2) |> Nx.sum()
+        loss = Axon.Losses.mean_squared_error(targets, y_pred, reduction: :mean)
+        {Nx.add(loss, Nx.multiply(1.0e-3, penalty)), output}
+      end
+
+      model
+      |> Axon.Loop.trainer(objective, :sgd)
+      |> Axon.Loop.run(data)
+
+  The `loss` metric of a loop built from an objective is the running
+  average of the objective's loss kept by the training step. Because it
+  cannot be recomputed from `y_true` and `y_pred` alone, it is not carried
+  over to the evaluator by `validate/4`.
+
   ## Options
 
     * `:log` - training loss and metric log interval. Set to 0 to silence
@@ -652,18 +729,29 @@ defmodule Axon.Loop do
   """
   def trainer(model, loss, optimizer, opts \\ []) do
     opts = Keyword.validate!(opts, [:seed, :loss_scale, log: 50])
-
-    # Build loss now so we can use it as a metric
-    loss_fn = build_loss_fn(loss)
     step_opts = Keyword.take(opts, [:loss_scale, :seed])
-    {init_fn, step_fn} = train_step(model, loss_fn, optimizer, step_opts)
-
     log_interval = opts[:log] || 50
 
     loop =
-      step_fn
-      |> loop(init_fn)
-      |> metric(loss_fn, "loss")
+      case loss do
+        objective when is_function(objective, 4) ->
+          {init_fn, step_fn} = train_step(model, objective, optimizer, step_opts)
+
+          # The objective's loss is only known inside the training step, so
+          # the metric reads the running average the step keeps in its state
+          step_fn
+          |> loop(init_fn)
+          |> metric(&Function.identity/1, "loss", :running_average, [:loss])
+
+        loss ->
+          # Build loss now so we can use it as a metric
+          loss_fn = build_loss_fn(loss)
+          {init_fn, step_fn} = train_step(model, loss_fn, optimizer, step_opts)
+
+          step_fn
+          |> loop(init_fn)
+          |> metric(loss_fn, "loss")
+      end
 
     if log_interval > 0 do
       loop
@@ -990,6 +1078,12 @@ defmodule Axon.Loop do
 
   only `:mean_absolute_error` will be computed at validation time.
 
+  Metrics are attached to the evaluator with the default `[:y_true, :y_pred]`
+  transform, so only metrics given as an atom or as an arity-2 function
+  carry over. In particular, the `loss` of a loop built from an objective
+  function (see `trainer/4`) is tracked during training only and is not
+  reported as `validation_loss`.
+
   The returned loop state is altered to contain validation
   metrics for use in later handlers such as early stopping and model
   checkpoints. Since the order of execution of event handlers is in
@@ -1020,8 +1114,13 @@ defmodule Axon.Loop do
     validation_loop = fn %State{metrics: metrics, step_state: step_state} = state ->
       %{model_state: model_state} = step_state
 
+      # Only metrics which accept the default [:y_true, :y_pred] transform
+      # can be recomputed by the evaluator
       %State{metrics: %{0 => validation_metrics}} =
-        Enum.reduce(metric_fns, evaluator, fn {k, {_, v}}, loop -> metric(loop, v, k) end)
+        Enum.reduce(metric_fns, evaluator, fn
+          {k, {_, v}}, loop when is_atom(v) or is_function(v, 2) -> metric(loop, v, k)
+          {_k, _}, loop -> loop
+        end)
         |> run(validation_data, model_state)
 
       metrics =
@@ -2110,8 +2209,25 @@ defmodule Axon.Loop do
         raise ArgumentError,
               "Invalid loss function #{inspect(invalid)}, a valid loss" <>
                 " function is an atom which matches a function in Axon.Losses," <>
-                " an arity-2 function of the form loss(y_true, y_pred), or a list" <>
-                " of 2-tuples of {loss, weight} for multi-objective models"
+                " an arity-2 function of the form loss(y_true, y_pred), a list" <>
+                " of 2-tuples of {loss, weight} for multi-objective models, or" <>
+                " an arity-4 objective function of the form" <>
+                " objective(forward_fn, model_state, inputs, targets)"
+    end
+  end
+
+  # Builds an objective function from either an objective of the form
+  # objective(forward_fn, model_state, inputs, targets) :: {loss, output}
+  # or anything build_loss_fn/1 accepts, in which case the objective runs
+  # the forward pass once and applies the loss to its prediction.
+  defp build_objective_fn(objective) when is_function(objective, 4), do: objective
+
+  defp build_objective_fn(loss) do
+    loss_fn = build_loss_fn(loss)
+
+    fn forward_fn, model_state, inputs, targets ->
+      %{prediction: prediction} = output = forward_fn.(model_state, inputs)
+      {loss_fn.(targets, prediction), output}
     end
   end
 

--- a/notebooks/vision/metric-learning.livemd
+++ b/notebooks/vision/metric-learning.livemd
@@ -175,7 +175,7 @@ defmodule KinoAxon do
 
     handler = fn state ->
       %Axon.Loop.State{epoch: epoch, iteration: _iter, step_state: step_state} = state
-      Kino.VegaLite.push_many(vl_widget, [%{epoch: epoch, loss: Nx.to_number(step_state[:epoch_avg_loss]), dataset: "train"}])
+      Kino.VegaLite.push_many(vl_widget, [%{epoch: epoch, loss: Nx.to_number(step_state.loss), dataset: "train"}])
       {:continue, state}
     end
 
@@ -186,93 +186,58 @@ end
 
 ### Embedding Model
 
-We wrap our model in a custom train_step that does three things each batch:
+We train the model with an objective function which does three things each batch:
 
 * Embed both anchors and positives through the network.
 * Score them by taking dot products (our raw “how-similar?” numbers).
 * Compute a softmax cross-entropy loss over those scores—using temperature scaling to sharpen or soften the comparison.
 
-The training loop then uses that loss to nudge parameters, pulling same-class vectors together and pushing others apart, one batch at a time.
+`Axon.Loop.trainer/3` accepts an objective function anywhere it accepts a loss. The objective receives the model's training-mode forward function, the model state, the batch inputs and the batch targets, and returns the loss along with the forward output to use as the prediction. The training loop then uses that loss to nudge parameters, pulling same-class vectors together and pushing others apart, one batch at a time.
 
 ```elixir
 defmodule MetricLearning do
   import Nx.Defn
-  require Logger
 
-  defn objective_fn(predict_fn, params, {anchor, positive}) do
-    %{prediction: anchor_embeddings} = predict_fn.(params, %{"input" => anchor})
+  defn objective_fn(predict_fn, params, inputs, labels) do
+    %{"input" => anchor, "positive" => positive} = inputs
+
+    %{prediction: anchor_embeddings, state: state} = predict_fn.(params, %{"input" => anchor})
     %{prediction: positive_embeddings} = predict_fn.(params, %{"input" => positive})
 
     similarities = Nx.dot(anchor_embeddings, [1], positive_embeddings, [1])
     temperature = 0.2
     similarities = similarities / temperature
-    sparse_labels = Nx.iota({10})
 
-    Axon.Losses.categorical_cross_entropy(sparse_labels, similarities,
-      reduction: :mean,
-      sparse: true,
-      from_logits: true
-    )
+    loss =
+      Axon.Losses.categorical_cross_entropy(labels, similarities,
+        reduction: :mean,
+        sparse: true,
+        from_logits: true
+      )
+
+    # The similarities become y_pred in the loop state and the labels y_true
+    {loss, %{prediction: similarities, state: state}}
   end
 
-  defn batch_step(predict_fn, optim, {anchor, positive}, state) do
-    # Compute gradient of objective defined above
-    {loss, gradients} =
-      value_and_grad(state.model_state, &objective_fn(predict_fn, &1, {anchor, positive}))
+  def run(train_images, class_idx_to_train_idxs) do
+    model = MetricModel.build_model()
 
-    {updates, new_optimizer_state} = optim.(gradients, state.optimizer_state, state.model_state)
-    new_params = Polaris.Updates.apply_updates(state.model_state, updates)
-    
-    %{
-      state
-      | model_state: new_params,
-        optimizer_state: new_optimizer_state,
-        epoch_loss: state[:epoch_loss] + loss,
-        epoch_count: state[:epoch_count] + 1,
-        epoch_avg_loss: (state[:epoch_loss] + loss) / (state[:epoch_count] + 1)
-    }
-  end
-
-  def init(template, init_fn, init_optim) do
-    model_state = init_fn.(template, Axon.ModelState.empty())
-
-    %{
-      model_state: model_state,
-      optimizer_state: init_optim.(model_state),
-      epoch_loss: Nx.tensor(0.0),
-      epoch_count: Nx.tensor(0),
-      epoch_avg_loss: Nx.tensor(0.0)
-    }
-  end
-
-   def run(train_images, class_idx_to_train_idxs) do
-
-    {optim_init_fn, optim_update_fn} = Polaris.Optimizers.adam()
-    {init_fn, predict_fn} = Axon.build(MetricModel.build_model(), mode: :train, debug: false)
-
-    step = &batch_step(predict_fn, optim_update_fn, &1, &2)
-    init = fn {template, _}, _state -> init(%{"input" => template}, init_fn, optim_init_fn) end
-
-    training_data = Stream.repeatedly(fn ->
-      GetImages.batch(train_images, class_idx_to_train_idxs)
-    end)
+    training_data =
+      Stream.repeatedly(fn ->
+        {anchors, positives} = GetImages.batch(train_images, class_idx_to_train_idxs)
+        {%{"input" => anchors, "positive" => positives}, Nx.iota({10})}
+      end)
 
     final_state =
-      Axon.Loop.loop(step, init)
-      |> Axon.Loop.log(
-        fn %Axon.Loop.State{epoch: epoch, step_state: state} ->
-          loss_str = :io_lib.format(~c"~.4f", [Nx.to_number(state[:epoch_avg_loss])])
-          "\rEpoch: #{epoch}, Loss: #{loss_str}\n"
-        end,
-        event: :epoch_completed
-      )
+      model
+      |> Axon.Loop.trainer(&objective_fn/4, :adam)
       |> KinoAxon.plot_losses()
       |> Axon.Loop.run(training_data, %{}, iterations: 1000, epochs: 20, compiler: EXLA)
 
+    {_init_fn, predict_fn} = Axon.build(model, mode: :train)
+
     {final_state, predict_fn}
-
   end
-
 end
 
 {final_state, predict_fn} = MetricLearning.run(train_images, class_idx_to_train_idxs)

--- a/test/axon/loop_test.exs
+++ b/test/axon/loop_test.exs
@@ -117,7 +117,8 @@ defmodule Axon.LoopTest do
       assert %{model_state: %{}} =
                pstate =
                init_fn.(
-                 {%{"input_0" => Nx.tensor([[2]]), "input_1" => Nx.tensor([[2]])}, Nx.tensor(0)},
+                 {%{"input_0" => Nx.tensor([[2]]), "input_1" => Nx.tensor([[2]])},
+                  {Nx.tensor([[0]]), Nx.tensor([[0]])}},
                  Axon.ModelState.empty()
                )
 
@@ -288,6 +289,170 @@ defmodule Axon.LoopTest do
 
       assert_all_close(state.model_state.data["instance_norm"]["mean"], Nx.broadcast(0.9, {8}))
       assert_all_close(state.model_state.data["instance_norm"]["var"], Nx.broadcast(0.1, {8}))
+    end
+
+    test "train_step/3 accepts an objective function" do
+      model = objective_model()
+      {x, y} = objective_batch()
+
+      # Two forward passes plus a penalty read straight from the model state,
+      # none of which a loss function could express
+      objective = fn forward_fn, model_state, inp, tar ->
+        %{prediction: y_pred} = out = forward_fn.(model_state, inp)
+        %{prediction: y_pred_scaled} = forward_fn.(model_state, Nx.multiply(inp, 2))
+
+        penalty = model_state.data["dense_1"]["kernel"] |> Nx.pow(2) |> Nx.sum()
+
+        loss =
+          Axon.Losses.mean_squared_error(tar, y_pred, reduction: :mean)
+          |> Nx.add(Axon.Losses.mean_squared_error(tar, y_pred_scaled, reduction: :mean))
+          |> Nx.add(Nx.multiply(1.0e-3, penalty))
+
+        {loss, out}
+      end
+
+      {init_fn, step_fn} =
+        Axon.Loop.train_step(model, objective, Polaris.Optimizers.adam(learning_rate: 0.01))
+
+      state = init_fn.({x, y}, Axon.ModelState.empty())
+
+      assert %{
+               i: i,
+               y_true: y_true,
+               y_pred: y_pred,
+               loss: loss,
+               model_state: %Axon.ModelState{},
+               optimizer_state: _,
+               loss_scale_state: _
+             } = state
+
+      assert_equal(i, Nx.tensor(0))
+      assert Nx.shape(y_true) == {2, 1}
+      assert Nx.shape(y_pred) == {2, 1}
+      assert_equal(loss, Nx.tensor(0.0))
+
+      first = step_fn.({x, y}, state)
+      last = Enum.reduce(1..4, first, fn _, state -> step_fn.({x, y}, state) end)
+
+      assert_equal(last.i, Nx.tensor(5))
+      assert Nx.shape(last.y_pred) == {2, 1}
+      assert Nx.to_number(last.loss) < Nx.to_number(first.loss)
+    end
+
+    for loss_scale <- [:identity, :dynamic] do
+      test "train_step/3 with an objective matches the equivalent loss with #{loss_scale} loss scale" do
+        model = objective_model()
+        {x, y} = objective_batch()
+        loss_scale = unquote(loss_scale)
+
+        objective = fn forward_fn, model_state, inp, tar ->
+          %{prediction: y_pred} = out = forward_fn.(model_state, inp)
+          {Axon.Losses.mean_squared_error(tar, y_pred, reduction: :mean), out}
+        end
+
+        {model_init_fn, _} = Axon.build(model)
+        initial_state = model_init_fn.(x, Axon.ModelState.empty())
+
+        run = fn loss ->
+          {init_fn, step_fn} =
+            Axon.Loop.train_step(model, loss, Polaris.Optimizers.adam(learning_rate: 0.01),
+              loss_scale: loss_scale
+            )
+
+          state = init_fn.({x, y}, initial_state)
+          Enum.reduce(1..3, state, fn _, state -> step_fn.({x, y}, state) end)
+        end
+
+        from_loss = run.(:mean_squared_error)
+        from_objective = run.(objective)
+
+        assert_all_close(from_objective.model_state.data, from_loss.model_state.data)
+        assert_all_close(from_objective.loss, from_loss.loss)
+        assert_equal(from_objective.loss_scale_state, from_loss.loss_scale_state)
+      end
+    end
+
+    test "train_step/3 objective receives the training-mode forward function" do
+      val = Nx.broadcast(1, {1, 8})
+
+      model = Axon.constant(val) |> Axon.batch_norm(name: "batch_norm")
+
+      objective = fn forward_fn, model_state, inp, tar ->
+        %{prediction: y_pred} = out = forward_fn.(model_state, inp)
+        {Axon.Losses.mean_squared_error(tar, y_pred, reduction: :mean), out}
+      end
+
+      {init_fn, step_fn} = Axon.Loop.train_step(model, objective, :adam)
+
+      state = init_fn.({val, val}, Axon.ModelState.empty())
+      state = step_fn.({val, val}, state)
+
+      assert_all_close(state.model_state.data["batch_norm"]["mean"], Nx.broadcast(0.9, {8}))
+      assert_all_close(state.model_state.data["batch_norm"]["var"], Nx.broadcast(0.1, {8}))
+    end
+
+    test "train_step/3 raises when an objective does not return {loss, output}" do
+      model = objective_model()
+      {x, y} = objective_batch()
+
+      objective = fn forward_fn, model_state, inp, tar ->
+        %{prediction: y_pred} = forward_fn.(model_state, inp)
+        Axon.Losses.mean_squared_error(tar, y_pred, reduction: :mean)
+      end
+
+      {init_fn, _step_fn} = Axon.Loop.train_step(model, objective, :sgd)
+
+      assert_raise ArgumentError, ~r/objective function must return a 2-tuple/, fn ->
+        init_fn.({x, y}, Axon.ModelState.empty())
+      end
+    end
+
+    test "train_step/3 leaves frozen parameters unchanged with an objective" do
+      model = objective_model()
+      {x, y} = objective_batch()
+
+      objective = fn forward_fn, model_state, inp, tar ->
+        %{prediction: y_pred} = out = forward_fn.(model_state, inp)
+        {Axon.Losses.mean_squared_error(tar, y_pred, reduction: :mean), out}
+      end
+
+      {init_fn, step_fn} = Axon.Loop.train_step(model, objective, :sgd)
+      {init_optimizer_fn, _} = Polaris.Optimizers.sgd()
+
+      state = init_fn.({x, y}, Axon.ModelState.empty())
+
+      model_state =
+        Axon.ModelState.freeze(state.model_state, fn [layer | _] -> layer == "dense_0" end)
+
+      optimizer_state = init_optimizer_fn.(Axon.ModelState.trainable_parameters(model_state))
+      state = %{state | model_state: model_state, optimizer_state: optimizer_state}
+
+      trained = Enum.reduce(1..2, state, fn _, state -> step_fn.({x, y}, state) end)
+
+      assert_equal(trained.model_state.data["dense_0"], model_state.data["dense_0"])
+
+      assert_not_equal(
+        trained.model_state.data["dense_1"]["kernel"],
+        model_state.data["dense_1"]["kernel"]
+      )
+    end
+  end
+
+  defp objective_model do
+    Axon.input("input", shape: {nil, 4})
+    |> Axon.dense(8, name: "dense_0")
+    |> Axon.dense(1, name: "dense_1")
+  end
+
+  defp objective_batch do
+    x = Nx.iota({2, 4}, type: :f32) |> Nx.divide(10)
+    {x, Nx.sum(x, axes: [1], keep_axes: true)}
+  end
+
+  defp objective_data do
+    for i <- 1..4 do
+      x = Nx.iota({2, 4}, type: :f32) |> Nx.add(i) |> Nx.divide(10)
+      {x, Nx.sum(x, axes: [1], keep_axes: true)}
     end
   end
 
@@ -473,6 +638,47 @@ defmodule Axon.LoopTest do
         model
         |> Axon.Loop.trainer(:categorical_cross_entropy, :adam)
         |> Axon.Loop.run(data, %{})
+      end
+    end
+
+    test "trainer/3 accepts an objective function" do
+      model = objective_model()
+      data = objective_data()
+
+      objective = fn forward_fn, model_state, inp, tar ->
+        %{prediction: y_pred} = out = forward_fn.(model_state, inp)
+        penalty = model_state.data["dense_0"]["kernel"] |> Nx.pow(2) |> Nx.sum()
+        loss = Axon.Losses.mean_squared_error(tar, y_pred, reduction: :mean)
+        {Nx.add(loss, Nx.multiply(1.0e-3, penalty)), out}
+      end
+
+      ExUnit.CaptureIO.capture_io(fn ->
+        result =
+          model
+          |> Axon.Loop.trainer(objective, :sgd)
+          |> Axon.Loop.metric(:mean_absolute_error)
+          |> Axon.Loop.run(data, Axon.ModelState.empty(), epochs: 2)
+
+        send(self(), {:result, result})
+      end)
+
+      assert_receive {:result, result}
+
+      assert %Axon.Loop.State{
+               metrics: %{1 => %{"loss" => loss, "mean_absolute_error" => _}},
+               step_state: %{model_state: %Axon.ModelState{}}
+             } = result
+
+      assert Nx.shape(loss) == {}
+      assert Nx.type(loss) == {:f, 32}
+      assert is_float(Nx.to_number(loss))
+    end
+
+    test "trainer/3 rejects a function which is neither a loss nor an objective" do
+      model = objective_model()
+
+      assert_raise ArgumentError, ~r/arity-4 objective function/, fn ->
+        Axon.Loop.trainer(model, fn _, _, _ -> Nx.tensor(0.0) end, :sgd)
       end
     end
   end
@@ -845,7 +1051,7 @@ defmodule Axon.LoopTest do
       loss = :binary_cross_entropy
 
       {init_fn, _} = Axon.Loop.train_step(model, loss, optimizer)
-      step_state = init_fn.({Nx.tensor([[1]]), Nx.tensor(1)}, Axon.ModelState.empty())
+      step_state = init_fn.({Nx.tensor([[1]]), Nx.tensor([[1, 0]])}, Axon.ModelState.empty())
       state = %State{step_state: step_state}
 
       serialized = Axon.Loop.serialize_state(state)
@@ -1037,6 +1243,29 @@ defmodule Axon.LoopTest do
           fn %{epoch: epoch}, _ -> epoch == 1 end
         )
         |> Axon.Loop.run(data, Axon.ModelState.empty(), epochs: 5, iterations: 5)
+      end)
+    end
+
+    test "skips the loss of a loop trained with an objective" do
+      model = objective_model()
+      data = objective_data()
+
+      objective = fn forward_fn, model_state, inp, tar ->
+        %{prediction: y_pred} = out = forward_fn.(model_state, inp)
+        {Axon.Losses.mean_squared_error(tar, y_pred, reduction: :mean), out}
+      end
+
+      ExUnit.CaptureIO.capture_io(fn ->
+        model
+        |> Axon.Loop.trainer(objective, :sgd)
+        |> Axon.Loop.metric(:mean_absolute_error)
+        |> Axon.Loop.validate(model, data)
+        |> Axon.Loop.handle_event(:epoch_completed, fn %{metrics: metrics} = state ->
+          assert Map.has_key?(metrics, "validation_mean_absolute_error")
+          refute Map.has_key?(metrics, "validation_loss")
+          {:continue, state}
+        end)
+        |> Axon.Loop.run(data, Axon.ModelState.empty(), epochs: 2)
       end)
     end
   end


### PR DESCRIPTION
Closes #595.

`Axon.Loop.train_step/4` and `Axon.Loop.trainer/4` only accepted a loss of the form `loss(y_true, y_pred)`. Anything that needs more than one prediction and its targets, such as a contrastive objective that runs the model on an anchor and a positive, a penalty computed from the parameters, or any objective that wants to see the whole model state, had to re-implement the entire training step. `notebooks/vision/metric-learning.livemd` did exactly that: sixty lines of `batch_step`/`init` boilerplate to express a four-line objective with two forward passes.

Both functions now accept an arity-4 objective function anywhere they accept a loss:

```elixir
objective = fn forward_fn, model_state, inputs, targets ->
  %{prediction: y_pred} = output = forward_fn.(model_state, inputs)
  penalty = model_state.data["dense_0"]["kernel"] |> Nx.pow(2) |> Nx.sum()
  loss = Axon.Losses.mean_squared_error(targets, y_pred, reduction: :mean)
  {Nx.add(loss, Nx.multiply(1.0e-3, penalty)), output}
end

model
|> Axon.Loop.trainer(objective, :sgd)
|> Axon.Loop.run(data)
```

The objective receives the model's training-mode forward function, so users never build the model a second time or remember `mode: :train`, the `%Axon.ModelState{}` being trained, and the batch. It returns the unscaled loss and the forward output to use as the prediction, which must be the `%{prediction: _, state: _}` map the forward returns in training mode. That keeps `y_pred` available to metrics and lets `Axon.ModelState.update/3` merge the updated layer state (batch norm statistics, dropout keys) back as before. With several forward passes the user picks which output counts as the prediction. Dispatch is by arity: an arity-4 function is an objective, everything else goes through the existing `build_loss_fn/1`, which now wraps the loss in the default objective `{loss_fn.(targets, prediction), forward_fn.(model_state, inputs)}`. The step's return value is checked at trace time, so an objective that returns only the loss raises a clear `ArgumentError` before anything is compiled.

This also removes the "trainable parameters as grad" hack the issue calls out. The step now differentiates with respect to the whole `%Axon.ModelState{}` (it is an `Nx.Container` whose `parameters`/`state`/`frozen_parameters` metadata are kept fields) and selects the trainable subset of the resulting gradient struct with `Axon.ModelState.trainable_parameters/1`, so the optimizer sees exactly the parameters its state was initialised from. Gradients of frozen parameters and layer state are dead nodes and are eliminated by the compiler; `Axon.ModelState.update/3` still passes frozen leaves through untouched, so buffer donation behaves as before. This is what lets an objective read `model_state.data[...]` directly and have it differentiated. The private `tree_merge/3` in `Axon.Loop` only existed for the hack and is gone.

For loops built from an objective, `trainer/4` reports `loss` from the running average the step keeps in its state instead of recomputing it from `y_true`/`y_pred`, which is what `build_batch_fn/2` already did for the `loss` metric of a plain loss.

## Limitations

- `validate/4` re-attaches training metrics to the evaluator with the default `[:y_true, :y_pred]` transform. An objective's loss cannot be recomputed that way, so `validate/4` now only carries over metrics given as an atom or an arity-2 function and a loop trained with an objective gets `validation_<metric>` for its other metrics but no `validation_loss`. Previously any other metric arity crashed with a `BadArityError` at the end of the first epoch, so this is not a regression. An `evaluator/eval_step` that accepts an objective is a natural follow-up.
- `init_fn` now traces the objective rather than just the forward pass to learn the prediction shape, since with a user objective that is the only way to know it. Only shapes are kept, nothing is lowered, but it does mean the targets handed to `init_fn` must be ones the loss can consume. Two existing tests passed dummy targets of the wrong shape to `init_fn` directly and were updated; `Axon.Loop.run/4` always initialises from a real batch so this does not affect loops.

## Docs

`train_step/4` gains an "Objective functions" section with the contract and two examples, `trainer/4` a "Custom objective" example and the `validate/4` note, `validate/4` documents which metrics carry over, the custom-loss guide gains a "Using custom objectives in training loops" section, and the metric-learning notebook now uses `Axon.Loop.trainer(model, &objective_fn/4, :adam)` with an objective that returns the similarity logits as the prediction instead of its hand-written step.

## Tests

`test/axon/loop_test.exs`:

- `train_step/3` with an objective that runs two forward passes plus a parameter penalty: step state shape and a decreasing loss over five steps.
- `train_step/3` with an objective equivalent to `:mean_squared_error` produces the same parameters, loss and loss-scale state as the loss form, for both `:identity` and `:dynamic` loss scaling.
- The objective receives the training-mode forward: batch-norm running statistics update through an objective.
- An objective returning only the loss raises `ArgumentError` at init.
- Frozen parameters stay untouched while trainable ones move, exercising `trainable_parameters/1` on the gradient struct.
- `trainer/3` with an objective runs end to end with a `loss` and a `:mean_absolute_error` metric; an arity-3 function is rejected with a message pointing at the objective form.
- `validate/4` on an objective loop reports `validation_mean_absolute_error` and no `validation_loss`.

All nine fail against `main`'s `lib/axon/loop.ex`. `mix test`: 886 passed, 47 excluded. `USE_EXLA=1 mix test test/axon/loop_test.exs`: 70 passed, which covers the buffer-donation tests through the rewritten gradient path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
